### PR TITLE
fix: resolve ocache build and add CI/CD workflows

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,47 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    # Skip validation for release PRs (main -> release branch)
+    if: github.event.pull_request.base.ref != 'release'
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # All valid conventional commit types
+          types: |
+            feat
+            fix
+            perf
+            docs
+            style
+            refactor
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            PR title must follow conventional commit format: type: description
+
+            Release-triggering types:
+            - feat: new features (minor release)
+            - fix: bug fixes (patch release)
+            - perf: performance improvements (patch release)
+
+            Non-release types (still valid):
+            - docs, style, refactor, test, build, ci, chore, revert
+
+            Examples:
+            - feat: add user authentication
+            - fix: resolve memory leak in cache
+            - ci: update GitHub Actions workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,10 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     permissions:
+      actions: write
       contents: read
+      packages: write
+    secrets: inherit
 
   build-binaries:
     needs: test
@@ -45,7 +48,7 @@ jobs:
 
       - name: Configure git for private modules
         run: |
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -145,4 +148,3 @@ jobs:
               fi
             done
           done
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,14 +24,17 @@ jobs:
       matrix:
         include:
           - runner: namespace-profile-ubuntu-2404
+            arch: x86_64
             goos: linux
             goarch: amd64
             suffix: linux-amd64
           - runner: namespace-profile-ubuntu-2404-arm
+            arch: aarch64
             goos: linux
             goarch: arm64
             suffix: linux-arm64
           - runner: namespace-profile-macos-1561-arm
+            arch: arm64
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
@@ -80,8 +83,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -108,7 +110,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         run: npx semantic-release --debug
 
       - name: Get new release tag
@@ -129,7 +131,7 @@ jobs:
       - name: Upload binaries to release
         if: steps.new_tag.outputs.new_release == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         run: |
           TAG=${{ steps.new_tag.outputs.new_tag }}
           echo "Uploading binaries for release $TAG"
@@ -146,8 +148,6 @@ jobs:
 
       - name: Create module tag
         if: steps.new_tag.outputs.new_release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           TAG=${{ steps.new_tag.outputs.new_tag }}
           MODULE_TAG="tag/$TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,163 @@
+name: Release
+
+on:
+  push:
+    branches: [release]
+
+env:
+  GO_VERSION: "1.24.2"
+  GOPRIVATE: github.com/tigrisdata
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
+
+  build-binaries:
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        include:
+          - runner: namespace-profile-ubuntu-2404
+            goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - runner: namespace-profile-ubuntu-2404-arm
+            goos: linux
+            goarch: arm64
+            suffix: linux-arm64
+          - runner: namespace-profile-macos-1561-arm
+            goos: darwin
+            goarch: arm64
+            suffix: darwin-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure git for private modules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build binary
+        run: |
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o tag ./cmd/tag
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv tag tag-${{ matrix.suffix }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tag-${{ matrix.suffix }}
+          path: tag-${{ matrix.suffix }}
+          retention-days: 1
+
+  release:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List artifacts
+        run: |
+          echo "Downloaded artifacts:"
+          find artifacts -type f -ls
+
+      - name: Get tags before release
+        id: before_release
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag before release: $LATEST_TAG"
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: npx semantic-release --debug
+
+      - name: Get new release tag
+        id: new_tag
+        run: |
+          git fetch --tags
+          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "New tag after release: $NEW_TAG"
+          if [ "$NEW_TAG" != "${{ steps.before_release.outputs.latest_tag }}" ] && [ "$NEW_TAG" != "none" ]; then
+            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "New release detected: $NEW_TAG"
+          else
+            echo "new_release=false" >> $GITHUB_OUTPUT
+            echo "No new release"
+          fi
+
+      - name: Upload binaries to release
+        if: steps.new_tag.outputs.new_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=${{ steps.new_tag.outputs.new_tag }}
+          echo "Uploading binaries for release $TAG"
+
+          # Flatten and upload binaries
+          for artifact_dir in artifacts/*/; do
+            for binary in "$artifact_dir"*; do
+              if [ -f "$binary" ]; then
+                echo "Uploading $binary"
+                gh release upload "$TAG" "$binary" --clobber
+              fi
+            done
+          done
+
+      - name: Create module tag
+        if: steps.new_tag.outputs.new_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=${{ steps.new_tag.outputs.new_tag }}
+          MODULE_TAG="tag/$TAG"
+
+          echo "Creating module tag: $MODULE_TAG"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$MODULE_TAG" -m "Release $MODULE_TAG"
+          git push origin "$MODULE_TAG"
+
+          echo "Created and pushed module tag: $MODULE_TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,18 +146,3 @@ jobs:
             done
           done
 
-      - name: Create module tag
-        if: steps.new_tag.outputs.new_release == 'true'
-        run: |
-          TAG=${{ steps.new_tag.outputs.new_tag }}
-          MODULE_TAG="tag/$TAG"
-
-          echo "Creating module tag: $MODULE_TAG"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "$MODULE_TAG" -m "Release $MODULE_TAG"
-          git push origin "$MODULE_TAG"
-
-          echo "Created and pushed module tag: $MODULE_TAG"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,7 @@ jobs:
         run: make test-race
 
       - name: Run coverage tests
-        run: |
-          go test -coverprofile=coverage.out -timeout 120s ./...
-          go tool cover -html=coverage.out -o coverage.html
+        run: make test-coverage
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+  workflow_call:
+
+env:
+  GO_VERSION: "1.24.2"
+  GOPRIVATE: github.com/tigrisdata
+
+jobs:
+  test:
+    runs-on: namespace-profile-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure git for private modules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run linting
+        run: make lint-ci
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Run integration tests
+        run: make test-integration
+
+      - name: Run tests with race detector
+        run: make test-race
+
+      - name: Run coverage tests
+        run: |
+          go test -coverprofile=coverage.out -timeout 120s ./...
+          go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.out
+            coverage.html
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Configure git for private modules
         run: |
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,9 @@ jobs:
   test:
     runs-on: namespace-profile-ubuntu-2404
     permissions:
+      actions: write
       contents: read
+      packages: write
 
     steps:
       - name: Checkout code

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,7 @@
+branches:
+  - release
+
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,13 @@ build:
 # Testing targets
 .PHONY: test
 test:
-	@echo "Running all tests..."
+	@echo "Running unit tests..."
 	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
-	go test -v -timeout 60s $(TESTFLAGS) ./...
+	go test -v -timeout 60s $(TESTFLAGS) ./auth/... ./cache/... ./config/... ./handlers/... ./metrics/... ./proxy/...
+
+.PHONY: test-all
+test-all: test test-integration
+	@echo "All tests completed!"
 
 .PHONY: test-auth
 test-auth:
@@ -57,6 +61,33 @@ test-coverage:
 	go test -coverprofile=coverage.out -timeout 60s $(TESTFLAGS) ./...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated at coverage.html"
+
+# Integration test targets
+.PHONY: test-integration
+test-integration:
+	@echo "Running integration tests..."
+	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
+	go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/...
+
+.PHONY: test-integration-short
+test-integration-short:
+	@echo "Running integration tests (short mode)..."
+	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
+	go test -v -short -timeout 30s $(TESTFLAGS) ./tests/integration/...
+
+.PHONY: test-integration-race
+test-integration-race:
+	@echo "Running integration tests with race detector..."
+	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
+	go test -race -v -timeout 300s $(TESTFLAGS) ./tests/integration/...
+
+.PHONY: test-integration-coverage
+test-integration-coverage:
+	@echo "Running integration tests with coverage..."
+	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
+	go test -coverprofile=coverage-integration.out -timeout 300s $(TESTFLAGS) ./tests/integration/...
+	go tool cover -html=coverage-integration.out -o coverage-integration.html
+	@echo "Integration coverage report generated at coverage-integration.html"
 
 # Code quality targets
 .PHONY: lint
@@ -124,12 +155,19 @@ help:
 	@echo "  build         - Build the TAG binary"
 	@echo ""
 	@echo "Test targets:"
-	@echo "  test          - Run all unit tests"
+	@echo "  test          - Run unit tests only"
+	@echo "  test-all      - Run all tests (unit + integration)"
 	@echo "  test-auth     - Run auth package tests"
 	@echo "  test-cache    - Run cache package tests"
 	@echo "  test-proxy    - Run proxy package tests"
-	@echo "  test-race     - Run tests with race detector"
-	@echo "  test-coverage - Run tests with coverage report"
+	@echo "  test-race     - Run unit tests with race detector"
+	@echo "  test-coverage - Run unit tests with coverage report"
+	@echo ""
+	@echo "Integration test targets:"
+	@echo "  test-integration          - Run integration tests"
+	@echo "  test-integration-short    - Run integration tests (short mode)"
+	@echo "  test-integration-race     - Run integration tests with race detector"
+	@echo "  test-integration-coverage - Run integration tests with coverage report"
 	@echo ""
 	@echo "  To run specific tests, use TEST or TESTRUN variable:"
 	@echo "    make test TEST=TestMyFunction      - Run exact test name"

--- a/Makefile
+++ b/Makefile
@@ -50,15 +50,15 @@ test-proxy:
 
 .PHONY: test-race
 test-race:
-	@echo "Running tests with race detector..."
+	@echo "Running unit tests with race detector..."
 	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
-	go test -race -v -timeout 120s $(TESTFLAGS) ./...
+	go test -race -v -timeout 120s $(TESTFLAGS) ./auth/... ./cache/... ./config/... ./handlers/... ./metrics/... ./proxy/...
 
 .PHONY: test-coverage
 test-coverage:
-	@echo "Running tests with coverage..."
+	@echo "Running unit tests with coverage..."
 	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
-	go test -coverprofile=coverage.out -timeout 60s $(TESTFLAGS) ./...
+	go test -coverprofile=coverage.out -timeout 60s $(TESTFLAGS) ./auth/... ./cache/... ./config/... ./handlers/... ./metrics/... ./proxy/...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated at coverage.html"
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigri
 - Access to an [ocache](https://github.com/tigrisdata/ocache) cluster (for caching)
 - Tigris account with access credentials
 
+### Developer Setup (One-Time)
+
+This project depends on private Tigris repositories. Configure Go and Git to access them:
+
+```bash
+# Tell Go to fetch tigrisdata repos directly (not via proxy)
+export GOPRIVATE=github.com/tigrisdata
+
+# Configure Git to use SSH for tigrisdata repos
+git config --global url."git@github.com:tigrisdata/".insteadOf "https://github.com/tigrisdata/"
+```
+
+Add the `GOPRIVATE` export to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`) for persistence.
+
 ### Build
 
 ```bash

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -314,4 +314,3 @@ func (v *RequestValidator) deriveSigningKey(secretKey, dateStr, region string) [
 	kSigning := hmacSHA256(kService, []byte(terminationString))
 	return kSigning
 }
-

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
-	github.com/tigrisdata/ocache/client v0.0.0-00010101000000-000000000000
+	github.com/tigrisdata/ocache/client v1.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -69,10 +69,10 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
-	github.com/tigrisdata/ocache/common v0.0.0-00010101000000-000000000000 // indirect
-	github.com/tigrisdata/ocache/coordinator v0.0.0-00010101000000-000000000000 // indirect
-	github.com/tigrisdata/ocache/coordinator/proto v0.0.0-00010101000000-000000000000 // indirect
-	github.com/tigrisdata/ocache/proto v0.0.0-00010101000000-000000000000 // indirect
+	github.com/tigrisdata/ocache/common v1.2.0 // indirect
+	github.com/tigrisdata/ocache/coordinator v1.2.0 // indirect
+	github.com/tigrisdata/ocache/coordinator/proto v1.2.0 // indirect
+	github.com/tigrisdata/ocache/proto v1.2.0 // indirect
 	github.com/uber/jaeger-client-go v2.28.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
@@ -95,14 +95,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/grpc v1.72.2 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
-)
-
-// Local development: replace with local ocache modules
-// When deploying, remove these replace directives and use versioned tags
-replace (
-	github.com/tigrisdata/ocache/client => ../../../../ocache/client
-	github.com/tigrisdata/ocache/common => ../../../../ocache/common
-	github.com/tigrisdata/ocache/coordinator => ../../../../ocache/coordinator
-	github.com/tigrisdata/ocache/coordinator/proto => ../../../../ocache/coordinator/proto
-	github.com/tigrisdata/ocache/proto => ../../../../ocache/proto
 )

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,16 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tigrisdata/ocache/client v1.2.0 h1:0XfwByKR99XqS39E82+gv8WSrE4D7JK0U7y+j6KFbJY=
+github.com/tigrisdata/ocache/client v1.2.0/go.mod h1:KQ9XCYFbd407lI4empZTdgiJCjfbE8MwtnPwbaQ0Q4E=
+github.com/tigrisdata/ocache/common v1.2.0 h1:sKyC/T630R39ks135fjTcCOpb34H1AKzRXpHjFeLfDw=
+github.com/tigrisdata/ocache/common v1.2.0/go.mod h1:5dy2d/b+59f2TljpvOTbYuwtSQxh9fSUhCLhCITV1F4=
+github.com/tigrisdata/ocache/coordinator v1.2.0 h1:uc6C3e6BKZuuGprsKFBbqTObYeATNkiT3+mFP+PbI9c=
+github.com/tigrisdata/ocache/coordinator v1.2.0/go.mod h1:7Tz/rsPMUKEao2BLv6mLrwHqHvG8IsRQGl7J1O1NnBU=
+github.com/tigrisdata/ocache/coordinator/proto v1.2.0 h1:K27TAoAcPsGeh2uvSSF+wQq11kSmRm8g3ck6csGO6gE=
+github.com/tigrisdata/ocache/coordinator/proto v1.2.0/go.mod h1:VJRxHBf/TquQ8vtMaJX5VYSxHFe20N61TqgUWJb1ySM=
+github.com/tigrisdata/ocache/proto v1.2.0 h1:YcWH9aibjBP2MBgDQKSm9DYp81GXyJSYzAL+6IqUANk=
+github.com/tigrisdata/ocache/proto v1.2.0/go.mod h1:7Yo5vs0iLy/K/KZGenC7oV9zBqexyKEOyZdstdzFmJQ=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.28.0+incompatible h1:G4QSBfvPKvg5ZM2j9MrJFdfI5iSljY/WnJqOGFao6HI=
 github.com/uber/jaeger-client-go v2.28.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -13,32 +13,32 @@ type ErrorCode string
 
 // S3 Error codes
 const (
-	ErrNone                      ErrorCode = ""
-	ErrAccessDenied              ErrorCode = "AccessDenied"
-	ErrBucketNotEmpty            ErrorCode = "BucketNotEmpty"
-	ErrBucketAlreadyExists       ErrorCode = "BucketAlreadyExists"
-	ErrBucketAlreadyOwnedByYou   ErrorCode = "BucketAlreadyOwnedByYou"
-	ErrNoSuchBucket              ErrorCode = "NoSuchBucket"
-	ErrNoSuchKey                 ErrorCode = "NoSuchKey"
-	ErrNoSuchUpload              ErrorCode = "NoSuchUpload"
-	ErrInvalidAccessKeyId        ErrorCode = "InvalidAccessKeyId"
-	ErrSignatureDoesNotMatch     ErrorCode = "SignatureDoesNotMatch"
-	ErrInvalidBucketName         ErrorCode = "InvalidBucketName"
-	ErrInvalidObjectName         ErrorCode = "InvalidObjectName"
-	ErrInvalidPart               ErrorCode = "InvalidPart"
-	ErrInvalidPartNumber         ErrorCode = "InvalidPartNumber"
-	ErrInvalidPartOrder          ErrorCode = "InvalidPartOrder"
-	ErrInternalError             ErrorCode = "InternalError"
-	ErrMalformedXML              ErrorCode = "MalformedXML"
-	ErrMethodNotAllowed          ErrorCode = "MethodNotAllowed"
-	ErrNotImplemented            ErrorCode = "NotImplemented"
-	ErrRequestTimeout            ErrorCode = "RequestTimeout"
-	ErrServiceUnavailable        ErrorCode = "ServiceUnavailable"
-	ErrSlowDown                  ErrorCode = "SlowDown"
-	ErrInvalidRequest            ErrorCode = "InvalidRequest"
-	ErrMissingContentLength      ErrorCode = "MissingContentLength"
-	ErrIncompleteBody            ErrorCode = "IncompleteBody"
-	ErrInvalidRange              ErrorCode = "InvalidRange"
+	ErrNone                         ErrorCode = ""
+	ErrAccessDenied                 ErrorCode = "AccessDenied"
+	ErrBucketNotEmpty               ErrorCode = "BucketNotEmpty"
+	ErrBucketAlreadyExists          ErrorCode = "BucketAlreadyExists"
+	ErrBucketAlreadyOwnedByYou      ErrorCode = "BucketAlreadyOwnedByYou"
+	ErrNoSuchBucket                 ErrorCode = "NoSuchBucket"
+	ErrNoSuchKey                    ErrorCode = "NoSuchKey"
+	ErrNoSuchUpload                 ErrorCode = "NoSuchUpload"
+	ErrInvalidAccessKeyId           ErrorCode = "InvalidAccessKeyId"
+	ErrSignatureDoesNotMatch        ErrorCode = "SignatureDoesNotMatch"
+	ErrInvalidBucketName            ErrorCode = "InvalidBucketName"
+	ErrInvalidObjectName            ErrorCode = "InvalidObjectName"
+	ErrInvalidPart                  ErrorCode = "InvalidPart"
+	ErrInvalidPartNumber            ErrorCode = "InvalidPartNumber"
+	ErrInvalidPartOrder             ErrorCode = "InvalidPartOrder"
+	ErrInternalError                ErrorCode = "InternalError"
+	ErrMalformedXML                 ErrorCode = "MalformedXML"
+	ErrMethodNotAllowed             ErrorCode = "MethodNotAllowed"
+	ErrNotImplemented               ErrorCode = "NotImplemented"
+	ErrRequestTimeout               ErrorCode = "RequestTimeout"
+	ErrServiceUnavailable           ErrorCode = "ServiceUnavailable"
+	ErrSlowDown                     ErrorCode = "SlowDown"
+	ErrInvalidRequest               ErrorCode = "InvalidRequest"
+	ErrMissingContentLength         ErrorCode = "MissingContentLength"
+	ErrIncompleteBody               ErrorCode = "IncompleteBody"
+	ErrInvalidRange                 ErrorCode = "InvalidRange"
 	ErrAuthorizationHeaderMalformed ErrorCode = "AuthorizationHeaderMalformed"
 	ErrInvalidArgument              ErrorCode = "InvalidArgument"
 	ErrBadContentLength             ErrorCode = "BadContentLength"
@@ -46,11 +46,11 @@ const (
 
 // ErrorResponse represents an S3 error response.
 type ErrorResponse struct {
-	XMLName    xml.Name  `xml:"Error"`
-	Code       ErrorCode `xml:"Code"`
-	Message    string    `xml:"Message"`
-	Resource   string    `xml:"Resource,omitempty"`
-	RequestID  string    `xml:"RequestId,omitempty"`
+	XMLName   xml.Name  `xml:"Error"`
+	Code      ErrorCode `xml:"Code"`
+	Message   string    `xml:"Message"`
+	Resource  string    `xml:"Resource,omitempty"`
+	RequestID string    `xml:"RequestId,omitempty"`
 }
 
 // errorInfo holds error details for writing responses.
@@ -62,31 +62,31 @@ type errorInfo struct {
 
 // errorMap maps error codes to HTTP status and messages.
 var errorMap = map[ErrorCode]errorInfo{
-	ErrAccessDenied:              {http.StatusForbidden, ErrAccessDenied, "Access Denied"},
-	ErrBucketNotEmpty:            {http.StatusConflict, ErrBucketNotEmpty, "The bucket you tried to delete is not empty"},
-	ErrBucketAlreadyExists:       {http.StatusConflict, ErrBucketAlreadyExists, "The requested bucket name is not available"},
-	ErrBucketAlreadyOwnedByYou:   {http.StatusConflict, ErrBucketAlreadyOwnedByYou, "Your previous request to create the named bucket succeeded"},
-	ErrNoSuchBucket:              {http.StatusNotFound, ErrNoSuchBucket, "The specified bucket does not exist"},
-	ErrNoSuchKey:                 {http.StatusNotFound, ErrNoSuchKey, "The specified key does not exist"},
-	ErrNoSuchUpload:              {http.StatusNotFound, ErrNoSuchUpload, "The specified multipart upload does not exist"},
-	ErrInvalidAccessKeyId:        {http.StatusForbidden, ErrInvalidAccessKeyId, "The AWS access key ID you provided does not exist in our records"},
-	ErrSignatureDoesNotMatch:     {http.StatusForbidden, ErrSignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided"},
-	ErrInvalidBucketName:         {http.StatusBadRequest, ErrInvalidBucketName, "The specified bucket is not valid"},
-	ErrInvalidObjectName:         {http.StatusBadRequest, ErrInvalidObjectName, "Object name is not valid"},
-	ErrInvalidPart:               {http.StatusBadRequest, ErrInvalidPart, "One or more of the specified parts could not be found"},
-	ErrInvalidPartNumber:         {http.StatusBadRequest, ErrInvalidPartNumber, "The part number you specified is not valid"},
-	ErrInvalidPartOrder:          {http.StatusBadRequest, ErrInvalidPartOrder, "The list of parts was not in ascending order"},
-	ErrInternalError:             {http.StatusInternalServerError, ErrInternalError, "We encountered an internal error. Please try again."},
-	ErrMalformedXML:              {http.StatusBadRequest, ErrMalformedXML, "The XML you provided was not well-formed"},
-	ErrMethodNotAllowed:          {http.StatusMethodNotAllowed, ErrMethodNotAllowed, "The specified method is not allowed against this resource"},
-	ErrNotImplemented:            {http.StatusNotImplemented, ErrNotImplemented, "A header you provided implies functionality that is not implemented"},
-	ErrRequestTimeout:            {http.StatusBadRequest, ErrRequestTimeout, "Your socket connection to the server was not read from or written to within the timeout period"},
-	ErrServiceUnavailable:        {http.StatusServiceUnavailable, ErrServiceUnavailable, "Service is unable to handle request"},
-	ErrSlowDown:                  {http.StatusServiceUnavailable, ErrSlowDown, "Please reduce your request rate"},
-	ErrInvalidRequest:            {http.StatusBadRequest, ErrInvalidRequest, "Invalid Request"},
-	ErrMissingContentLength:      {http.StatusLengthRequired, ErrMissingContentLength, "You must provide the Content-Length HTTP header"},
-	ErrIncompleteBody:            {http.StatusBadRequest, ErrIncompleteBody, "You did not provide the number of bytes specified by the Content-Length HTTP header"},
-	ErrInvalidRange:              {http.StatusRequestedRangeNotSatisfiable, ErrInvalidRange, "The requested range is not satisfiable"},
+	ErrAccessDenied:                 {http.StatusForbidden, ErrAccessDenied, "Access Denied"},
+	ErrBucketNotEmpty:               {http.StatusConflict, ErrBucketNotEmpty, "The bucket you tried to delete is not empty"},
+	ErrBucketAlreadyExists:          {http.StatusConflict, ErrBucketAlreadyExists, "The requested bucket name is not available"},
+	ErrBucketAlreadyOwnedByYou:      {http.StatusConflict, ErrBucketAlreadyOwnedByYou, "Your previous request to create the named bucket succeeded"},
+	ErrNoSuchBucket:                 {http.StatusNotFound, ErrNoSuchBucket, "The specified bucket does not exist"},
+	ErrNoSuchKey:                    {http.StatusNotFound, ErrNoSuchKey, "The specified key does not exist"},
+	ErrNoSuchUpload:                 {http.StatusNotFound, ErrNoSuchUpload, "The specified multipart upload does not exist"},
+	ErrInvalidAccessKeyId:           {http.StatusForbidden, ErrInvalidAccessKeyId, "The AWS access key ID you provided does not exist in our records"},
+	ErrSignatureDoesNotMatch:        {http.StatusForbidden, ErrSignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided"},
+	ErrInvalidBucketName:            {http.StatusBadRequest, ErrInvalidBucketName, "The specified bucket is not valid"},
+	ErrInvalidObjectName:            {http.StatusBadRequest, ErrInvalidObjectName, "Object name is not valid"},
+	ErrInvalidPart:                  {http.StatusBadRequest, ErrInvalidPart, "One or more of the specified parts could not be found"},
+	ErrInvalidPartNumber:            {http.StatusBadRequest, ErrInvalidPartNumber, "The part number you specified is not valid"},
+	ErrInvalidPartOrder:             {http.StatusBadRequest, ErrInvalidPartOrder, "The list of parts was not in ascending order"},
+	ErrInternalError:                {http.StatusInternalServerError, ErrInternalError, "We encountered an internal error. Please try again."},
+	ErrMalformedXML:                 {http.StatusBadRequest, ErrMalformedXML, "The XML you provided was not well-formed"},
+	ErrMethodNotAllowed:             {http.StatusMethodNotAllowed, ErrMethodNotAllowed, "The specified method is not allowed against this resource"},
+	ErrNotImplemented:               {http.StatusNotImplemented, ErrNotImplemented, "A header you provided implies functionality that is not implemented"},
+	ErrRequestTimeout:               {http.StatusBadRequest, ErrRequestTimeout, "Your socket connection to the server was not read from or written to within the timeout period"},
+	ErrServiceUnavailable:           {http.StatusServiceUnavailable, ErrServiceUnavailable, "Service is unable to handle request"},
+	ErrSlowDown:                     {http.StatusServiceUnavailable, ErrSlowDown, "Please reduce your request rate"},
+	ErrInvalidRequest:               {http.StatusBadRequest, ErrInvalidRequest, "Invalid Request"},
+	ErrMissingContentLength:         {http.StatusLengthRequired, ErrMissingContentLength, "You must provide the Content-Length HTTP header"},
+	ErrIncompleteBody:               {http.StatusBadRequest, ErrIncompleteBody, "You did not provide the number of bytes specified by the Content-Length HTTP header"},
+	ErrInvalidRange:                 {http.StatusRequestedRangeNotSatisfiable, ErrInvalidRange, "The requested range is not satisfiable"},
 	ErrAuthorizationHeaderMalformed: {http.StatusBadRequest, ErrAuthorizationHeaderMalformed, "The authorization header is malformed"},
 	ErrInvalidArgument:              {http.StatusBadRequest, ErrInvalidArgument, "Invalid argument"},
 	ErrBadContentLength:             {http.StatusBadRequest, ErrBadContentLength, "The Content-Length you specified is invalid"},


### PR DESCRIPTION
Resolves the ocache build failure by removing local replace directives and updating to v1.2.0.

Adds GitHub Actions workflows for testing and release automation, following the ocache project pattern. Separates unit tests from integration tests in the Makefile, and includes semantic-release configuration for automated versioning.

Includes developer setup documentation for private Tigris repository access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CI/CD and dependency updates aligned with ocache standards.
> 
> - Adds GitHub Actions: `commitlint` for PR titles, `test.yml` for lint/unit/integration/race/coverage on main/PRs, and `release.yaml` to build multi-platform binaries and publish via semantic-release on `release` branch
> - Updates `go.mod`/`go.sum` to use `github.com/tigrisdata/ocache/*` v1.2.0 and drops local replace directives
> - Refactors `Makefile` testing: separates unit vs integration, adds targets (`test-all`, integration variants), and scopes unit test packages; adjusts race/coverage to unit tests
> - Updates `README` with developer setup for accessing private Tigris repos
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9df4478528c538f657286ba875aa41d1d419bf8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->