### PR TITLE
docs: update API Reference to reflect full S3 endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,15 +148,7 @@ See [docs/deployment.md](docs/deployment.md) for complete deployment guide inclu
 
 ## API Reference
 
-TAG implements a subset of the S3 API:
-
-| Operation | Endpoint | Description |
-|-----------|----------|-------------|
-| GetObject | `GET /{bucket}/{key}` | Retrieve object (with caching) |
-| PutObject | `PUT /{bucket}/{key}` | Upload object (invalidates cache) |
-| DeleteObject | `DELETE /{bucket}/{key}` | Delete object (invalidates cache) |
-| HeadObject | `HEAD /{bucket}/{key}` | Get object metadata |
-| CopyObject | `PUT /{bucket}/{key}` with `x-amz-copy-source` | Copy object |
+TAG supports all S3 API endpoints supported by Tigris, including bucket operations, object operations, multipart uploads, and more. See the [Tigris S3 API documentation](https://www.tigrisdata.com/docs/api/s3/) for the complete list of supported operations.
 
 ### Response Headers
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigri
 
 ## Features
 
-- **S3-Compatible API**: Supports GET, PUT, DELETE, HEAD, and COPY operations
+- **S3-Compatible API**: Supports all S3 API endpoints supported by Tigris
 - **Transparent Caching**: Automatic caching of objects with configurable TTL and size thresholds
 - **Request Coalescing**: Streaming broadcast pattern reduces duplicate upstream requests under concurrent load
 - **Range Request Caching**: Background fetch of full objects on range cache miss for optimal ML training workloads


### PR DESCRIPTION
## Summary
- Replace inaccurate API Reference table with accurate description
- TAG supports all S3 endpoints that Tigris supports, not just a subset
- Link to Tigris documentation for complete list of operations

## Changes
Updated the API Reference section to state that TAG supports all S3 API endpoints supported by Tigris, including bucket operations, object operations, multipart uploads, and more. The Response Headers and Cache Behavior sections remain unchanged as they document TAG-specific behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Documentation update**
> 
> - Updates `README.md` to state the S3 compatibility covers all endpoints supported by Tigris (not just a subset)
> - Replaces the API Reference table with a concise statement and a link to the official Tigris S3 API documentation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f454174a076af9578ab5cf5be60de0dcfd83136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->