### PR TITLE
feat: add Docker setup with docker-compose configurations

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,78 @@
+name: Docker Build and Push
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag (e.g., v1.0.0)"
+        required: true
+
+env:
+  GOPRIVATE: github.com/tigrisdata
+
+jobs:
+  build-and-push:
+    runs-on: namespace-profile-ubuntu-2404
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git for private modules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            git fetch --tags
+            VERSION=$(git tag --list 'v*' --sort=-version:refname | head -1)
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.GH_DOCKER_ACCESS_USER }}
+          password: ${{ secrets.GH_DOCKER_ACCESS_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          TAGS="tigrisdata/tag:${VERSION}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            TAGS="${TAGS},tigrisdata/tag:latest"
+          fi
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            GOPRIVATE=github.com/tigrisdata
+          secrets: |
+            "git_auth_token=${{ secrets.GH_BOT_ACCESS_TOKEN }}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,12 +35,19 @@ jobs:
         id: version
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            VERSION="${{ github.event.inputs.version }}"
           else
             git fetch --tags
             VERSION=$(git tag --list 'v*' --sort=-version:refname | head -1)
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
           fi
+          if [ -z "$VERSION" ]; then
+            echo "Error: No version found"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout release tag
+        run: git checkout ${{ steps.version.outputs.version }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -166,13 +166,69 @@ See [docs/metrics.md](docs/metrics.md) for complete metrics reference.
 
 ### Docker
 
+#### Quick Start
+
 ```bash
-docker build -t tag:latest -f deploy/Dockerfile .
+# Single node (TAG + ocache)
+cd docker
+docker-compose up -d
+
+# Cluster mode (2 TAG + 3 ocache)
+docker-compose -f docker-compose-cluster.yml up -d
+```
+
+#### Environment Variables
+
+Create a `.env` file in the `docker/` directory:
+
+```bash
+# Required
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+
+# Optional
+TAG_LOG_LEVEL=info
+```
+
+#### Single Node Setup
+
+```bash
+# Start services
+docker-compose -f docker/docker-compose.yml up -d
+
+# View logs
+docker-compose -f docker/docker-compose.yml logs -f tag
+
+# Stop services
+docker-compose -f docker/docker-compose.yml down
+```
+
+#### Cluster Setup
+
+```bash
+# Start 2 TAG nodes + 3 ocache cluster
+docker-compose -f docker/docker-compose-cluster.yml up -d
+
+# TAG endpoints are available at:
+# - http://localhost:8081 (tag-1)
+# - http://localhost:8082 (tag-2)
+
+# Stop cluster
+docker-compose -f docker/docker-compose-cluster.yml down -v
+```
+
+#### Building Local Image
+
+```bash
+# Build image locally
+docker build -t tag:local -f docker/Dockerfile .
+
+# Run with local image
 docker run -p 8080:8080 \
   -e AWS_ACCESS_KEY_ID=your_key \
   -e AWS_SECRET_ACCESS_KEY=your_secret \
-  -e TAG_OCACHE_ENDPOINTS=ocache:9000 \
-  tag:latest
+  -e TAG_OCACHE_ENDPOINTS=host.docker.internal:9000 \
+  tag:local
 ```
 
 ### Kubernetes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,20 @@ FROM golang:1.24-alpine AS builder
 # Install git and ca-certificates (needed for go mod download)
 RUN apk add --no-cache git ca-certificates
 
+# Configure GOPRIVATE for tigrisdata modules
+ENV GOPRIVATE=github.com/tigrisdata
+
 WORKDIR /app
 
 # Copy go mod files
 COPY go.mod go.sum ./
-RUN go mod download
+
+# Download dependencies with git auth for private modules
+RUN --mount=type=secret,id=git_auth_token \
+    if [ -f /run/secrets/git_auth_token ]; then \
+      git config --global url."https://x-access-token:$(cat /run/secrets/git_auth_token)@github.com/".insteadOf "https://github.com/"; \
+    fi && \
+    go mod download
 
 # Copy source code
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,4 +49,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget -q --spider http://localhost:8080/health || exit 1
 
 ENTRYPOINT ["tag"]
-CMD ["--config", "/etc/tag/config.yaml"]

--- a/docker/docker-compose-cluster.yml
+++ b/docker/docker-compose-cluster.yml
@@ -1,0 +1,129 @@
+x-ocache-common: &ocache-common
+  image: tigrisdata/ocache:latest
+  restart: unless-stopped
+  networks:
+    - tag-cluster
+
+x-tag-common: &tag-common
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile
+  image: tigrisdata/tag:latest
+  restart: unless-stopped
+  networks:
+    - tag-cluster
+
+services:
+  # TAG Node 1
+  tag-1:
+    <<: *tag-common
+    container_name: tag-1
+    hostname: tag-1
+    ports:
+      - "8081:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_OCACHE_ENDPOINTS=ocache-node1:9000,ocache-node2:9000,ocache-node3:9000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    depends_on:
+      ocache-node1:
+        condition: service_healthy
+      ocache-node2:
+        condition: service_healthy
+      ocache-node3:
+        condition: service_healthy
+
+  # TAG Node 2
+  tag-2:
+    <<: *tag-common
+    container_name: tag-2
+    hostname: tag-2
+    ports:
+      - "8082:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_OCACHE_ENDPOINTS=ocache-node1:9000,ocache-node2:9000,ocache-node3:9000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    depends_on:
+      ocache-node1:
+        condition: service_healthy
+      ocache-node2:
+        condition: service_healthy
+      ocache-node3:
+        condition: service_healthy
+
+  # OCache Node 1
+  ocache-node1:
+    <<: *ocache-common
+    container_name: ocache-node1
+    hostname: ocache-node1
+    ports:
+      - "9001:9000"
+      - "9101:9001"
+      - "7001:7000"
+    volumes:
+      - ocache-node1-data:/data
+    command:
+      - "-disk=/data"
+      - "-listen-addr=:9000"
+      - "-listen-http=:9001"
+      - "-cluster-enabled"
+      - "-node-id=node1"
+      - "-cluster-addr=:7000"
+      - "-seeds=ocache-node1:7000,ocache-node2:7000,ocache-node3:7000"
+
+  # OCache Node 2
+  ocache-node2:
+    <<: *ocache-common
+    container_name: ocache-node2
+    hostname: ocache-node2
+    ports:
+      - "9002:9000"
+      - "9102:9001"
+      - "7002:7000"
+    volumes:
+      - ocache-node2-data:/data
+    command:
+      - "-disk=/data"
+      - "-listen-addr=:9000"
+      - "-listen-http=:9001"
+      - "-cluster-enabled"
+      - "-node-id=node2"
+      - "-cluster-addr=:7000"
+      - "-seeds=ocache-node1:7000,ocache-node2:7000,ocache-node3:7000"
+    depends_on:
+      - ocache-node1
+
+  # OCache Node 3
+  ocache-node3:
+    <<: *ocache-common
+    container_name: ocache-node3
+    hostname: ocache-node3
+    ports:
+      - "9003:9000"
+      - "9103:9001"
+      - "7003:7000"
+    volumes:
+      - ocache-node3-data:/data
+    command:
+      - "-disk=/data"
+      - "-listen-addr=:9000"
+      - "-listen-http=:9001"
+      - "-cluster-enabled"
+      - "-node-id=node3"
+      - "-cluster-addr=:7000"
+      - "-seeds=ocache-node1:7000,ocache-node2:7000,ocache-node3:7000"
+    depends_on:
+      - ocache-node2
+
+networks:
+  tag-cluster:
+
+volumes:
+  ocache-node1-data:
+  ocache-node2-data:
+  ocache-node3-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  tag:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: tigrisdata/tag:latest
+    container_name: tag
+    ports:
+      - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_OCACHE_ENDPOINTS=ocache:9000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    depends_on:
+      ocache:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - tag-network
+
+  ocache:
+    image: tigrisdata/ocache:latest
+    container_name: ocache
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ocache-data:/data
+    command:
+      - "-disk=/data"
+      - "-listen-addr=:9000"
+      - "-listen-http=:9001"
+    restart: unless-stopped
+    networks:
+      - tag-network
+
+networks:
+  tag-network:
+
+volumes:
+  ocache-data:


### PR DESCRIPTION
## Summary

Add Docker infrastructure for TAG following ocache patterns.

- Dockerfile moved to docker/ with build secret support for private modules
- docker-compose.yml for single-node deployment (TAG + ocache)
- docker-compose-cluster.yml for multi-node setup (2 TAG + 3 ocache cluster)
- GitHub workflow for multi-architecture Docker image builds (amd64, arm64)
- Updated README with comprehensive Docker deployment instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Docker-based build and deployment for TAG, including local dev and multi-node setups, plus CI to publish images.
> 
> - New `docker/Dockerfile` with `GOPRIVATE` and build secret support for private modules; static build; non-root runtime; healthcheck
> - Adds `docker/docker-compose.yml` (single TAG + ocache) and `docker/docker-compose-cluster.yml` (2 TAG + 3 ocache) with env-driven config
> - Adds `.github/workflows/docker.yaml` to build/push multi-arch images (amd64, arm64) on Release completion or manual dispatch, with version/`latest` tagging and Docker Hub auth
> - Updates `README.md` with Docker quick start, env vars, single/cluster setup, and local image build/run instructions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483d3e9fe810206608215c05471bf7b94844e688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->