### PR TITLE
fix: S3 compatibility improvements and multipart idempotency

### DIFF
--- a/.github/workflows/s3-tests.yaml
+++ b/.github/workflows/s3-tests.yaml
@@ -1,0 +1,74 @@
+name: S3 Compatibility Tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+  workflow_call:
+
+env:
+  GO_VERSION: "1.24.2"
+  GOPRIVATE: github.com/tigrisdata
+
+jobs:
+  s3-compat-tests:
+    runs-on: namespace-profile-ubuntu-2404
+    permissions:
+      actions: write
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure git for private modules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Start test infrastructure
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make s3-test-infra
+
+      - name: Wait for services to be ready
+        run: |
+          echo "Waiting for TAG to be ready..."
+          timeout 60 bash -c 'until curl -s http://localhost:8080/health > /dev/null 2>&1; do sleep 2; done'
+          echo "TAG is ready!"
+
+      - name: Run S3 compatibility tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make s3-tests
+
+      - name: Show TAG logs on failure
+        if: failure()
+        run: docker compose -f tests/s3compat/docker-compose.yml logs tag
+
+      - name: Cleanup
+        if: always()
+        run: make s3-test-infra-down

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@
 
 # Go build artifacts
 /tag
+
+# S3 compatibility tests (cloned repo, venv, and generated config with credentials)
+tests/s3compat/s3-tests/
+tests/s3compat/.venv/
+tests/s3compat/s3tests.conf.generated
+
+# Coverage reports
+coverage.out
+coverage.html
+coverage-integration.out
+coverage-integration.html

--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,87 @@ help:
 	@echo "  run           - Run TAG with default options"
 	@echo "  run-verbose   - Run TAG with debug logging"
 	@echo ""
+	@echo "S3 compatibility test targets:"
+	@echo "  s3-test-local      - Start local S3 test env (TAG on host, ocache in Docker)"
+	@echo "  s3-test-local-down - Stop local S3 test environment"
+	@echo "  s3-tests           - Run S3 compatibility tests (ceph s3-tests)"
+	@echo "  s3-tests-clean     - Remove cloned s3-tests repository"
+	@echo ""
+	@echo "  LOCAL DEVELOPMENT (recommended - no GH_TOKEN needed):"
+	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
+	@echo "    export AWS_SECRET_ACCESS_KEY=<your-secret>"
+	@echo "    make s3-test-local      # Starts ocache + TAG locally"
+	@echo "    make s3-tests           # Run tests"
+	@echo "    make s3-test-local-down # Cleanup"
+	@echo ""
+	@echo "  CI/DOCKER BUILD (requires GH_TOKEN for private repos):"
+	@echo "  s3-test-infra      - Start S3 test infrastructure (TAG + ocache in Docker)"
+	@echo "  s3-test-infra-down - Stop S3 test infrastructure"
+	@echo "    export GH_TOKEN=<your-github-pat>"
+	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
+	@echo "    export AWS_SECRET_ACCESS_KEY=<your-secret>"
+	@echo "    make s3-test-infra && make s3-tests"
+	@echo ""
 	@echo "Other targets:"
 	@echo "  clean         - Remove built binary and generated files"
 	@echo "  help          - Show this help message"
+
+# S3 compatibility tests
+S3_TEST_COMPOSE := docker compose -f tests/s3compat/docker-compose.yml
+
+.PHONY: s3-test-infra
+s3-test-infra:
+	@echo "Starting S3 test infrastructure..."
+	@if [ -z "$$GH_TOKEN" ]; then \
+		echo "Error: GH_TOKEN environment variable is not set."; \
+		echo "Set it to a GitHub Personal Access Token with repo access:"; \
+		echo "  export GH_TOKEN=<your-github-pat>"; \
+		echo "Create a PAT at: https://github.com/settings/tokens"; \
+		exit 1; \
+	fi
+	$(S3_TEST_COMPOSE) --profile full build
+	$(S3_TEST_COMPOSE) --profile full up -d --wait
+
+.PHONY: s3-test-infra-down
+s3-test-infra-down:
+	@echo "Stopping S3 test infrastructure..."
+	$(S3_TEST_COMPOSE) --profile full down -v
+
+# Local development: Run TAG on host, only ocache in Docker (no GH_TOKEN needed)
+.PHONY: s3-test-local
+s3-test-local: build
+	@echo "Starting S3 test infrastructure (local mode)..."
+	@if [ -z "$$AWS_ACCESS_KEY_ID" ] || [ -z "$$AWS_SECRET_ACCESS_KEY" ]; then \
+		echo "Error: AWS credentials not set."; \
+		echo "  export AWS_ACCESS_KEY_ID=<your-key>"; \
+		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
+		exit 1; \
+	fi
+	$(S3_TEST_COMPOSE) up -d ocache --wait
+	@echo "Starting TAG locally..."
+	@TAG_UPSTREAM_ENDPOINT=$${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev} \
+		TAG_OCACHE_ENDPOINTS=localhost:9000 \
+		TAG_LOG_LEVEL=$${TAG_LOG_LEVEL:-debug} \
+		./$(BINARY_NAME) &
+	@echo "Waiting for TAG to be ready..."
+	@timeout 30 bash -c 'until curl -s http://localhost:8080/health > /dev/null 2>&1; do sleep 1; done' || \
+		(echo "TAG failed to start"; exit 1)
+	@echo "TAG is ready at http://localhost:8080"
+
+.PHONY: s3-test-local-down
+s3-test-local-down:
+	@echo "Stopping S3 test infrastructure (local mode)..."
+	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
+	$(S3_TEST_COMPOSE) down -v
+
+.PHONY: s3-tests
+s3-tests:
+	@echo "Running S3 compatibility tests..."
+	cd tests/s3compat && ./run-tests.sh
+
+.PHONY: s3-tests-clean
+s3-tests-clean:
+	@echo "Cleaning up S3 test artifacts..."
+	rm -rf tests/s3compat/s3-tests
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ make test-proxy
 
 # Run with race detector
 make test-race
+
+# Run S3 compatibility tests (requires AWS credentials)
+make s3-test-local && make s3-tests
 ```
+
+See [docs/s3-compatibility-testing.md](docs/s3-compatibility-testing.md) for detailed S3 compatibility testing guide.
 
 ## Configuration
 

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -60,8 +60,26 @@ func NewRequestSigner(endpoint, region string) *RequestSigner {
 func (s *RequestSigner) SignRequest(ctx context.Context, method, path string,
 	body io.Reader, bodyHash string, accessKey, secretKey string, headers http.Header) (*http.Request, error) {
 
-	// Build the full URL
-	fullURL := s.endpoint + path
+	// Build the full URL using url.URL to properly handle encoding
+	// This ensures special characters like % are properly encoded
+	baseURL, err := url.Parse(s.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
+	}
+
+	// Split path and query string
+	pathPart := path
+	queryPart := ""
+	if idx := strings.Index(path, "?"); idx != -1 {
+		pathPart = path[:idx]
+		queryPart = path[idx+1:]
+	}
+
+	// Set path (Go will properly encode special characters like % when converting to string)
+	baseURL.Path = pathPart
+	baseURL.RawQuery = queryPart
+
+	fullURL := baseURL.String()
 
 	// Create the new request with streaming body
 	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
@@ -121,8 +139,9 @@ func (s *RequestSigner) signHTTP(req *http.Request, accessKey, secretKey, bodyHa
 
 // buildCanonicalRequest builds the canonical request string for signing.
 func (s *RequestSigner) buildCanonicalRequest(req *http.Request, bodyHash string) (string, string) {
-	// Canonical URI (URL-encoded path)
-	canonicalURI := req.URL.EscapedPath()
+	// Canonical URI - use AWS SigV4 encoding which encodes more characters than Go's EscapedPath
+	// Specifically, + must be encoded as %2B per AWS spec, but Go's EscapedPath leaves it unencoded
+	canonicalURI := awsURIEncode(req.URL.Path, false)
 	if canonicalURI == "" {
 		canonicalURI = "/"
 	}
@@ -159,13 +178,13 @@ func (s *RequestSigner) buildCanonicalQueryString(query url.Values) string {
 	}
 	sort.Strings(keys)
 
-	// Build sorted key=value pairs
+	// Build sorted key=value pairs using AWS SigV4 encoding
 	pairs := make([]string, 0, len(query))
 	for _, k := range keys {
 		values := query[k]
 		sort.Strings(values)
 		for _, v := range values {
-			pairs = append(pairs, url.QueryEscape(k)+"="+url.QueryEscape(v))
+			pairs = append(pairs, awsURIEncode(k, true)+"="+awsURIEncode(v, true))
 		}
 	}
 
@@ -283,4 +302,23 @@ func hashSHA256(data []byte) string {
 	h := sha256.New()
 	h.Write(data)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// awsURIEncode encodes a string per AWS SigV4 spec (RFC 3986).
+// Unlike url.QueryEscape, this encodes spaces as %20 not +.
+// Set encodeSlash to false for path encoding (S3 bucket/key paths).
+func awsURIEncode(s string, encodeSlash bool) string {
+	var result strings.Builder
+	result.Grow(len(s) * 3) // Worst case: all chars need encoding
+	for _, c := range []byte(s) {
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || c == '_' || c == '-' || c == '~' || c == '.' {
+			result.WriteByte(c)
+		} else if c == '/' && !encodeSlash {
+			result.WriteByte(c)
+		} else {
+			result.WriteString(fmt.Sprintf("%%%02X", c))
+		}
+	}
+	return result.String()
 }

--- a/auth/signer_test.go
+++ b/auth/signer_test.go
@@ -163,7 +163,7 @@ func TestBuildCanonicalQueryString(t *testing.T) {
 		{
 			name:     "parameters with special characters",
 			query:    "prefix=test/path&marker=file name.txt",
-			expected: "marker=file+name.txt&prefix=test%2Fpath",
+			expected: "marker=file%20name.txt&prefix=test%2Fpath", // AWS SigV4 uses %20 for spaces, not +
 		},
 	}
 
@@ -229,6 +229,59 @@ func TestHashSHA256(t *testing.T) {
 			result := hashSHA256([]byte(tt.input))
 			if result != tt.expected {
 				t.Errorf("hashSHA256(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAwsURIEncode(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		encodeSlash bool
+		expected    string
+	}{
+		// Unreserved characters should not be encoded
+		{name: "lowercase letters", input: "abcxyz", encodeSlash: true, expected: "abcxyz"},
+		{name: "uppercase letters", input: "ABCXYZ", encodeSlash: true, expected: "ABCXYZ"},
+		{name: "digits", input: "0123456789", encodeSlash: true, expected: "0123456789"},
+		{name: "unreserved special", input: "_-~.", encodeSlash: true, expected: "_-~."},
+
+		// Spaces should be %20, not +
+		{name: "space", input: "hello world", encodeSlash: true, expected: "hello%20world"},
+		{name: "multiple spaces", input: "a b c", encodeSlash: true, expected: "a%20b%20c"},
+
+		// Slash handling
+		{name: "slash with encodeSlash true", input: "a/b/c", encodeSlash: true, expected: "a%2Fb%2Fc"},
+		{name: "slash with encodeSlash false", input: "a/b/c", encodeSlash: false, expected: "a/b/c"},
+
+		// Special characters should be percent-encoded
+		{name: "at sign", input: "user@example.com", encodeSlash: true, expected: "user%40example.com"},
+		{name: "ampersand", input: "a&b", encodeSlash: true, expected: "a%26b"},
+		{name: "equals", input: "a=b", encodeSlash: true, expected: "a%3Db"},
+		{name: "plus sign", input: "a+b", encodeSlash: true, expected: "a%2Bb"},
+		{name: "percent", input: "100%", encodeSlash: true, expected: "100%25"},
+		{name: "colon", input: "a:b", encodeSlash: true, expected: "a%3Ab"},
+		{name: "question mark", input: "a?b", encodeSlash: true, expected: "a%3Fb"},
+		{name: "hash", input: "a#b", encodeSlash: true, expected: "a%23b"},
+
+		// Mixed content
+		{name: "path with space", input: "path/to/my file.txt", encodeSlash: false, expected: "path/to/my%20file.txt"},
+		{name: "query param value", input: "hello world!", encodeSlash: true, expected: "hello%20world%21"},
+
+		// Empty string
+		{name: "empty string", input: "", encodeSlash: true, expected: ""},
+
+		// Unicode characters should be UTF-8 encoded then percent-encoded
+		{name: "unicode", input: "日本", encodeSlash: true, expected: "%E6%97%A5%E6%9C%AC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := awsURIEncode(tt.input, tt.encodeSlash)
+			if result != tt.expected {
+				t.Errorf("awsURIEncode(%q, %v) = %q, want %q",
+					tt.input, tt.encodeSlash, result, tt.expected)
 			}
 		})
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -197,8 +197,9 @@ func (v *RequestValidator) computePresignedSignature(r *http.Request, authInfo *
 
 // buildCanonicalRequest builds the canonical request for signature verification.
 func (v *RequestValidator) buildCanonicalRequest(r *http.Request, signedHeaders []string, bodyHash string) string {
-	// Canonical URI
-	canonicalURI := r.URL.EscapedPath()
+	// Canonical URI - use AWS SigV4 encoding which encodes more characters than Go's EscapedPath
+	// Specifically, + must be encoded as %2B per AWS spec, but Go's EscapedPath leaves it unencoded
+	canonicalURI := awsURIEncode(r.URL.Path, false)
 	if canonicalURI == "" {
 		canonicalURI = "/"
 	}
@@ -224,8 +225,9 @@ func (v *RequestValidator) buildCanonicalRequest(r *http.Request, signedHeaders 
 
 // buildCanonicalRequestPresigned builds the canonical request for presigned URL verification.
 func (v *RequestValidator) buildCanonicalRequestPresigned(r *http.Request, signedHeaders []string, bodyHash string) string {
-	// Canonical URI
-	canonicalURI := r.URL.EscapedPath()
+	// Canonical URI - use AWS SigV4 encoding which encodes more characters than Go's EscapedPath
+	// Specifically, + must be encoded as %2B per AWS spec, but Go's EscapedPath leaves it unencoded
+	canonicalURI := awsURIEncode(r.URL.Path, false)
 	if canonicalURI == "" {
 		canonicalURI = "/"
 	}
@@ -264,13 +266,13 @@ func (v *RequestValidator) buildCanonicalQueryString(query url.Values) string {
 	}
 	sort.Strings(keys)
 
-	// Build sorted key=value pairs
+	// Build sorted key=value pairs using AWS SigV4 encoding
 	pairs := make([]string, 0, len(query))
 	for _, k := range keys {
 		values := query[k]
 		sort.Strings(values)
 		for _, val := range values {
-			pairs = append(pairs, url.QueryEscape(k)+"="+url.QueryEscape(val))
+			pairs = append(pairs, awsURIEncode(k, true)+"="+awsURIEncode(val, true))
 		}
 	}
 

--- a/cache/completion.go
+++ b/cache/completion.go
@@ -1,0 +1,93 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// CompletionCacheTTL is the TTL for completion cache entries in seconds.
+	// tigris-os uses 1 second; we use 5 seconds for safety margin.
+	CompletionCacheTTL = 5
+
+	// completionKeyPrefix is the prefix for completion cache keys.
+	completionKeyPrefix = "complete:"
+)
+
+// CompletionEntry stores a cached CompleteMultipartUpload response.
+type CompletionEntry struct {
+	StatusCode int               `json:"status_code"`
+	Headers    map[string]string `json:"headers"`
+	Body       []byte            `json:"body"`
+}
+
+// MakeCompletionKey creates a cache key for a completion response.
+func MakeCompletionKey(bucket, key, uploadId string) string {
+	return completionKeyPrefix + bucket + "|" + key + "|" + uploadId
+}
+
+// GetCompletion retrieves a cached completion response.
+func (c *Cache) GetCompletion(ctx context.Context, bucket, key, uploadId string) (*CompletionEntry, bool, error) {
+	if !c.IsEnabled() {
+		return nil, false, nil
+	}
+
+	cacheKey := MakeCompletionKey(bucket, key, uploadId)
+	data, err := c.client.Get(ctx, cacheKey)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if data == nil {
+		return nil, false, nil
+	}
+
+	var entry CompletionEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		log.Debug().Err(err).Str("key", cacheKey).Msg("Completion cache decode error")
+		return nil, false, nil // Treat decode errors as cache miss
+	}
+
+	log.Debug().Str("bucket", bucket).Str("uploadId", uploadId).Msg("Completion cache hit")
+	return &entry, true, nil
+}
+
+// PutCompletion stores a completion response in cache.
+func (c *Cache) PutCompletion(ctx context.Context, bucket, key, uploadId string, statusCode int, headers http.Header, body []byte) error {
+	if !c.IsEnabled() {
+		return nil
+	}
+
+	// Convert headers to simple map (single value per key)
+	headerMap := make(map[string]string)
+	for k, v := range headers {
+		if len(v) > 0 {
+			headerMap[k] = v[0]
+		}
+	}
+
+	entry := CompletionEntry{
+		StatusCode: statusCode,
+		Headers:    headerMap,
+		Body:       body,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+
+	cacheKey := MakeCompletionKey(bucket, key, uploadId)
+	if err := c.client.Put(ctx, cacheKey, data, CompletionCacheTTL); err != nil {
+		log.Debug().Err(err).Str("key", cacheKey).Msg("Completion cache put error")
+		return err
+	}
+
+	log.Debug().Str("bucket", bucket).Str("uploadId", uploadId).Msg("Completion cached")
+	return nil
+}

--- a/cache/completion_test.go
+++ b/cache/completion_test.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+)
+
+func TestCompletionCache(t *testing.T) {
+	// Create an in-memory cache for testing
+	memCache := cacheclient.NewMemoryCache()
+	cache := NewCacheWithClient(memCache, nil)
+
+	ctx := context.Background()
+	bucket := "test-bucket"
+	key := "test-key"
+	uploadId := "upload-123"
+
+	// Test 1: GetCompletion returns not found for non-existent entry
+	t.Run("GetCompletion_NotFound", func(t *testing.T) {
+		entry, found, err := cache.GetCompletion(ctx, bucket, key, uploadId)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Error("expected not found, got found")
+		}
+		if entry != nil {
+			t.Error("expected nil entry, got non-nil")
+		}
+	})
+
+	// Test 2: PutCompletion stores and GetCompletion retrieves
+	t.Run("PutCompletion_and_GetCompletion", func(t *testing.T) {
+		headers := http.Header{
+			"Content-Type": []string{"application/xml"},
+			"X-Amz-Id-2":   []string{"test-id"},
+			"ETag":         []string{"\"abc123\""},
+		}
+		body := []byte(`<CompleteMultipartUploadResult><ETag>"abc123"</ETag></CompleteMultipartUploadResult>`)
+		statusCode := 200
+
+		err := cache.PutCompletion(ctx, bucket, key, uploadId, statusCode, headers, body)
+		if err != nil {
+			t.Fatalf("PutCompletion failed: %v", err)
+		}
+
+		// Retrieve and verify
+		entry, found, err := cache.GetCompletion(ctx, bucket, key, uploadId)
+		if err != nil {
+			t.Fatalf("GetCompletion failed: %v", err)
+		}
+		if !found {
+			t.Fatal("expected entry to be found")
+		}
+		if entry == nil {
+			t.Fatal("expected non-nil entry")
+		}
+		if entry.StatusCode != statusCode {
+			t.Errorf("expected status code %d, got %d", statusCode, entry.StatusCode)
+		}
+		if entry.Headers["Content-Type"] != "application/xml" {
+			t.Errorf("expected Content-Type 'application/xml', got %q", entry.Headers["Content-Type"])
+		}
+		if entry.Headers["ETag"] != "\"abc123\"" {
+			t.Errorf("expected ETag '\"abc123\"', got %q", entry.Headers["ETag"])
+		}
+		if string(entry.Body) != string(body) {
+			t.Errorf("expected body %q, got %q", body, entry.Body)
+		}
+	})
+
+	// Test 3: Different uploadId returns not found
+	t.Run("Different_UploadId_NotFound", func(t *testing.T) {
+		entry, found, err := cache.GetCompletion(ctx, bucket, key, "different-upload-id")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Error("expected not found for different uploadId")
+		}
+		if entry != nil {
+			t.Error("expected nil entry for different uploadId")
+		}
+	})
+
+	// Test 4: MakeCompletionKey format
+	t.Run("MakeCompletionKey_Format", func(t *testing.T) {
+		key := MakeCompletionKey("bucket", "path/to/object", "upload-abc")
+		expected := "complete:bucket|path/to/object|upload-abc"
+		if key != expected {
+			t.Errorf("expected key %q, got %q", expected, key)
+		}
+	})
+}
+
+func TestCompletionCache_DisabledCache(t *testing.T) {
+	// Create a disabled cache
+	cache := &Cache{enabled: false}
+
+	ctx := context.Background()
+
+	// GetCompletion should return not found without error
+	entry, found, err := cache.GetCompletion(ctx, "bucket", "key", "uploadId")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected not found for disabled cache")
+	}
+	if entry != nil {
+		t.Error("expected nil entry for disabled cache")
+	}
+
+	// PutCompletion should succeed without error (no-op)
+	err = cache.PutCompletion(ctx, "bucket", "key", "uploadId", 200, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error for disabled cache: %v", err)
+	}
+}

--- a/cache/object.go
+++ b/cache/object.go
@@ -59,10 +59,11 @@ func MetaFromHTTPHeaders(bucket, key string, statusCode int, headers http.Header
 	}
 
 	// Extract user metadata (x-amz-meta-*)
+	// Store with lowercase key to match S3 convention
 	for k, v := range headers {
 		lk := strings.ToLower(k)
 		if strings.HasPrefix(lk, "x-amz-meta-") && len(v) > 0 {
-			meta.UserMetadata[k] = v[0]
+			meta.UserMetadata[lk] = v[0]
 		}
 	}
 
@@ -90,8 +91,10 @@ func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter) {
 	if m.StorageClass != "" {
 		w.Header().Set("x-amz-storage-class", m.StorageClass)
 	}
+	// Write user metadata with lowercase keys per S3 convention
 	for k, v := range m.UserMetadata {
-		w.Header().Set(k, v)
+		lk := strings.ToLower(k)
+		w.Header().Set(lk, v)
 	}
 }
 

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -219,6 +219,60 @@ func TestMetaFromHTTPHeaders_MultipleMetadataHeaders(t *testing.T) {
 	}
 }
 
+func TestMetaFromHTTPHeaders_MetadataLowercaseKeys(t *testing.T) {
+	// Go's http.Header canonicalizes keys (e.g., x-amz-meta-foo -> X-Amz-Meta-Foo)
+	// Our code should store metadata with lowercase keys per S3 convention
+	headers := http.Header{
+		"X-Amz-Meta-Custom-Key": []string{"custom-value"},
+		"X-Amz-Meta-Another":    []string{"another-value"},
+	}
+
+	obj := MetaFromHTTPHeaders("bucket", "key", http.StatusOK, headers)
+
+	// Keys should be stored lowercase
+	if _, ok := obj.UserMetadata["x-amz-meta-custom-key"]; !ok {
+		t.Error("UserMetadata should store key as lowercase 'x-amz-meta-custom-key'")
+	}
+	if _, ok := obj.UserMetadata["X-Amz-Meta-Custom-Key"]; ok {
+		t.Error("UserMetadata should NOT store key as canonical 'X-Amz-Meta-Custom-Key'")
+	}
+
+	// Values should be preserved
+	if obj.UserMetadata["x-amz-meta-custom-key"] != "custom-value" {
+		t.Errorf("UserMetadata[x-amz-meta-custom-key] = %q, want %q",
+			obj.UserMetadata["x-amz-meta-custom-key"], "custom-value")
+	}
+	if obj.UserMetadata["x-amz-meta-another"] != "another-value" {
+		t.Errorf("UserMetadata[x-amz-meta-another] = %q, want %q",
+			obj.UserMetadata["x-amz-meta-another"], "another-value")
+	}
+}
+
+func TestCachedObjectMeta_WriteHeaders_MetadataLowercase(t *testing.T) {
+	meta := &CachedObjectMeta{
+		Key:         "test-key",
+		Bucket:      "test-bucket",
+		ContentType: "application/octet-stream",
+		UserMetadata: map[string]string{
+			"x-amz-meta-custom": "custom-value",
+			"x-amz-meta-foo":    "foo-value",
+		},
+		StatusCode: http.StatusOK,
+	}
+
+	w := httptest.NewRecorder()
+	meta.WriteHeaders(w)
+
+	// Metadata headers should be written with lowercase keys
+	// http.Header.Get is case-insensitive, so it will find headers regardless of case
+	if w.Header().Get("x-amz-meta-custom") != "custom-value" {
+		t.Errorf("x-amz-meta-custom = %q, want %q", w.Header().Get("x-amz-meta-custom"), "custom-value")
+	}
+	if w.Header().Get("x-amz-meta-foo") != "foo-value" {
+		t.Errorf("x-amz-meta-foo = %q, want %q", w.Header().Get("x-amz-meta-foo"), "foo-value")
+	}
+}
+
 func TestCachedObjectMeta_MatchesETag(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,13 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Cache.Endpoints = splitEndpoints(endpoints)
 	}
 
-	// Disable cache from environment
+	// Auto-enable cache when endpoints are configured via environment
+	// This must run AFTER endpoints are set from environment
+	if len(cfg.Cache.Endpoints) > 0 && !cfg.Cache.Enabled {
+		cfg.Cache.Enabled = true
+	}
+
+	// Disable cache from environment (explicit disable takes precedence)
 	if disabled := os.Getenv("TAG_CACHE_DISABLED"); disabled == "true" || disabled == "1" {
 		cfg.Cache.Enabled = false
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -288,3 +288,50 @@ cache:
 		t.Error("Cache.Enabled = false, want true (auto-enabled with endpoints)")
 	}
 }
+
+func TestCacheAutoEnabledFromEnv(t *testing.T) {
+	// Create a config file WITHOUT cache endpoints
+	content := `
+server:
+  http_port: 8080
+`
+
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	// Set cache endpoints via environment variable
+	t.Setenv("TAG_OCACHE_ENDPOINTS", "localhost:9000")
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Verify cache is auto-enabled when endpoints are configured via environment
+	if !cfg.Cache.Enabled {
+		t.Error("Cache.Enabled = false, want true (auto-enabled with endpoints from env)")
+	}
+	if len(cfg.Cache.Endpoints) != 1 {
+		t.Errorf("Cache.Endpoints length = %d, want 1", len(cfg.Cache.Endpoints))
+	}
+	if cfg.Cache.Endpoints[0] != "localhost:9000" {
+		t.Errorf("Cache.Endpoints[0] = %q, want localhost:9000", cfg.Cache.Endpoints[0])
+	}
+}
+
+func TestNewDefaultCacheAutoEnabledFromEnv(t *testing.T) {
+	// Set cache endpoints via environment variable
+	t.Setenv("TAG_OCACHE_ENDPOINTS", "localhost:9000")
+
+	cfg := NewDefault()
+
+	// Verify cache is auto-enabled when endpoints are configured via environment
+	if !cfg.Cache.Enabled {
+		t.Error("Cache.Enabled = false, want true (auto-enabled with endpoints from env)")
+	}
+	if len(cfg.Cache.Endpoints) != 1 {
+		t.Errorf("Cache.Endpoints length = %d, want 1", len(cfg.Cache.Endpoints))
+	}
+}

--- a/docs/s3-compatibility-testing.md
+++ b/docs/s3-compatibility-testing.md
@@ -1,0 +1,148 @@
+# S3 Compatibility Tests
+
+TAG includes S3 compatibility tests using the upstream [ceph/s3-tests](https://github.com/ceph/s3-tests) test suite. Test files are located in `tests/s3compat/`.
+
+## Overview
+
+The S3 compatibility tests validate that TAG correctly implements the S3 API by running a curated subset of the ceph/s3-tests against a real Tigris backend (t3.storage.dev). This ensures end-to-end compatibility for:
+
+- **Header validation** - Content-Type, MD5, Content-Length handling
+- **Bucket operations** - Create, delete, list, naming validation
+- **Object operations** - Read, write, metadata, ETags
+- **Multipart uploads** - Initiate, upload parts, complete, abort
+- **Copy operations** - Same bucket, cross-bucket, metadata handling
+
+## Prerequisites
+
+1. **AWS Credentials** - Valid credentials for Tigris (t3.storage.dev):
+   ```bash
+   export AWS_ACCESS_KEY_ID=<your-tigris-access-key>
+   export AWS_SECRET_ACCESS_KEY=<your-tigris-secret-key>
+   ```
+
+2. **Docker** - Required for running ocache
+
+3. **Python 3** - Required for running the ceph/s3-tests suite
+
+4. **Go 1.21+** - Required for building TAG (local mode only)
+
+## Running Tests Locally (Recommended)
+
+The recommended approach runs TAG on your host machine with ocache in Docker. This avoids needing a GitHub token for private module access.
+
+```bash
+# 1. Set credentials
+export AWS_ACCESS_KEY_ID=<your-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret>
+
+# 2. Start test infrastructure (builds TAG, starts ocache)
+make s3-test-local
+
+# 3. Run S3 compatibility tests
+make s3-tests
+
+# 4. Cleanup when done
+make s3-test-local-down
+```
+
+### Running a Single Test
+
+To run a specific test, pass the test path as an argument:
+
+```bash
+cd tests/s3compat
+./run-tests.sh test_s3.py::test_bucket_list_empty
+```
+
+## Running Tests in Docker (CI Mode)
+
+For CI or fully containerized testing, both TAG and ocache run in Docker. This requires a GitHub token for private Go module access.
+
+```bash
+# 1. Set credentials and GitHub token
+export AWS_ACCESS_KEY_ID=<your-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret>
+export GH_TOKEN=<your-github-pat>
+
+# 2. Start infrastructure (builds and runs TAG + ocache in Docker)
+make s3-test-infra
+
+# 3. Run tests
+make s3-tests
+
+# 4. Cleanup
+make s3-test-infra-down
+```
+
+## Test Categories
+
+The test suite is organized into categories matching the curated test list from tigris-os:
+
+| Category | Description | Test Count |
+|----------|-------------|------------|
+| `test_headers` | Header validation (MD5, Content-Type, etc.) | 18 |
+| `test_s3` | Core S3 list operations (prefix, delimiter) | 58 |
+| `test_objects` | Object read/write/metadata | 10 |
+| `test_buckets` | Bucket operations and naming rules | 17 |
+| `test_multipart` | Multipart upload operations | 8 |
+| `test_copy` | Object copy operations | 9 |
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   s3-tests      │────▶│      TAG        │────▶│     Tigris      │
+│  (ceph/pytest)  │     │  (localhost:    │     │ (t3.storage.dev)│
+│                 │     │      8080)      │     │                 │
+└─────────────────┘     └────────┬────────┘     └─────────────────┘
+                                 │
+                                 ▼
+                        ┌─────────────────┐
+                        │     ocache      │
+                        │  (localhost:    │
+                        │      9000)      │
+                        └─────────────────┘
+```
+
+## Configuration
+
+The test configuration is in `tests/s3compat/s3tests.conf`. Key settings:
+
+- **Host/Port**: `localhost:8080` (TAG endpoint)
+- **Protocol**: HTTP (not HTTPS)
+- **Bucket prefix**: `tag-test-{random}-` to avoid conflicts
+
+Credentials are substituted at runtime via `run-tests.sh`.
+
+## Troubleshooting
+
+### Tests fail with "AWS credentials not set"
+
+Ensure both environment variables are exported:
+```bash
+export AWS_ACCESS_KEY_ID=<your-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret>
+```
+
+### Tests fail with connection errors
+
+Verify TAG and ocache are running:
+```bash
+curl http://localhost:8080/health  # TAG health
+curl http://localhost:9001/health  # ocache health
+```
+
+### Cleaning up test artifacts
+
+Remove the cloned s3-tests repository:
+```bash
+make s3-tests-clean
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `tests/s3compat/run-tests.sh` | Test runner script (clones s3-tests, runs pytest via tox) |
+| `tests/s3compat/s3tests.conf` | Test configuration template |
+| `tests/s3compat/docker-compose.yml` | Docker setup for TAG + ocache |

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -109,6 +109,11 @@ func (s *Server) setupRouter() *mux.Router {
 		Queries("location", "").
 		Methods("GET")
 
+	// DeleteObjects (multi-object delete)
+	r.HandleFunc("/{bucket}", s.handleDeleteObjects).
+		Queries("delete", "").
+		Methods("POST")
+
 	// Basic bucket operations (ListObjects V1, CreateBucket, DeleteBucket, HeadBucket)
 	r.HandleFunc("/{bucket}", s.handleBucket).Methods("GET", "HEAD", "PUT", "DELETE")
 
@@ -407,6 +412,16 @@ func (s *Server) handleBucketLocation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.service.HandlePassthrough(w, r); err != nil {
+		handleError(w, r, err)
+	}
+}
+
+// handleDeleteObjects handles DeleteObjects (multi-object delete) operation.
+func (s *Server) handleDeleteObjects(w http.ResponseWriter, r *http.Request) {
+	if !validateBucketName(w, r) {
+		return
+	}
+	if err := s.service.HandleDeleteObjects(w, r); err != nil {
 		handleError(w, r, err)
 	}
 }

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -46,7 +48,18 @@ func (s *Server) setupRouter() *mux.Router {
 	// S3 API routes - path style
 	// The order matters - more specific routes should come first
 
-	// Object operations with query parameters
+	// CompleteMultipartUpload - POST with uploadId but no partNumber
+	// Must be registered before generic handleObjectWithQuery to cache completion responses
+	r.HandleFunc("/{bucket}/{object:.+}", s.handleCompleteMultipartUpload).
+		Queries("uploadId", "{uploadId}").
+		Methods("POST").
+		MatcherFunc(func(r *http.Request, rm *mux.RouteMatch) bool {
+			// Only match if partNumber is NOT present (CompleteMultipartUpload)
+			// UploadPart has both uploadId and partNumber
+			return r.URL.Query().Get("partNumber") == ""
+		})
+
+	// Object operations with query parameters (UploadPart, ListParts, AbortMultipartUpload, etc.)
 	r.HandleFunc("/{bucket}/{object:.+}", s.handleObjectWithQuery).
 		Queries("uploadId", "{uploadId}").
 		Methods("PUT", "POST", "DELETE", "GET")
@@ -175,8 +188,21 @@ func getBucketName(r *http.Request) string {
 	return vars["bucket"]
 }
 
-// validateBucketName checks if bucket name is non-empty.
+// validBucketNameRegex validates basic S3 bucket name format:
+// - Must start with a lowercase letter or number
+// - Can contain lowercase letters, numbers, hyphens, and dots
+// - Must end with a lowercase letter or number
+var validBucketNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*[a-z0-9]$`)
+
+// validateBucketName checks if bucket name follows S3 naming rules.
 // Returns true if valid, false if invalid (error already written to response).
+// S3 bucket naming rules:
+// - 3-63 characters
+// - Lowercase letters, numbers, hyphens, dots only
+// - Must start and end with letter or number
+// - Cannot contain consecutive dots (..)
+// - Cannot contain dot-dash (.-) or dash-dot (-.) patterns
+// - Cannot contain underscores
 func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 	bucket := getBucketName(r)
 	if bucket == "" {
@@ -184,6 +210,42 @@ func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 		WriteError(w, r, ErrInvalidArgument)
 		return false
 	}
+
+	// Length check: 3-63 characters
+	if len(bucket) < 3 || len(bucket) > 63 {
+		log.Debug().Str("bucket", bucket).Msg("Bucket name length invalid")
+		WriteError(w, r, ErrInvalidBucketName)
+		return false
+	}
+
+	// Must match valid pattern (start/end with letter or number)
+	if !validBucketNameRegex.MatchString(bucket) {
+		log.Debug().Str("bucket", bucket).Msg("Bucket name format invalid")
+		WriteError(w, r, ErrInvalidBucketName)
+		return false
+	}
+
+	// Cannot contain consecutive dots (..)
+	if strings.Contains(bucket, "..") {
+		log.Debug().Str("bucket", bucket).Msg("Bucket name contains consecutive dots")
+		WriteError(w, r, ErrInvalidBucketName)
+		return false
+	}
+
+	// Cannot contain dot-dash (.-) or dash-dot (-.)
+	if strings.Contains(bucket, ".-") || strings.Contains(bucket, "-.") {
+		log.Debug().Str("bucket", bucket).Msg("Bucket name contains invalid dot-dash pattern")
+		WriteError(w, r, ErrInvalidBucketName)
+		return false
+	}
+
+	// Cannot contain underscore
+	if strings.Contains(bucket, "_") {
+		log.Debug().Str("bucket", bucket).Msg("Bucket name contains underscore")
+		WriteError(w, r, ErrInvalidBucketName)
+		return false
+	}
+
 	return true
 }
 
@@ -292,6 +354,18 @@ func (s *Server) handleListObjectsV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.service.HandlePassthrough(w, r); err != nil {
+		handleError(w, r, err)
+	}
+}
+
+// handleCompleteMultipartUpload handles CompleteMultipartUpload with idempotency caching.
+// This caches successful completion responses in ocache to support idempotent calls,
+// matching tigris-os behavior where a second CompleteMultipartUpload returns success.
+func (s *Server) handleCompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
+	if !validateBucketName(w, r) {
+		return
+	}
+	if err := s.service.HandleCompleteMultipartUpload(w, r); err != nil {
 		handleError(w, r, err)
 	}
 }
@@ -407,13 +481,17 @@ func (s *Server) handleBucketTagging(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleBucketLocation handles GetBucketLocation operation.
+// Returns the configured region directly instead of proxying to upstream.
 func (s *Server) handleBucketLocation(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+
+	region := s.service.GetRegion()
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">%s</LocationConstraint>`, region)
 }
 
 // handleDeleteObjects handles DeleteObjects (multi-object delete) operation.

--- a/handlers/validation_test.go
+++ b/handlers/validation_test.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestValidateBucketName(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucketName string
+		wantValid  bool
+	}{
+		// Valid bucket names
+		{name: "valid simple", bucketName: "mybucket", wantValid: true},
+		{name: "valid with numbers", bucketName: "bucket123", wantValid: true},
+		{name: "valid with hyphens", bucketName: "my-bucket-name", wantValid: true},
+		{name: "valid with dots", bucketName: "my.bucket.name", wantValid: true},
+		{name: "valid minimum length", bucketName: "abc", wantValid: true},
+		{name: "valid 63 chars", bucketName: "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz1", wantValid: true},
+
+		// Invalid: empty
+		{name: "empty bucket name", bucketName: "", wantValid: false},
+
+		// Invalid: length
+		{name: "too short 1 char", bucketName: "a", wantValid: false},
+		{name: "too short 2 chars", bucketName: "ab", wantValid: false},
+		{name: "too long 64 chars", bucketName: "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz12", wantValid: false},
+
+		// Invalid: characters
+		{name: "uppercase letters", bucketName: "MyBucket", wantValid: false},
+		{name: "underscore", bucketName: "my_bucket", wantValid: false},
+		{name: "special characters", bucketName: "my@bucket", wantValid: false},
+
+		// Invalid: start/end
+		{name: "starts with hyphen", bucketName: "-mybucket", wantValid: false},
+		{name: "ends with hyphen", bucketName: "mybucket-", wantValid: false},
+		{name: "starts with dot", bucketName: ".mybucket", wantValid: false},
+		{name: "ends with dot", bucketName: "mybucket.", wantValid: false},
+
+		// Invalid: patterns
+		{name: "consecutive dots", bucketName: "my..bucket", wantValid: false},
+		{name: "dot-dash pattern", bucketName: "my.-bucket", wantValid: false},
+		{name: "dash-dot pattern", bucketName: "my-.bucket", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a request with the bucket name in the path
+			req := httptest.NewRequest(http.MethodGet, "/"+tt.bucketName, nil)
+
+			// Set up mux vars to simulate gorilla/mux routing
+			req = mux.SetURLVars(req, map[string]string{"bucket": tt.bucketName})
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Call validateBucketName
+			got := validateBucketName(w, req)
+
+			if got != tt.wantValid {
+				t.Errorf("validateBucketName() = %v, want %v", got, tt.wantValid)
+			}
+
+			// If invalid, check that an error response was written
+			if !tt.wantValid && tt.bucketName != "" {
+				if w.Code != http.StatusBadRequest {
+					t.Errorf("HTTP status = %d, want %d for invalid bucket", w.Code, http.StatusBadRequest)
+				}
+			}
+		})
+	}
+}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -1,0 +1,235 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+	"github.com/tigrisdata/tag/proxy/broadcast"
+)
+
+// setupCacheListener creates a listener that streams chunks directly to cache via io.Pipe.
+// This avoids buffering the entire response in memory.
+// Stores both metadata (from headers) and body in separate cache entries.
+func (s *Service) setupCacheListener(
+	ctx context.Context,
+	bucket, key string,
+	broadcaster *broadcast.Broadcaster,
+) (*io.PipeWriter, chan error) {
+	listener := broadcaster.Subscribe()
+	if listener == nil {
+		return nil, nil
+	}
+
+	// Create pipe for streaming to cache
+	pipeReader, pipeWriter := io.Pipe()
+	errCh := make(chan error, 1)
+
+	// Start goroutine to consume chunks, build metadata, and write to cache
+	go func() {
+		defer close(errCh)
+
+		// Wait for headers to build metadata
+		statusCode, headers, err := listener.WaitForHeaders(ctx)
+		if err != nil {
+			pipeWriter.CloseWithError(err)
+			errCh <- err
+			return
+		}
+
+		// Build metadata from response headers
+		meta := cache.MetaFromHTTPHeaders(bucket, key, statusCode, headers)
+
+		// Check if still cacheable based on metadata
+		if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
+			pipeWriter.CloseWithError(nil)
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache - not cacheable")
+			return
+		}
+
+		// Start a goroutine to stream chunks to the pipe
+		go func() {
+			for chunk := range listener.Chunks() {
+				if chunk.Err != nil {
+					pipeWriter.CloseWithError(chunk.Err)
+					return
+				}
+				if len(chunk.Data) > 0 {
+					if _, writeErr := pipeWriter.Write(chunk.Data); writeErr != nil {
+						pipeWriter.CloseWithError(writeErr)
+						return
+					}
+				}
+			}
+			pipeWriter.Close()
+		}()
+
+		// Use a detached context for cache writes to avoid cancellation when HTTP request completes.
+		// The cache write should continue even after the client has received the response.
+		cacheCtx, cacheCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cacheCancel()
+
+		// Write to cache with metadata (streaming)
+		ttl := int(s.config.Cache.TTL.Seconds())
+		cacheErr := s.cache.PutWithMetaStream(cacheCtx, bucket, key, meta, pipeReader, ttl)
+		if cacheErr != nil {
+			log.Debug().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write with metadata failed")
+		}
+		errCh <- cacheErr
+	}()
+
+	return pipeWriter, errCh
+}
+
+// fetchFullObjectToCache fetches the full object and caches it.
+// This makes a full-object request (no Range header) and streams directly to cache.
+func (s *Service) fetchFullObjectToCache(
+	ctx context.Context,
+	bucket, key, accessKey, secretKey string,
+	broadcaster *broadcast.Broadcaster,
+) error {
+	// Execute full object request (no Range header)
+	resp, err := s.forwarder.DoFullObjectRequest(ctx, bucket, key, accessKey, secretKey)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d for background fetch", resp.StatusCode)
+	}
+
+	// Check if response is within cache threshold
+	if resp.ContentLength > 0 && resp.ContentLength > s.config.Cache.SizeThreshold {
+		log.Debug().
+			Str("bucket", bucket).
+			Str("key", key).
+			Int64("size", resp.ContentLength).
+			Int64("threshold", s.config.Cache.SizeThreshold).
+			Msg("Skipping background cache - object too large")
+		return nil
+	}
+
+	// Check for no-cache headers
+	if s.hasNoCacheHeaders(resp.Header) {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping background cache - no-cache headers")
+		return nil
+	}
+
+	// Set up cache listener (streams to cache via pipe)
+	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster)
+
+	// Set headers for the cache listener
+	broadcaster.SetHeaders(resp.StatusCode, resp.Header)
+
+	// Stream body to broadcaster (which includes cache listener)
+	chunkSize := s.config.Broadcast.ChunkSize
+	if chunkSize <= 0 {
+		chunkSize = broadcast.DefaultChunkSize
+	}
+	buf := make([]byte, chunkSize)
+
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			broadcaster.Broadcast(buf[:n])
+		}
+
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+
+	// Wait for cache write to complete
+	if cacheErrCh != nil {
+		select {
+		case err := <-cacheErrCh:
+			if err != nil {
+				log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background cache write failed")
+			}
+			return err
+		case <-time.After(30 * time.Second):
+			log.Warn().Str("bucket", bucket).Str("key", key).Msg("Background cache write timeout")
+			return errors.New("cache write timeout")
+		}
+	}
+
+	_ = cachePipeWriter // managed by cache listener goroutine
+	return nil
+}
+
+// triggerBackgroundCacheFetch starts a background fetch of the full object.
+// Uses broadcast manager to coalesce multiple triggers for the same object.
+func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string) {
+	bcastKey := "bg:" + bucket + "/" + key
+
+	broadcaster, isFirst := s.backgroundFetchManager.GetOrCreate(bcastKey)
+	if !isFirst {
+		// Another background fetch is already in progress
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background fetch already in progress, coalescing")
+		return
+	}
+
+	// I'm the first - start the background fetch
+	metrics.RecordBackgroundFetchTriggered()
+	metrics.SetActiveBackgroundFetches(s.backgroundFetchManager.ActiveCount())
+
+	go func() {
+		defer func() {
+			s.backgroundFetchManager.Remove(bcastKey)
+			metrics.SetActiveBackgroundFetches(s.backgroundFetchManager.ActiveCount())
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, broadcaster)
+		broadcaster.Complete(err)
+
+		if err != nil {
+			log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background cache fetch failed")
+			metrics.RecordBackgroundFetchFailed()
+		} else {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background cache fetch completed")
+			metrics.RecordBackgroundFetchSucceeded()
+		}
+	}()
+}
+
+// hasNoCacheHeaders checks if response has no-cache directives.
+func (s *Service) hasNoCacheHeaders(headers http.Header) bool {
+	cc := headers.Get("Cache-Control")
+	return strings.Contains(cc, "no-store") || strings.Contains(cc, "private")
+}
+
+// isWithinSizeThreshold checks if response is within cache size threshold.
+// Uses Content-Length header if available.
+func (s *Service) isWithinSizeThreshold(resp *http.Response) bool {
+	if resp.ContentLength > 0 {
+		return resp.ContentLength <= s.config.Cache.SizeThreshold
+	}
+	// Unknown size - allow caching (will be handled by cache layer)
+	return true
+}
+
+// shouldSkipCache checks if cache should be skipped for this request.
+func shouldSkipCache(r *http.Request) bool {
+	cc := r.Header.Get("Cache-Control")
+	return strings.Contains(cc, "no-cache") || strings.Contains(cc, "max-age=0")
+}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// ============================================================================
+// DeleteObjects (Multi-Object Delete) Support
+// ============================================================================
+
+// deleteObjectsRequest represents the S3 DeleteObjects request body.
+type deleteObjectsRequest struct {
+	XMLName xml.Name            `xml:"Delete"`
+	Objects []deleteObjectEntry `xml:"Object"`
+	Quiet   bool                `xml:"Quiet"`
+}
+
+type deleteObjectEntry struct {
+	Key       string `xml:"Key"`
+	VersionId string `xml:"VersionId,omitempty"`
+}
+
+// HandleDeleteObjects handles POST /{bucket}?delete for bulk object deletion.
+// Invalidates cache for requested objects BEFORE forwarding to ensure consistency.
+func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	bucket, _ := ParseBucketKey(r)
+
+	log.Debug().Str("bucket", bucket).Msg("HandleDeleteObjects")
+
+	// Read request body to buffer it for parsing and forwarding
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
+	// This ensures cache consistency even if forwarding fails after cache invalidation
+	if s.cache.IsEnabled() {
+		var deleteReq deleteObjectsRequest
+		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
+			for _, obj := range deleteReq.Objects {
+				s.cache.Delete(context.Background(), bucket, obj.Key)
+				metrics.RecordCacheOperation("delete", "success")
+				log.Debug().
+					Str("bucket", bucket).
+					Str("key", obj.Key).
+					Msg("Cache invalidated for bulk-delete object")
+			}
+		}
+	}
+
+	// Forward request to upstream
+	err = s.forwarder.Forward(r.Context(), w, r)
+
+	// Record metrics
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("DeleteObjects", status, time.Since(start).Seconds())
+
+	return err
+}

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -216,6 +216,9 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 	capture.Body, readErr = io.ReadAll(io.TeeReader(resp.Body, w))
 	if readErr != nil {
 		log.Warn().Err(readErr).Msg("Failed to fully capture response body")
+		capture.Complete = false
+	} else {
+		capture.Complete = true
 	}
 
 	return capture, nil
@@ -226,6 +229,7 @@ type ResponseCapture struct {
 	StatusCode int
 	Headers    http.Header
 	Body       []byte
+	Complete   bool // True if body was fully captured without errors
 }
 
 // ContentLength returns the content length from headers or body length.

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -233,9 +234,17 @@ func (r *ResponseCapture) ContentLength() int64 {
 }
 
 // copyHeaders copies headers from src to dst.
+// For x-amz-meta-* headers, the key is lowercased to match S3 convention,
+// since Go's http.Header canonicalizes keys (e.g., x-amz-meta-foo → X-Amz-Meta-Foo).
 func copyHeaders(dst, src http.Header) {
 	for k, v := range src {
-		dst[k] = v
+		lower := strings.ToLower(k)
+		if strings.HasPrefix(lower, "x-amz-meta-") {
+			// Use lowercase for metadata headers per S3 convention
+			dst[lower] = v
+		} else {
+			dst[k] = v
+		}
 	}
 }
 

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -1,0 +1,535 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+	"github.com/tigrisdata/tag/proxy/broadcast"
+)
+
+// HandleGetObject handles GET requests for objects with cache-first logic.
+// Uses streaming broadcast for request coalescing to reduce upstream load.
+// Supports conditional requests (If-None-Match, If-Modified-Since).
+func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+	noCacheRead := shouldSkipCache(r)
+	rangeHeader := r.Header.Get("Range")
+
+	// Conditional request headers
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	ifModifiedSince := r.Header.Get("If-Modified-Since")
+
+	log.Debug().
+		Str("bucket", bucket).
+		Str("key", key).
+		Bool("no_cache", noCacheRead).
+		Str("if_none_match", ifNoneMatch).
+		Msg("HandleGetObject")
+
+	// 1. Validate credentials FIRST (before any broadcast operations)
+	accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil {
+		metrics.RecordRequest("GetObject", "auth_error", time.Since(start).Seconds())
+		return err
+	}
+
+	// 2. Check cache (fast path) - now also works for range requests!
+	// For range requests: check if full object is in cache, then serve range from it.
+	if !noCacheRead && s.cache.IsEnabled() {
+		meta, bodyReader, found, cacheErr := s.cache.GetWithMeta(ctx, bucket, key)
+		if cacheErr == nil && found && meta != nil {
+			// Close body reader if we got one (we may serve range instead)
+			if bodyReader != nil {
+				if closer, ok := bodyReader.(io.Closer); ok {
+					defer closer.Close()
+				}
+			}
+
+			// If this is a Range request and we have the full object cached,
+			// serve the range from the cached object
+			if rangeHeader != "" {
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
+				return s.serveRangeFromCache(ctx, w, bucket, key, meta, rangeHeader, start)
+			}
+
+			// Check conditional request: If-None-Match
+			if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(http.StatusNotModified)
+				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				return nil
+			}
+
+			// Check conditional request: If-Modified-Since
+			if ifModifiedSince != "" {
+				if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
+					if !meta.IsModifiedSince(t) {
+						metrics.RecordCacheHit()
+						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
+						w.Header().Set(XCacheHeader, XCacheHit)
+						w.WriteHeader(http.StatusNotModified)
+						metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+						return nil
+					}
+				}
+			}
+
+			// Serve full response from cache with proper headers
+			metrics.RecordCacheHit()
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata")
+			meta.WriteHeaders(w)
+			w.Header().Set(XCacheHeader, XCacheHit)
+			w.WriteHeader(meta.StatusCode)
+			if bodyReader != nil {
+				if _, copyErr := io.Copy(w, bodyReader); copyErr != nil {
+					log.Warn().Err(copyErr).Msg("Failed to copy cached content to response")
+				}
+			}
+			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+			return nil
+		}
+		metrics.RecordCacheMiss()
+	}
+
+	// 3. Cache miss - handle differently for range requests vs full object requests
+	// Range requests: forward immediately + trigger background cache fetch
+	if rangeHeader != "" {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range request cache miss - forwarding with background cache")
+		return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
+	}
+
+	// Full object request: use broadcast manager for streaming coalescing
+	bcastKey := makeBroadcastKey(bucket, key, rangeHeader)
+	broadcaster, isFirstCaller := s.broadcastManager.GetOrCreate(bcastKey)
+
+	// Determine X-Cache header value for this request
+	var xCache string
+	if !s.cache.IsEnabled() {
+		xCache = XCacheDisabled
+	} else {
+		xCache = XCacheMiss
+	}
+
+	// Update active broadcasts metric
+	metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
+
+	if isFirstCaller {
+		// I'm the fetcher - stream from upstream and broadcast to all listeners
+		metrics.RecordBroadcastFetch()
+		defer func() {
+			s.broadcastManager.Remove(bcastKey)
+			metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
+		}()
+		return s.fetchAndBroadcast(ctx, w, r, bucket, key, accessKey, secretKey, broadcaster, start, xCache)
+	}
+
+	// I'm a listener - try to subscribe
+	listener := broadcaster.Subscribe()
+	if listener == nil {
+		// Streaming already started (no late joiners) - start own fetch
+		metrics.RecordBroadcastFetch()
+		newBroadcaster, _ := s.broadcastManager.GetOrCreate(bcastKey + ":late")
+		defer func() {
+			s.broadcastManager.Remove(bcastKey + ":late")
+			metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
+		}()
+		return s.fetchAndBroadcast(ctx, w, r, bucket, key, accessKey, secretKey, newBroadcaster, start, xCache)
+	}
+
+	// Successfully subscribed - receive streamed chunks
+	metrics.RecordBroadcastShared()
+	return s.receiveFromBroadcastListener(ctx, w, listener, start, xCache)
+}
+
+// makeBroadcastKey creates a unique key for broadcast coalescing.
+func makeBroadcastKey(bucket, key, rangeHeader string) string {
+	if rangeHeader == "" {
+		return bucket + "/" + key
+	}
+	return bucket + "/" + key + ":" + rangeHeader
+}
+
+// fetchAndBroadcast fetches from upstream and broadcasts to all listeners.
+// This is the "fetcher" path - only one goroutine executes this per broadcast.
+// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
+func (s *Service) fetchAndBroadcast(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key, accessKey, secretKey string,
+	broadcaster *broadcast.Broadcaster,
+	start time.Time,
+	xCache string,
+) error {
+	// Subscribe ourselves as the first listener
+	listener := broadcaster.Subscribe()
+
+	// Start the upstream fetch in a goroutine
+	go func() {
+		err := s.streamFromUpstream(ctx, r, bucket, key, accessKey, secretKey, broadcaster)
+		broadcaster.Complete(err)
+	}()
+
+	// Receive chunks like any other listener
+	err := s.writeChunksToResponse(ctx, w, listener, xCache)
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	return err
+}
+
+// streamFromUpstream reads from upstream and broadcasts chunks.
+// Cache is added as a listener and receives chunks via io.Pipe (no buffering).
+func (s *Service) streamFromUpstream(
+	ctx context.Context,
+	r *http.Request,
+	bucket, key, accessKey, secretKey string,
+	broadcaster *broadcast.Broadcaster,
+) error {
+	// Execute upstream request
+	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Determine if we should cache this response
+	shouldCache := resp.StatusCode == http.StatusOK &&
+		s.cache.IsEnabled() &&
+		!s.hasNoCacheHeaders(resp.Header) &&
+		s.isWithinSizeThreshold(resp)
+
+	// Set up cache listener if caching (streams directly to cache via pipe)
+	var cachePipeWriter *io.PipeWriter
+	var cacheErrCh chan error
+
+	if shouldCache {
+		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster)
+	}
+
+	// Set headers for all listeners
+	broadcaster.SetHeaders(resp.StatusCode, resp.Header)
+
+	// Stream body in chunks, broadcasting to all listeners (including cache)
+	chunkSize := s.config.Broadcast.ChunkSize
+	if chunkSize <= 0 {
+		chunkSize = broadcast.DefaultChunkSize
+	}
+	buf := make([]byte, chunkSize)
+
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			broadcaster.Broadcast(buf[:n])
+		}
+
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			// Error during streaming - the broadcast will signal error to all listeners including cache
+			return readErr
+		}
+
+		// Check context cancellation
+		select {
+		case <-ctx.Done():
+			// Context canceled - the broadcast will signal error to all listeners
+			return ctx.Err()
+		default:
+		}
+	}
+
+	// Wait briefly for cache write to complete (the goroutine in setupCacheListener handles closing the pipe)
+	// We don't close cachePipeWriter here - the cache listener goroutine closes it when it finishes.
+	if cacheErrCh != nil {
+		// Wait up to 100ms for cache write to complete, otherwise continue
+		select {
+		case cacheWriteErr := <-cacheErrCh:
+			if cacheWriteErr != nil {
+				log.Warn().Err(cacheWriteErr).Str("bucket", bucket).Str("key", key).Msg("Cache write failed")
+			}
+		case <-time.After(100 * time.Millisecond):
+			// Don't block too long waiting for cache - it will complete in background
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache write still in progress, continuing")
+		}
+	}
+	// Ignore unused cachePipeWriter - it's managed by the cache listener goroutine
+	_ = cachePipeWriter
+
+	return nil
+}
+
+// receiveFromBroadcastListener receives chunks from an existing broadcast.
+// This is the "listener" path - waits for fetcher to stream data.
+// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
+func (s *Service) receiveFromBroadcastListener(
+	ctx context.Context,
+	w http.ResponseWriter,
+	listener *broadcast.Listener,
+	start time.Time,
+	xCache string,
+) error {
+	err := s.writeChunksToResponse(ctx, w, listener, xCache)
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	return err
+}
+
+// writeChunksToResponse writes received chunks to the HTTP response.
+// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
+func (s *Service) writeChunksToResponse(
+	ctx context.Context,
+	w http.ResponseWriter,
+	listener *broadcast.Listener,
+	xCache string,
+) error {
+	// Wait for headers first
+	status, headers, err := listener.WaitForHeaders(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Write headers to response
+	copyHeaders(w.Header(), headers)
+	w.Header().Set(XCacheHeader, xCache)
+	w.WriteHeader(status)
+
+	// Receive and write chunks
+	for chunk := range listener.Chunks() {
+		if chunk.Err != nil {
+			if chunk.Err == broadcast.ErrSlowConsumer {
+				metrics.RecordBroadcastSlowConsumer()
+			}
+			return chunk.Err
+		}
+
+		if len(chunk.Data) > 0 {
+			if _, writeErr := w.Write(chunk.Data); writeErr != nil {
+				return writeErr
+			}
+			// Flush if ResponseWriter supports it
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Range Request Caching Support
+// ============================================================================
+
+// byteRange represents a parsed byte range.
+type byteRange struct {
+	start int64
+	end   int64
+}
+
+// parseRangeHeader parses HTTP Range header.
+// Returns list of ranges or error if invalid.
+// totalSize is the size of the full object.
+func parseRangeHeader(rangeHeader string, totalSize int64) ([]byteRange, error) {
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		return nil, errors.New("invalid range header: missing 'bytes=' prefix")
+	}
+
+	rangeSpec := strings.TrimPrefix(rangeHeader, "bytes=")
+	parts := strings.Split(rangeSpec, ",")
+
+	var ranges []byteRange
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		dashIdx := strings.Index(part, "-")
+		if dashIdx == -1 {
+			return nil, errors.New("invalid range: missing dash")
+		}
+
+		startStr := part[:dashIdx]
+		endStr := part[dashIdx+1:]
+
+		var start, end int64
+
+		if startStr == "" {
+			// Suffix range: "-500" means last 500 bytes
+			suffixLen, err := strconv.ParseInt(endStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid suffix range: %v", err)
+			}
+			start = totalSize - suffixLen
+			if start < 0 {
+				start = 0
+			}
+			end = totalSize - 1
+		} else {
+			// Normal range: "0-499" or "500-"
+			var err error
+			start, err = strconv.ParseInt(startStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid range start: %v", err)
+			}
+
+			if endStr == "" {
+				// Open-ended: "500-" means from 500 to end
+				end = totalSize - 1
+			} else {
+				end, err = strconv.ParseInt(endStr, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("invalid range end: %v", err)
+				}
+			}
+		}
+
+		// Validate range
+		if start < 0 || start >= totalSize {
+			return nil, errors.New("range start out of bounds")
+		}
+		if end >= totalSize {
+			end = totalSize - 1
+		}
+		if start > end {
+			return nil, errors.New("invalid range: start > end")
+		}
+
+		ranges = append(ranges, byteRange{start: start, end: end})
+	}
+
+	return ranges, nil
+}
+
+// serveRangeFromCache serves a Range request from the cached full object.
+func (s *Service) serveRangeFromCache(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key string,
+	meta *cache.CachedObjectMeta,
+	rangeHeader string,
+	startTime time.Time,
+) error {
+	// Parse Range header
+	ranges, err := parseRangeHeader(rangeHeader, meta.ContentLength)
+	if err != nil || len(ranges) == 0 {
+		// Invalid range - return 416 Range Not Satisfiable
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
+		w.Header().Set(XCacheHeader, XCacheHit)
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
+		return nil
+	}
+
+	// Only support single range (multi-range is complex and rare)
+	if len(ranges) > 1 {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Multi-range not supported from cache")
+		// For multi-range, return 416 - we don't support it
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
+		w.Header().Set(XCacheHeader, XCacheHit)
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
+		return nil
+	}
+
+	rng := ranges[0]
+	contentLength := rng.end - rng.start + 1
+
+	// Set response headers
+	if meta.ContentType != "" {
+		w.Header().Set("Content-Type", meta.ContentType)
+	}
+	w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, meta.ContentLength))
+	if meta.ETag != "" {
+		w.Header().Set("ETag", meta.ETag)
+	}
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set(XCacheHeader, XCacheHit)
+	w.WriteHeader(http.StatusPartialContent)
+
+	// Stream range from cache
+	if err := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, w); err != nil {
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).
+			Int64("start", rng.start).Int64("end", rng.end).
+			Msg("Failed to stream range from cache")
+		// Headers already sent, can't return error to client
+		return err
+	}
+
+	metrics.RecordRangeFromCacheHit()
+	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	return nil
+}
+
+// handleRangeWithBackgroundCache handles a Range request on cache miss.
+// It forwards the Range request immediately while triggering a background
+// fetch of the full object for caching (if within size threshold).
+func (s *Service) handleRangeWithBackgroundCache(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key, accessKey, secretKey string,
+	startTime time.Time,
+) error {
+	// Forward the Range request directly to client (low latency)
+	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
+	if err != nil {
+		metrics.RecordRequest("GetObject", "error", time.Since(startTime).Seconds())
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Determine total object size from Content-Range header
+	// Format: "bytes 0-499/1234" where 1234 is total size
+	totalSize := extractTotalSizeFromContentRange(resp.Header.Get("Content-Range"))
+
+	// Trigger background fetch if:
+	// - Response is 206 Partial Content (successful range response)
+	// - Total size is known and within cache threshold
+	// - Cache is enabled
+	// - We have valid credentials for the background fetch
+	if resp.StatusCode == http.StatusPartialContent &&
+		totalSize > 0 &&
+		totalSize <= s.config.Cache.SizeThreshold &&
+		s.cache.IsEnabled() &&
+		accessKey != "" && secretKey != "" {
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey)
+	}
+
+	// Write response headers
+	copyHeaders(w.Header(), resp.Header)
+	w.Header().Set(XCacheHeader, XCacheMiss)
+	w.WriteHeader(resp.StatusCode)
+
+	// Stream Range response body to client
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		log.Warn().Err(err).Msg("Failed to copy range response body")
+		return err
+	}
+
+	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	return nil
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -2,9 +2,6 @@ package proxy
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -56,432 +53,23 @@ func NewService(forwarder *Forwarder, cache *cache.Cache, cfg *config.Config) *S
 	}
 }
 
-// HandleGetObject handles GET requests for objects with cache-first logic.
-// Uses streaming broadcast for request coalescing to reduce upstream load.
-// Supports conditional requests (If-None-Match, If-Modified-Since).
-func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error {
-	start := time.Now()
-	ctx := r.Context()
-	bucket, key := ParseBucketKey(r)
-	noCacheRead := shouldSkipCache(r)
-	rangeHeader := r.Header.Get("Range")
-
-	// Conditional request headers
-	ifNoneMatch := r.Header.Get("If-None-Match")
-	ifModifiedSince := r.Header.Get("If-Modified-Since")
-
-	log.Debug().
-		Str("bucket", bucket).
-		Str("key", key).
-		Bool("no_cache", noCacheRead).
-		Str("if_none_match", ifNoneMatch).
-		Msg("HandleGetObject")
-
-	// 1. Validate credentials FIRST (before any broadcast operations)
-	accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
-	if err != nil {
-		metrics.RecordRequest("GetObject", "auth_error", time.Since(start).Seconds())
-		return err
-	}
-
-	// 2. Check cache (fast path) - now also works for range requests!
-	// For range requests: check if full object is in cache, then serve range from it.
-	if !noCacheRead && s.cache.IsEnabled() {
-		meta, bodyReader, found, cacheErr := s.cache.GetWithMeta(ctx, bucket, key)
-		if cacheErr == nil && found && meta != nil {
-			// Close body reader if we got one (we may serve range instead)
-			if bodyReader != nil {
-				if closer, ok := bodyReader.(io.Closer); ok {
-					defer closer.Close()
-				}
-			}
-
-			// If this is a Range request and we have the full object cached,
-			// serve the range from the cached object
-			if rangeHeader != "" {
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-				return s.serveRangeFromCache(ctx, w, bucket, key, meta, rangeHeader, start)
-			}
-
-			// Check conditional request: If-None-Match
-			if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
-				metrics.RecordCacheHit()
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
-				w.Header().Set(XCacheHeader, XCacheHit)
-				w.WriteHeader(http.StatusNotModified)
-				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-				return nil
-			}
-
-			// Check conditional request: If-Modified-Since
-			if ifModifiedSince != "" {
-				if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
-					if !meta.IsModifiedSince(t) {
-						metrics.RecordCacheHit()
-						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
-						w.Header().Set(XCacheHeader, XCacheHit)
-						w.WriteHeader(http.StatusNotModified)
-						metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-						return nil
-					}
-				}
-			}
-
-			// Serve full response from cache with proper headers
-			metrics.RecordCacheHit()
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata")
-			meta.WriteHeaders(w)
-			w.Header().Set(XCacheHeader, XCacheHit)
-			w.WriteHeader(meta.StatusCode)
-			if bodyReader != nil {
-				if _, copyErr := io.Copy(w, bodyReader); copyErr != nil {
-					log.Warn().Err(copyErr).Msg("Failed to copy cached content to response")
-				}
-			}
-			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-			return nil
-		}
-		metrics.RecordCacheMiss()
-	}
-
-	// 3. Cache miss - handle differently for range requests vs full object requests
-	// Range requests: forward immediately + trigger background cache fetch
-	if rangeHeader != "" {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range request cache miss - forwarding with background cache")
-		return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
-	}
-
-	// Full object request: use broadcast manager for streaming coalescing
-	bcastKey := makeBroadcastKey(bucket, key, rangeHeader)
-	broadcaster, isFirstCaller := s.broadcastManager.GetOrCreate(bcastKey)
-
-	// Determine X-Cache header value for this request
-	var xCache string
-	if !s.cache.IsEnabled() {
-		xCache = XCacheDisabled
-	} else {
-		xCache = XCacheMiss
-	}
-
-	// Update active broadcasts metric
-	metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
-
-	if isFirstCaller {
-		// I'm the fetcher - stream from upstream and broadcast to all listeners
-		metrics.RecordBroadcastFetch()
-		defer func() {
-			s.broadcastManager.Remove(bcastKey)
-			metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
-		}()
-		return s.fetchAndBroadcast(ctx, w, r, bucket, key, accessKey, secretKey, broadcaster, start, xCache)
-	}
-
-	// I'm a listener - try to subscribe
-	listener := broadcaster.Subscribe()
-	if listener == nil {
-		// Streaming already started (no late joiners) - start own fetch
-		metrics.RecordBroadcastFetch()
-		newBroadcaster, _ := s.broadcastManager.GetOrCreate(bcastKey + ":late")
-		defer func() {
-			s.broadcastManager.Remove(bcastKey + ":late")
-			metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
-		}()
-		return s.fetchAndBroadcast(ctx, w, r, bucket, key, accessKey, secretKey, newBroadcaster, start, xCache)
-	}
-
-	// Successfully subscribed - receive streamed chunks
-	metrics.RecordBroadcastShared()
-	return s.receiveFromBroadcastListener(ctx, w, listener, start, xCache)
-}
-
-// makeBroadcastKey creates a unique key for broadcast coalescing.
-func makeBroadcastKey(bucket, key, rangeHeader string) string {
-	if rangeHeader == "" {
-		return bucket + "/" + key
-	}
-	return bucket + "/" + key + ":" + rangeHeader
-}
-
-// fetchAndBroadcast fetches from upstream and broadcasts to all listeners.
-// This is the "fetcher" path - only one goroutine executes this per broadcast.
-// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
-func (s *Service) fetchAndBroadcast(
-	ctx context.Context,
-	w http.ResponseWriter,
-	r *http.Request,
-	bucket, key, accessKey, secretKey string,
-	broadcaster *broadcast.Broadcaster,
-	start time.Time,
-	xCache string,
-) error {
-	// Subscribe ourselves as the first listener
-	listener := broadcaster.Subscribe()
-
-	// Start the upstream fetch in a goroutine
-	go func() {
-		err := s.streamFromUpstream(ctx, r, bucket, key, accessKey, secretKey, broadcaster)
-		broadcaster.Complete(err)
-	}()
-
-	// Receive chunks like any other listener
-	err := s.writeChunksToResponse(ctx, w, listener, xCache)
-
-	status := "success"
-	if err != nil {
-		status = "error"
-	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
-	return err
-}
-
-// streamFromUpstream reads from upstream and broadcasts chunks.
-// Cache is added as a listener and receives chunks via io.Pipe (no buffering).
-func (s *Service) streamFromUpstream(
-	ctx context.Context,
-	r *http.Request,
-	bucket, key, accessKey, secretKey string,
-	broadcaster *broadcast.Broadcaster,
-) error {
-	// Execute upstream request
-	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Determine if we should cache this response
-	shouldCache := resp.StatusCode == http.StatusOK &&
-		s.cache.IsEnabled() &&
-		!s.hasNoCacheHeaders(resp.Header) &&
-		s.isWithinSizeThreshold(resp)
-
-	// Set up cache listener if caching (streams directly to cache via pipe)
-	var cachePipeWriter *io.PipeWriter
-	var cacheErrCh chan error
-
-	if shouldCache {
-		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster)
-	}
-
-	// Set headers for all listeners
-	broadcaster.SetHeaders(resp.StatusCode, resp.Header)
-
-	// Stream body in chunks, broadcasting to all listeners (including cache)
-	chunkSize := s.config.Broadcast.ChunkSize
-	if chunkSize <= 0 {
-		chunkSize = broadcast.DefaultChunkSize
-	}
-	buf := make([]byte, chunkSize)
-
-	for {
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			broadcaster.Broadcast(buf[:n])
-		}
-
-		if readErr == io.EOF {
-			break
-		}
-		if readErr != nil {
-			// Error during streaming - the broadcast will signal error to all listeners including cache
-			return readErr
-		}
-
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			// Context canceled - the broadcast will signal error to all listeners
-			return ctx.Err()
-		default:
-		}
-	}
-
-	// Wait briefly for cache write to complete (the goroutine in setupCacheListener handles closing the pipe)
-	// We don't close cachePipeWriter here - the cache listener goroutine closes it when it finishes.
-	if cacheErrCh != nil {
-		// Wait up to 100ms for cache write to complete, otherwise continue
-		select {
-		case cacheWriteErr := <-cacheErrCh:
-			if cacheWriteErr != nil {
-				log.Warn().Err(cacheWriteErr).Str("bucket", bucket).Str("key", key).Msg("Cache write failed")
-			}
-		case <-time.After(100 * time.Millisecond):
-			// Don't block too long waiting for cache - it will complete in background
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache write still in progress, continuing")
-		}
-	}
-	// Ignore unused cachePipeWriter - it's managed by the cache listener goroutine
-	_ = cachePipeWriter
-
-	return nil
-}
-
-// receiveFromBroadcastListener receives chunks from an existing broadcast.
-// This is the "listener" path - waits for fetcher to stream data.
-// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
-func (s *Service) receiveFromBroadcastListener(
-	ctx context.Context,
-	w http.ResponseWriter,
-	listener *broadcast.Listener,
-	start time.Time,
-	xCache string,
-) error {
-	err := s.writeChunksToResponse(ctx, w, listener, xCache)
-
-	status := "success"
-	if err != nil {
-		status = "error"
-	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
-	return err
-}
-
-// writeChunksToResponse writes received chunks to the HTTP response.
-// xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
-func (s *Service) writeChunksToResponse(
-	ctx context.Context,
-	w http.ResponseWriter,
-	listener *broadcast.Listener,
-	xCache string,
-) error {
-	// Wait for headers first
-	status, headers, err := listener.WaitForHeaders(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Write headers to response
-	copyHeaders(w.Header(), headers)
-	w.Header().Set(XCacheHeader, xCache)
-	w.WriteHeader(status)
-
-	// Receive and write chunks
-	for chunk := range listener.Chunks() {
-		if chunk.Err != nil {
-			if chunk.Err == broadcast.ErrSlowConsumer {
-				metrics.RecordBroadcastSlowConsumer()
-			}
-			return chunk.Err
-		}
-
-		if len(chunk.Data) > 0 {
-			if _, writeErr := w.Write(chunk.Data); writeErr != nil {
-				return writeErr
-			}
-			// Flush if ResponseWriter supports it
-			if flusher, ok := w.(http.Flusher); ok {
-				flusher.Flush()
-			}
-		}
-	}
-
-	return nil
-}
-
-// setupCacheListener creates a listener that streams chunks directly to cache via io.Pipe.
-// This avoids buffering the entire response in memory.
-// Stores both metadata (from headers) and body in separate cache entries.
-func (s *Service) setupCacheListener(
-	ctx context.Context,
-	bucket, key string,
-	broadcaster *broadcast.Broadcaster,
-) (*io.PipeWriter, chan error) {
-	listener := broadcaster.Subscribe()
-	if listener == nil {
-		return nil, nil
-	}
-
-	// Create pipe for streaming to cache
-	pipeReader, pipeWriter := io.Pipe()
-	errCh := make(chan error, 1)
-
-	// Start goroutine to consume chunks, build metadata, and write to cache
-	go func() {
-		defer close(errCh)
-
-		// Wait for headers to build metadata
-		statusCode, headers, err := listener.WaitForHeaders(ctx)
-		if err != nil {
-			pipeWriter.CloseWithError(err)
-			errCh <- err
-			return
-		}
-
-		// Build metadata from response headers
-		meta := cache.MetaFromHTTPHeaders(bucket, key, statusCode, headers)
-
-		// Check if still cacheable based on metadata
-		if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
-			pipeWriter.CloseWithError(nil)
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache - not cacheable")
-			return
-		}
-
-		// Start a goroutine to stream chunks to the pipe
-		go func() {
-			for chunk := range listener.Chunks() {
-				if chunk.Err != nil {
-					pipeWriter.CloseWithError(chunk.Err)
-					return
-				}
-				if len(chunk.Data) > 0 {
-					if _, writeErr := pipeWriter.Write(chunk.Data); writeErr != nil {
-						pipeWriter.CloseWithError(writeErr)
-						return
-					}
-				}
-			}
-			pipeWriter.Close()
-		}()
-
-		// Use a detached context for cache writes to avoid cancellation when HTTP request completes.
-		// The cache write should continue even after the client has received the response.
-		cacheCtx, cacheCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cacheCancel()
-
-		// Write to cache with metadata (streaming)
-		ttl := int(s.config.Cache.TTL.Seconds())
-		cacheErr := s.cache.PutWithMetaStream(cacheCtx, bucket, key, meta, pipeReader, ttl)
-		if cacheErr != nil {
-			log.Debug().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write with metadata failed")
-		}
-		errCh <- cacheErr
-	}()
-
-	return pipeWriter, errCh
-}
-
-// hasNoCacheHeaders checks if response has no-cache directives.
-func (s *Service) hasNoCacheHeaders(headers http.Header) bool {
-	cc := headers.Get("Cache-Control")
-	return strings.Contains(cc, "no-store") || strings.Contains(cc, "private")
-}
-
-// isWithinSizeThreshold checks if response is within cache size threshold.
-// Uses Content-Length header if available.
-func (s *Service) isWithinSizeThreshold(resp *http.Response) bool {
-	if resp.ContentLength > 0 {
-		return resp.ContentLength <= s.config.Cache.SizeThreshold
-	}
-	// Unknown size - allow caching (will be handled by cache layer)
-	return true
-}
-
 // HandlePutObject handles PUT requests for objects.
+// Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
 	bucket, key := ParseBucketKey(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandlePutObject")
 
-	// Forward to Tigris
-	err := s.forwarder.Forward(r.Context(), w, r)
-
-	// Invalidate cache on success
-	if err == nil && s.cache.IsEnabled() {
+	// Invalidate cache BEFORE forwarding to ensure consistency
+	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
+	if s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 		metrics.RecordCacheOperation("delete", "success")
 	}
+
+	// Forward to Tigris
+	err := s.forwarder.Forward(r.Context(), w, r)
 
 	status := "success"
 	if err != nil {
@@ -493,19 +81,22 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 }
 
 // HandleDeleteObject handles DELETE requests for objects.
+// Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
 	bucket, key := ParseBucketKey(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleDeleteObject")
 
-	err := s.forwarder.Forward(r.Context(), w, r)
-
-	// Invalidate cache on success
-	if err == nil && s.cache.IsEnabled() {
+	// Invalidate cache BEFORE forwarding to ensure consistency
+	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
+	if s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 		metrics.RecordCacheOperation("delete", "success")
 	}
+
+	// Forward to upstream
+	err := s.forwarder.Forward(r.Context(), w, r)
 
 	status := "success"
 	if err != nil {
@@ -559,19 +150,20 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 }
 
 // HandleCopyObject handles copy object requests.
+// Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error {
 	bucket, key := ParseBucketKey(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleCopyObject")
 
-	err := s.forwarder.Forward(r.Context(), w, r)
-
-	// Invalidate cache for destination object on success
-	if err == nil && s.cache.IsEnabled() {
+	// Invalidate cache for destination object BEFORE forwarding to ensure consistency
+	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
+	if s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
-	return err
+	// Forward to upstream
+	return s.forwarder.Forward(r.Context(), w, r)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.
@@ -580,89 +172,17 @@ func (s *Service) HandlePassthrough(w http.ResponseWriter, r *http.Request) erro
 	return s.forwarder.Forward(r.Context(), w, r)
 }
 
-// ============================================================================
-// Range Request Caching Support
-// ============================================================================
-
-// byteRange represents a parsed byte range.
-type byteRange struct {
-	start int64
-	end   int64
-}
-
-// parseRangeHeader parses HTTP Range header.
-// Returns list of ranges or error if invalid.
-// totalSize is the size of the full object.
-func parseRangeHeader(rangeHeader string, totalSize int64) ([]byteRange, error) {
-	if !strings.HasPrefix(rangeHeader, "bytes=") {
-		return nil, errors.New("invalid range header: missing 'bytes=' prefix")
+// ParseBucketKey extracts bucket and key from request path.
+func ParseBucketKey(r *http.Request) (bucket, key string) {
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) >= 1 {
+		bucket = parts[0]
 	}
-
-	rangeSpec := strings.TrimPrefix(rangeHeader, "bytes=")
-	parts := strings.Split(rangeSpec, ",")
-
-	var ranges []byteRange
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-
-		dashIdx := strings.Index(part, "-")
-		if dashIdx == -1 {
-			return nil, errors.New("invalid range: missing dash")
-		}
-
-		startStr := part[:dashIdx]
-		endStr := part[dashIdx+1:]
-
-		var start, end int64
-
-		if startStr == "" {
-			// Suffix range: "-500" means last 500 bytes
-			suffixLen, err := strconv.ParseInt(endStr, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid suffix range: %v", err)
-			}
-			start = totalSize - suffixLen
-			if start < 0 {
-				start = 0
-			}
-			end = totalSize - 1
-		} else {
-			// Normal range: "0-499" or "500-"
-			var err error
-			start, err = strconv.ParseInt(startStr, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid range start: %v", err)
-			}
-
-			if endStr == "" {
-				// Open-ended: "500-" means from 500 to end
-				end = totalSize - 1
-			} else {
-				end, err = strconv.ParseInt(endStr, 10, 64)
-				if err != nil {
-					return nil, fmt.Errorf("invalid range end: %v", err)
-				}
-			}
-		}
-
-		// Validate range
-		if start < 0 || start >= totalSize {
-			return nil, errors.New("range start out of bounds")
-		}
-		if end >= totalSize {
-			end = totalSize - 1
-		}
-		if start > end {
-			return nil, errors.New("invalid range: start > end")
-		}
-
-		ranges = append(ranges, byteRange{start: start, end: end})
+	if len(parts) >= 2 {
+		key = parts[1]
 	}
-
-	return ranges, nil
+	return
 }
 
 // extractTotalSizeFromContentRange extracts total size from Content-Range header.
@@ -690,258 +210,4 @@ func extractTotalSizeFromContentRange(contentRange string) int64 {
 		return 0
 	}
 	return total
-}
-
-// serveRangeFromCache serves a Range request from the cached full object.
-func (s *Service) serveRangeFromCache(
-	ctx context.Context,
-	w http.ResponseWriter,
-	bucket, key string,
-	meta *cache.CachedObjectMeta,
-	rangeHeader string,
-	startTime time.Time,
-) error {
-	// Parse Range header
-	ranges, err := parseRangeHeader(rangeHeader, meta.ContentLength)
-	if err != nil || len(ranges) == 0 {
-		// Invalid range - return 416 Range Not Satisfiable
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
-		w.Header().Set(XCacheHeader, XCacheHit)
-		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
-	}
-
-	// Only support single range (multi-range is complex and rare)
-	if len(ranges) > 1 {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Multi-range not supported from cache")
-		// For multi-range, return 416 - we don't support it
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
-		w.Header().Set(XCacheHeader, XCacheHit)
-		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
-	}
-
-	rng := ranges[0]
-	contentLength := rng.end - rng.start + 1
-
-	// Set response headers
-	if meta.ContentType != "" {
-		w.Header().Set("Content-Type", meta.ContentType)
-	}
-	w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, meta.ContentLength))
-	if meta.ETag != "" {
-		w.Header().Set("ETag", meta.ETag)
-	}
-	w.Header().Set("Accept-Ranges", "bytes")
-	w.Header().Set(XCacheHeader, XCacheHit)
-	w.WriteHeader(http.StatusPartialContent)
-
-	// Stream range from cache
-	if err := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, w); err != nil {
-		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).
-			Int64("start", rng.start).Int64("end", rng.end).
-			Msg("Failed to stream range from cache")
-		// Headers already sent, can't return error to client
-		return err
-	}
-
-	metrics.RecordRangeFromCacheHit()
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
-	return nil
-}
-
-// handleRangeWithBackgroundCache handles a Range request on cache miss.
-// It forwards the Range request immediately while triggering a background
-// fetch of the full object for caching (if within size threshold).
-func (s *Service) handleRangeWithBackgroundCache(
-	ctx context.Context,
-	w http.ResponseWriter,
-	r *http.Request,
-	bucket, key, accessKey, secretKey string,
-	startTime time.Time,
-) error {
-	// Forward the Range request directly to client (low latency)
-	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
-	if err != nil {
-		metrics.RecordRequest("GetObject", "error", time.Since(startTime).Seconds())
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Determine total object size from Content-Range header
-	// Format: "bytes 0-499/1234" where 1234 is total size
-	totalSize := extractTotalSizeFromContentRange(resp.Header.Get("Content-Range"))
-
-	// Trigger background fetch if:
-	// - Response is 206 Partial Content (successful range response)
-	// - Total size is known and within cache threshold
-	// - Cache is enabled
-	// - We have valid credentials for the background fetch
-	if resp.StatusCode == http.StatusPartialContent &&
-		totalSize > 0 &&
-		totalSize <= s.config.Cache.SizeThreshold &&
-		s.cache.IsEnabled() &&
-		accessKey != "" && secretKey != "" {
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey)
-	}
-
-	// Write response headers
-	copyHeaders(w.Header(), resp.Header)
-	w.Header().Set(XCacheHeader, XCacheMiss)
-	w.WriteHeader(resp.StatusCode)
-
-	// Stream Range response body to client
-	if _, err := io.Copy(w, resp.Body); err != nil {
-		log.Warn().Err(err).Msg("Failed to copy range response body")
-		return err
-	}
-
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
-	return nil
-}
-
-// triggerBackgroundCacheFetch starts a background fetch of the full object.
-// Uses broadcast manager to coalesce multiple triggers for the same object.
-func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string) {
-	bcastKey := "bg:" + bucket + "/" + key
-
-	broadcaster, isFirst := s.backgroundFetchManager.GetOrCreate(bcastKey)
-	if !isFirst {
-		// Another background fetch is already in progress
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background fetch already in progress, coalescing")
-		return
-	}
-
-	// I'm the first - start the background fetch
-	metrics.RecordBackgroundFetchTriggered()
-	metrics.SetActiveBackgroundFetches(s.backgroundFetchManager.ActiveCount())
-
-	go func() {
-		defer func() {
-			s.backgroundFetchManager.Remove(bcastKey)
-			metrics.SetActiveBackgroundFetches(s.backgroundFetchManager.ActiveCount())
-		}()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-
-		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, broadcaster)
-		broadcaster.Complete(err)
-
-		if err != nil {
-			log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background cache fetch failed")
-			metrics.RecordBackgroundFetchFailed()
-		} else {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background cache fetch completed")
-			metrics.RecordBackgroundFetchSucceeded()
-		}
-	}()
-}
-
-// fetchFullObjectToCache fetches the full object and caches it.
-// This makes a full-object request (no Range header) and streams directly to cache.
-func (s *Service) fetchFullObjectToCache(
-	ctx context.Context,
-	bucket, key, accessKey, secretKey string,
-	broadcaster *broadcast.Broadcaster,
-) error {
-	// Execute full object request (no Range header)
-	resp, err := s.forwarder.DoFullObjectRequest(ctx, bucket, key, accessKey, secretKey)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d for background fetch", resp.StatusCode)
-	}
-
-	// Check if response is within cache threshold
-	if resp.ContentLength > 0 && resp.ContentLength > s.config.Cache.SizeThreshold {
-		log.Debug().
-			Str("bucket", bucket).
-			Str("key", key).
-			Int64("size", resp.ContentLength).
-			Int64("threshold", s.config.Cache.SizeThreshold).
-			Msg("Skipping background cache - object too large")
-		return nil
-	}
-
-	// Check for no-cache headers
-	if s.hasNoCacheHeaders(resp.Header) {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping background cache - no-cache headers")
-		return nil
-	}
-
-	// Set up cache listener (streams to cache via pipe)
-	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster)
-
-	// Set headers for the cache listener
-	broadcaster.SetHeaders(resp.StatusCode, resp.Header)
-
-	// Stream body to broadcaster (which includes cache listener)
-	chunkSize := s.config.Broadcast.ChunkSize
-	if chunkSize <= 0 {
-		chunkSize = broadcast.DefaultChunkSize
-	}
-	buf := make([]byte, chunkSize)
-
-	for {
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			broadcaster.Broadcast(buf[:n])
-		}
-
-		if readErr == io.EOF {
-			break
-		}
-		if readErr != nil {
-			return readErr
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-	}
-
-	// Wait for cache write to complete
-	if cacheErrCh != nil {
-		select {
-		case err := <-cacheErrCh:
-			if err != nil {
-				log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background cache write failed")
-			}
-			return err
-		case <-time.After(30 * time.Second):
-			log.Warn().Str("bucket", bucket).Str("key", key).Msg("Background cache write timeout")
-			return errors.New("cache write timeout")
-		}
-	}
-
-	_ = cachePipeWriter // managed by cache listener goroutine
-	return nil
-}
-
-// ParseBucketKey extracts bucket and key from request path.
-func ParseBucketKey(r *http.Request) (bucket, key string) {
-	path := strings.TrimPrefix(r.URL.Path, "/")
-	parts := strings.SplitN(path, "/", 2)
-	if len(parts) >= 1 {
-		bucket = parts[0]
-	}
-	if len(parts) >= 2 {
-		key = parts[1]
-	}
-	return
-}
-
-// shouldSkipCache checks if cache should be skipped for this request.
-func shouldSkipCache(r *http.Request) bool {
-	cc := r.Header.Get("Cache-Control")
-	return strings.Contains(cc, "no-cache") || strings.Contains(cc, "max-age=0")
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -172,6 +172,47 @@ func (s *Service) HandlePassthrough(w http.ResponseWriter, r *http.Request) erro
 	return s.forwarder.Forward(r.Context(), w, r)
 }
 
+// HandleCompleteMultipartUpload handles CompleteMultipartUpload with idempotency caching.
+// This caches successful completion responses in ocache to support idempotent calls,
+// matching tigris-os behavior where a second CompleteMultipartUpload call returns success.
+func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.Request) error {
+	bucket, key := ParseBucketKey(r)
+	uploadId := r.URL.Query().Get("uploadId")
+	ctx := r.Context()
+
+	log.Debug().Str("bucket", bucket).Str("key", key).Str("uploadId", uploadId).Msg("HandleCompleteMultipartUpload")
+
+	// Check ocache first for idempotent completion (works across TAG pods)
+	if s.cache.IsEnabled() {
+		entry, found, err := s.cache.GetCompletion(ctx, bucket, key, uploadId)
+		if err == nil && found {
+			log.Debug().Str("uploadId", uploadId).Msg("CompleteMultipartUpload cache hit - returning cached response")
+			for k, v := range entry.Headers {
+				w.Header().Set(k, v)
+			}
+			w.WriteHeader(entry.StatusCode)
+			_, _ = w.Write(entry.Body)
+			return nil
+		}
+	}
+
+	// Forward to upstream with response capture
+	capture, err := s.forwarder.ForwardWithCapture(ctx, w, r)
+	if err != nil {
+		return err
+	}
+
+	// Cache successful completions (2xx status codes) in ocache
+	if capture.StatusCode >= 200 && capture.StatusCode < 300 {
+		if cacheErr := s.cache.PutCompletion(ctx, bucket, key, uploadId, capture.StatusCode, capture.Headers, capture.Body); cacheErr != nil {
+			log.Debug().Err(cacheErr).Msg("Failed to cache completion response")
+			// Don't fail the request if caching fails
+		}
+	}
+
+	return nil
+}
+
 // ParseBucketKey extracts bucket and key from request path.
 func ParseBucketKey(r *http.Request) (bucket, key string) {
 	path := strings.TrimPrefix(r.URL.Path, "/")
@@ -210,4 +251,9 @@ func extractTotalSizeFromContentRange(contentRange string) int64 {
 		return 0
 	}
 	return total
+}
+
+// GetRegion returns the configured upstream region.
+func (s *Service) GetRegion() string {
+	return s.config.Upstream.Region
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -203,7 +203,8 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 	}
 
 	// Cache successful completions (2xx status codes) in ocache
-	if capture.StatusCode >= 200 && capture.StatusCode < 300 {
+	// Only cache if the body was fully captured to avoid storing corrupted responses
+	if capture.StatusCode >= 200 && capture.StatusCode < 300 && capture.Complete {
 		if cacheErr := s.cache.PutCompletion(ctx, bucket, key, uploadId, capture.StatusCode, capture.Headers, capture.Body); cacheErr != nil {
 			log.Debug().Err(cacheErr).Msg("Failed to cache completion response")
 			// Don't fail the request if caching fails

--- a/proxy/service_test.go
+++ b/proxy/service_test.go
@@ -200,3 +200,42 @@ func TestCopyHeaders(t *testing.T) {
 		t.Errorf("Content-Length = %q, want %q", dst.Get("Content-Length"), "100")
 	}
 }
+
+func TestCopyHeaders_MetadataLowercase(t *testing.T) {
+	// Create headers using Set() to ensure proper canonical form
+	// This simulates how Go's HTTP library stores headers from real responses
+	src := http.Header{}
+	src.Set("X-Amz-Meta-Custom-Key", "custom-value")
+	src.Set("X-Amz-Meta-Another", "another-value")
+	src.Set("Content-Type", "application/octet-stream")
+	src.Set("ETag", `"abc123"`)
+
+	dst := http.Header{}
+	copyHeaders(dst, src)
+
+	// Metadata headers should be stored with lowercase keys
+	if _, ok := dst["x-amz-meta-custom-key"]; !ok {
+		t.Error("x-amz-meta-custom-key should be stored with lowercase key")
+	}
+	// Check canonical key is NOT used (it would be "X-Amz-Meta-Custom-Key")
+	if _, ok := dst["X-Amz-Meta-Custom-Key"]; ok {
+		t.Error("X-Amz-Meta-Custom-Key should NOT be stored with canonical key")
+	}
+
+	if _, ok := dst["x-amz-meta-another"]; !ok {
+		t.Error("x-amz-meta-another should be stored with lowercase key")
+	}
+
+	// Non-metadata headers should retain canonical form and be accessible via Get
+	if dst.Get("Content-Type") != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want %q", dst.Get("Content-Type"), "application/octet-stream")
+	}
+	if dst.Get("ETag") != `"abc123"` {
+		t.Errorf("ETag = %q, want %q", dst.Get("ETag"), `"abc123"`)
+	}
+
+	// Verify metadata values are correct
+	if dst["x-amz-meta-custom-key"][0] != "custom-value" {
+		t.Errorf("x-amz-meta-custom-key value = %q, want %q", dst["x-amz-meta-custom-key"][0], "custom-value")
+	}
+}

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -36,7 +36,6 @@ func TestCache_HitWithMetadata(t *testing.T) {
 	assert.False(t, env.IsCached(bucket, key), "Object should not be cached before first GET")
 
 	// First GET - should be cache miss, goes to upstream
-	env.ResetUpstreamRequestCount()
 	resp1, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -46,7 +45,7 @@ func TestCache_HitWithMetadata(t *testing.T) {
 	resp1.Body.Close()
 
 	assert.Equal(t, content, body1, "First GET should return correct content")
-	assert.Equal(t, int32(1), env.GetUpstreamRequestCount(), "First GET should hit upstream (cache miss)")
+	env.AssertXCacheMiss(t) // First GET should be cache miss
 	assert.NotEmpty(t, aws.ToString(resp1.ETag), "Response should have ETag")
 
 	// Save the ETag for comparison
@@ -59,7 +58,6 @@ func TestCache_HitWithMetadata(t *testing.T) {
 	assert.True(t, env.IsCached(bucket, key), "Object should be cached after first GET")
 
 	// Second GET - should be cache hit, no upstream request
-	env.ResetUpstreamRequestCount()
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -69,7 +67,7 @@ func TestCache_HitWithMetadata(t *testing.T) {
 	resp2.Body.Close()
 
 	assert.Equal(t, content, body2, "Second GET should return same content")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Second GET should NOT hit upstream (cache hit)")
+	env.AssertXCacheHit(t) // Second GET should be cache hit
 	assert.Equal(t, etag1, aws.ToString(resp2.ETag), "Cache hit should return same ETag")
 }
 
@@ -99,8 +97,8 @@ func TestCache_IfNoneMatch304(t *testing.T) {
 	etag := aws.ToString(resp1.ETag)
 	require.NotEmpty(t, etag, "ETag should not be empty")
 
-	// Reset counter for conditional request
-	env.ResetUpstreamRequestCount()
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
 
 	// GET with If-None-Match matching the ETag - should return 304
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -115,8 +113,8 @@ func TestCache_IfNoneMatch304(t *testing.T) {
 		errStr := err.Error()
 		assert.True(t, strings.Contains(errStr, "304") || strings.Contains(errStr, "NotModified"),
 			"Should get 304 Not Modified, got: %v", err)
-		// Should be served from cache without hitting upstream
-		assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "304 response should not hit upstream")
+		// Should be served from cache
+		env.AssertXCacheHit(t) // 304 response should be served from cache
 		return
 	}
 
@@ -157,8 +155,8 @@ func TestCache_IfModifiedSince304(t *testing.T) {
 		lastModified = time.Now()
 	}
 
-	// Reset counter for conditional request
-	env.ResetUpstreamRequestCount()
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
 
 	// Use a time in the future to ensure 304 response
 	futureTime := lastModified.Add(1 * time.Hour)
@@ -175,7 +173,7 @@ func TestCache_IfModifiedSince304(t *testing.T) {
 		errStr := err.Error()
 		assert.True(t, strings.Contains(errStr, "304") || strings.Contains(errStr, "NotModified"),
 			"Should get 304 Not Modified, got: %v", err)
-		assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "304 response should not hit upstream")
+		env.AssertXCacheHit(t) // 304 response should be served from cache
 		return
 	}
 
@@ -210,8 +208,8 @@ func TestCache_HeadFromCache(t *testing.T) {
 	etag := aws.ToString(resp1.ETag)
 	contentLength := aws.ToInt64(resp1.ContentLength)
 
-	// Reset counter
-	env.ResetUpstreamRequestCount()
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
 
 	// HEAD request - should be served from cache
 	resp2, err := client.HeadObject(ctx, &s3.HeadObjectInput{
@@ -220,7 +218,7 @@ func TestCache_HeadFromCache(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "HEAD should be served from cache")
+	env.AssertXCacheHit(t) // HEAD should be served from cache
 	assert.Equal(t, etag, aws.ToString(resp2.ETag), "HEAD should return same ETag as GET")
 	assert.Equal(t, contentLength, aws.ToInt64(resp2.ContentLength), "HEAD should return same Content-Length")
 }
@@ -249,6 +247,7 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 	body1, _ := io.ReadAll(resp1.Body)
 	resp1.Body.Close()
 	assert.Equal(t, originalContent, body1)
+	env.AssertXCacheMiss(t) // First GET should be cache miss
 
 	// Wait for async cache write to complete
 	time.Sleep(100 * time.Millisecond)
@@ -267,9 +266,6 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 	// Verify cache is invalidated (object removed from cache)
 	assert.False(t, env.IsCached(bucket, key), "Object should NOT be in cache after PUT (cache invalidated)")
 
-	// Reset counter
-	env.ResetUpstreamRequestCount()
-
 	// GET should return new content (cache was invalidated)
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
@@ -280,7 +276,7 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 	resp2.Body.Close()
 
 	assert.Equal(t, newContent, body2, "GET after PUT should return new content")
-	assert.Equal(t, int32(1), env.GetUpstreamRequestCount(), "GET after PUT should hit upstream (cache invalidated)")
+	env.AssertXCacheMiss(t) // GET after PUT should be cache miss (cache invalidated)
 
 	// Wait for async cache write to complete
 	time.Sleep(100 * time.Millisecond)
@@ -311,6 +307,7 @@ func TestCache_InvalidateOnDelete(t *testing.T) {
 	require.NoError(t, err)
 	io.Copy(io.Discard, resp1.Body)
 	resp1.Body.Close()
+	env.AssertXCacheMiss(t) // First GET should be cache miss
 
 	// Wait for async cache write to complete
 	time.Sleep(100 * time.Millisecond)
@@ -318,8 +315,7 @@ func TestCache_InvalidateOnDelete(t *testing.T) {
 	// Verify content is in cache (metadata exists)
 	assert.True(t, env.IsCached(bucket, key), "Object should be cached after first GET")
 
-	// Verify it's cached (via upstream request count)
-	env.ResetUpstreamRequestCount()
+	// Verify it's cached (via X-Cache status)
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -327,7 +323,7 @@ func TestCache_InvalidateOnDelete(t *testing.T) {
 	require.NoError(t, err)
 	io.Copy(io.Discard, resp2.Body)
 	resp2.Body.Close()
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Should be cache hit before delete")
+	env.AssertXCacheHit(t) // Should be cache hit before delete
 
 	// DELETE the object - should invalidate cache
 	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
@@ -371,9 +367,12 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 	require.NoError(t, err)
 	io.Copy(io.Discard, resp1.Body)
 	resp1.Body.Close()
+	env.AssertXCacheMiss(t) // First GET should be cache miss
+
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
 
 	// Verify full object is cached
-	env.ResetUpstreamRequestCount()
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -381,10 +380,7 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 	require.NoError(t, err)
 	io.Copy(io.Discard, resp2.Body)
 	resp2.Body.Close()
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Full GET should be cache hit")
-
-	// Reset counter
-	env.ResetUpstreamRequestCount()
+	env.AssertXCacheHit(t) // Full GET should be cache hit
 
 	// Range request - should be served from cache (full object is cached)
 	resp3, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -397,10 +393,9 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 	resp3.Body.Close()
 
 	assert.Equal(t, []byte("0123456789"), body3, "Range request should return correct bytes")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Range request should be served from cache when full object is cached")
+	env.AssertXCacheHit(t) // Range request should be served from cache when full object is cached
 
 	// Test another range from same cached object
-	env.ResetUpstreamRequestCount()
 	resp4, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -411,7 +406,7 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 	resp4.Body.Close()
 
 	assert.Equal(t, []byte("ABCDEFGHIJ"), body4, "Second range request should return correct bytes")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Second range request should also be served from cache")
+	env.AssertXCacheHit(t) // Second range request should also be served from cache
 }
 
 // TestCache_RangeSingleByteAtZero verifies the byte-0 quirk handling.
@@ -439,12 +434,12 @@ func TestCache_RangeSingleByteAtZero(t *testing.T) {
 	resp1.Body.Close()
 
 	assert.Equal(t, content, body1, "Full GET should return complete content")
+	env.AssertXCacheMiss(t) // First GET should be cache miss
 
 	// Wait for cache to be populated
 	time.Sleep(100 * time.Millisecond)
 
 	// Second: Full GET to verify cache hit
-	env.ResetUpstreamRequestCount()
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -453,11 +448,10 @@ func TestCache_RangeSingleByteAtZero(t *testing.T) {
 	io.ReadAll(resp2.Body)
 	resp2.Body.Close()
 
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Second full GET should be cache hit")
+	env.AssertXCacheHit(t) // Second full GET should be cache hit
 
 	// Third: Range request for single byte at position 0 (bytes=0-0)
 	// This tests the ocache byte-0 quirk handling
-	env.ResetUpstreamRequestCount()
 	resp3, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -468,10 +462,9 @@ func TestCache_RangeSingleByteAtZero(t *testing.T) {
 	resp3.Body.Close()
 
 	assert.Equal(t, []byte("A"), body3, "Range bytes=0-0 should return single byte 'A'")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Range request should be served from cache")
+	env.AssertXCacheHit(t) // Range request should be served from cache
 
 	// Fourth: Test other single-byte ranges work too (not just byte 0)
-	env.ResetUpstreamRequestCount()
 	resp4, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -482,10 +475,9 @@ func TestCache_RangeSingleByteAtZero(t *testing.T) {
 	resp4.Body.Close()
 
 	assert.Equal(t, []byte("B"), body4, "Range bytes=1-1 should return single byte 'B'")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Range request should be served from cache")
+	env.AssertXCacheHit(t) // Range request should be served from cache
 
 	// Fifth: Test last byte
-	env.ResetUpstreamRequestCount()
 	resp5, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -496,7 +488,7 @@ func TestCache_RangeSingleByteAtZero(t *testing.T) {
 	resp5.Body.Close()
 
 	assert.Equal(t, []byte("Z"), body5, "Range bytes=25-25 should return single byte 'Z'")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Range request should be served from cache")
+	env.AssertXCacheHit(t) // Range request should be served from cache
 }
 
 // TestCache_LargeObjectStreaming verifies large objects are handled correctly with streaming.
@@ -519,7 +511,6 @@ func TestCache_LargeObjectStreaming(t *testing.T) {
 	ctx := context.Background()
 
 	// First GET - cache miss, fetches from upstream
-	env.ResetUpstreamRequestCount()
 	resp1, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -530,10 +521,12 @@ func TestCache_LargeObjectStreaming(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, content, body1, "First GET should return correct content")
-	assert.Equal(t, int32(1), env.GetUpstreamRequestCount(), "First GET should hit upstream")
+	env.AssertXCacheMiss(t) // First GET should be cache miss
+
+	// Wait for cache to be populated (large objects may take longer)
+	time.Sleep(200 * time.Millisecond)
 
 	// Second GET - cache hit
-	env.ResetUpstreamRequestCount()
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -544,7 +537,7 @@ func TestCache_LargeObjectStreaming(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, content, body2, "Second GET should return same content")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Second GET should be cache hit")
+	env.AssertXCacheHit(t) // Second GET should be cache hit
 }
 
 // TestCache_MultipleObjectsIndependent verifies different objects are cached independently.
@@ -577,11 +570,13 @@ func TestCache_MultipleObjectsIndependent(t *testing.T) {
 		require.NoError(t, err)
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
+		env.AssertXCacheMiss(t) // First GET of each object should be cache miss
 	}
 
-	// Reset and verify all are cached
-	env.ResetUpstreamRequestCount()
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
 
+	// Verify all are cached
 	for key, expectedContent := range objects {
 		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: aws.String(bucket),
@@ -592,9 +587,8 @@ func TestCache_MultipleObjectsIndependent(t *testing.T) {
 		resp.Body.Close()
 
 		assert.Equal(t, expectedContent, body, "Object %s should have correct content", key)
+		env.AssertXCacheHit(t) // Second GET of each object should be cache hit
 	}
-
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "All GETs should be cache hits")
 }
 
 // TestCache_CacheHitHeaders verifies cache hits include correct headers including X-Cache.
@@ -630,7 +624,6 @@ func TestCache_CacheHitHeaders(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Second request - cache hit
-	env.ResetUpstreamRequestCount()
 	resp2, err := env.DoSignedRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
 	require.NoError(t, err)
 	defer resp2.Body.Close()
@@ -638,7 +631,7 @@ func TestCache_CacheHitHeaders(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 	assert.Equal(t, etag, resp2.Header.Get("ETag"), "Cache hit should have same ETag")
 	assert.Equal(t, "HIT", resp2.Header.Get("X-Cache"), "Second request should be cache HIT")
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "Should be cache hit")
+	env.AssertXCacheHit(t) // Should be cache hit
 }
 
 // TestCache_XCacheForRangeRequests verifies X-Cache headers for range requests.
@@ -877,8 +870,7 @@ func TestCache_InvalidateOnDeleteObjects(t *testing.T) {
 		assert.True(t, env.IsCached(bucket, key), "Object %s should be cached after GET", key)
 	}
 
-	// Verify all are cached (via upstream request count)
-	env.ResetUpstreamRequestCount()
+	// Verify all are cached (via X-Cache status)
 	for _, key := range keys {
 		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: aws.String(bucket),
@@ -887,8 +879,8 @@ func TestCache_InvalidateOnDeleteObjects(t *testing.T) {
 		require.NoError(t, err)
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
+		env.AssertXCacheHit(t) // All GETs should be cache hits before delete
 	}
-	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "All GETs should be cache hits before delete")
 
 	// Build delete request
 	objectIds := make([]types.ObjectIdentifier, len(keys))

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,9 @@ func TestCache_HitWithMetadata(t *testing.T) {
 	client := env.GetS3Client()
 	ctx := context.Background()
 
+	// Verify object is NOT in cache initially
+	assert.False(t, env.IsCached(bucket, key), "Object should not be cached before first GET")
+
 	// First GET - should be cache miss, goes to upstream
 	env.ResetUpstreamRequestCount()
 	resp1, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -47,6 +51,12 @@ func TestCache_HitWithMetadata(t *testing.T) {
 
 	// Save the ETag for comparison
 	etag1 := aws.ToString(resp1.ETag)
+
+	// Wait for async cache write to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify object IS now in cache (metadata exists)
+	assert.True(t, env.IsCached(bucket, key), "Object should be cached after first GET")
 
 	// Second GET - should be cache hit, no upstream request
 	env.ResetUpstreamRequestCount()
@@ -240,6 +250,12 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 	resp1.Body.Close()
 	assert.Equal(t, originalContent, body1)
 
+	// Wait for async cache write to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify original content is in cache (metadata exists)
+	assert.True(t, env.IsCached(bucket, key), "Object should be cached after first GET")
+
 	// PUT new content - should invalidate cache
 	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
@@ -247,6 +263,9 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 		Body:   bytes.NewReader(newContent),
 	})
 	require.NoError(t, err)
+
+	// Verify cache is invalidated (object removed from cache)
+	assert.False(t, env.IsCached(bucket, key), "Object should NOT be in cache after PUT (cache invalidated)")
 
 	// Reset counter
 	env.ResetUpstreamRequestCount()
@@ -262,6 +281,12 @@ func TestCache_InvalidateOnPut(t *testing.T) {
 
 	assert.Equal(t, newContent, body2, "GET after PUT should return new content")
 	assert.Equal(t, int32(1), env.GetUpstreamRequestCount(), "GET after PUT should hit upstream (cache invalidated)")
+
+	// Wait for async cache write to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify new content is now cached (metadata exists)
+	assert.True(t, env.IsCached(bucket, key), "Object should be cached again after GET")
 }
 
 // TestCache_InvalidateOnDelete verifies DELETE invalidates the cache.
@@ -287,7 +312,13 @@ func TestCache_InvalidateOnDelete(t *testing.T) {
 	io.Copy(io.Discard, resp1.Body)
 	resp1.Body.Close()
 
-	// Verify it's cached
+	// Wait for async cache write to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify content is in cache (metadata exists)
+	assert.True(t, env.IsCached(bucket, key), "Object should be cached after first GET")
+
+	// Verify it's cached (via upstream request count)
 	env.ResetUpstreamRequestCount()
 	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
@@ -304,6 +335,9 @@ func TestCache_InvalidateOnDelete(t *testing.T) {
 		Key:    aws.String(key),
 	})
 	require.NoError(t, err)
+
+	// Verify cache is invalidated (object removed from cache)
+	assert.False(t, env.IsCached(bucket, key), "Object should NOT be in cache after DELETE")
 
 	// GET should now return 404
 	_, err = client.GetObject(ctx, &s3.GetObjectInput{
@@ -801,4 +835,92 @@ func TestCache_HeaderPreservation(t *testing.T) {
 
 	t.Logf("Header preservation verified: ETag=%s, Content-Type=%s, Content-Length=%s, Last-Modified=%s",
 		upstreamETag, upstreamContentType, upstreamContentLength, upstreamLastModified)
+}
+
+// TestCache_InvalidateOnDeleteObjects verifies DeleteObjects invalidates cache for all deleted objects.
+func TestCache_InvalidateOnDeleteObjects(t *testing.T) {
+	env := NewTestEnvironmentWithCache()
+	defer env.Close()
+
+	bucket := "cache-test-bucket"
+	keys := []string{"bulk-delete1.txt", "bulk-delete2.txt", "bulk-delete3.txt"}
+
+	// Create objects
+	for _, key := range keys {
+		require.NoError(t, env.PutTestObject(bucket, key, []byte("content for "+key)))
+	}
+
+	client := env.GetS3Client()
+	ctx := context.Background()
+
+	// Verify objects are NOT in cache initially
+	for _, key := range keys {
+		assert.False(t, env.IsCached(bucket, key), "Object %s should not be cached initially", key)
+	}
+
+	// GET all objects to populate cache
+	for _, key := range keys {
+		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		require.NoError(t, err)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify all objects ARE now in cache (metadata exists)
+	for _, key := range keys {
+		assert.True(t, env.IsCached(bucket, key), "Object %s should be cached after GET", key)
+	}
+
+	// Verify all are cached (via upstream request count)
+	env.ResetUpstreamRequestCount()
+	for _, key := range keys {
+		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		require.NoError(t, err)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+	assert.Equal(t, int32(0), env.GetUpstreamRequestCount(), "All GETs should be cache hits before delete")
+
+	// Build delete request
+	objectIds := make([]types.ObjectIdentifier, len(keys))
+	for i, key := range keys {
+		objectIds[i] = types.ObjectIdentifier{Key: aws.String(key)}
+	}
+
+	// DeleteObjects - should invalidate cache for all deleted objects
+	result, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucket),
+		Delete: &types.Delete{
+			Objects: objectIds,
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, len(keys))
+
+	// Verify all objects are removed from cache
+	for _, key := range keys {
+		assert.False(t, env.IsCached(bucket, key), "Object %s should NOT be in cache after DeleteObjects", key)
+	}
+
+	// Verify objects no longer exist in upstream (404 returned)
+	for _, key := range keys {
+		_, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		assert.Error(t, err, "GET after DeleteObjects should return error for %s", key)
+		assert.True(t, strings.Contains(err.Error(), "NoSuchKey") || strings.Contains(err.Error(), "404"),
+			"Error should indicate object not found for %s", key)
+	}
+
+	t.Logf("DeleteObjects cache invalidation verified: %d objects deleted and cache invalidated", len(keys))
 }

--- a/tests/integration/sdk_test.go
+++ b/tests/integration/sdk_test.go
@@ -1351,3 +1351,151 @@ func TestSDK_GetObjectRange_SingleByteAtZero(t *testing.T) {
 
 	t.Logf("Byte-0 quirk verified: single byte at position 0 returned correctly: %q", body2)
 }
+
+// TestSDK_DeleteObjects verifies DeleteObjects (bulk delete) operation with AWS SDK.
+func TestSDK_DeleteObjects(t *testing.T) {
+	env := NewTestEnvironment()
+	defer env.Close()
+
+	bucket := "test-bucket"
+	keys := []string{"delete1.txt", "delete2.txt", "delete3.txt"}
+
+	// Pre-populate test objects
+	for _, key := range keys {
+		if err := env.PutTestObject(bucket, key, []byte("content for "+key)); err != nil {
+			t.Fatalf("Failed to pre-populate test data: %v", err)
+		}
+	}
+
+	client := env.GetS3Client()
+	ctx := context.Background()
+
+	// Build delete request
+	objectIds := make([]types.ObjectIdentifier, len(keys))
+	for i, key := range keys {
+		objectIds[i] = types.ObjectIdentifier{Key: aws.String(key)}
+	}
+
+	// Delete all objects
+	result, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucket),
+		Delete: &types.Delete{
+			Objects: objectIds,
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeleteObjects failed: %v", err)
+	}
+
+	// Verify all objects were deleted
+	if len(result.Deleted) != len(keys) {
+		t.Errorf("Expected %d deleted objects, got %d", len(keys), len(result.Deleted))
+	}
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got %d errors", len(result.Errors))
+	}
+
+	// Verify objects no longer exist
+	for _, key := range keys {
+		_, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err == nil {
+			t.Errorf("Expected error for deleted object %s, got nil", key)
+		}
+	}
+
+	t.Logf("DeleteObjects verified: %d objects deleted successfully", len(result.Deleted))
+}
+
+// TestSDK_DeleteObjects_WithCache verifies DeleteObjects with caching enabled.
+// Objects should be removed from cache after bulk deletion.
+func TestSDK_DeleteObjects_WithCache(t *testing.T) {
+	env := NewTestEnvironmentWithCache()
+	defer env.Close()
+
+	bucket := "test-bucket"
+	keys := []string{"delete1.txt", "delete2.txt", "delete3.txt"}
+
+	// Pre-populate test objects
+	for _, key := range keys {
+		if err := env.PutTestObject(bucket, key, []byte("content for "+key)); err != nil {
+			t.Fatalf("Failed to pre-populate test data: %v", err)
+		}
+	}
+
+	client := env.GetS3Client()
+	ctx := context.Background()
+
+	// GET all objects to populate cache
+	for _, key := range keys {
+		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			t.Fatalf("GetObject for %s failed: %v", key, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Wait for cache to be populated
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify all are cached
+	env.ResetUpstreamRequestCount()
+	for _, key := range keys {
+		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			t.Fatalf("GetObject for %s failed: %v", key, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+	if count := env.GetUpstreamRequestCount(); count != 0 {
+		t.Errorf("Expected 0 upstream requests for cached objects, got %d", count)
+	}
+
+	// Build delete request
+	objectIds := make([]types.ObjectIdentifier, len(keys))
+	for i, key := range keys {
+		objectIds[i] = types.ObjectIdentifier{Key: aws.String(key)}
+	}
+
+	// Delete all objects - should invalidate cache
+	result, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucket),
+		Delete: &types.Delete{
+			Objects: objectIds,
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeleteObjects failed: %v", err)
+	}
+
+	// Verify all objects were deleted
+	if len(result.Deleted) != len(keys) {
+		t.Errorf("Expected %d deleted objects, got %d", len(keys), len(result.Deleted))
+	}
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got %d errors", len(result.Errors))
+	}
+
+	// Verify objects no longer exist (cache should be invalidated)
+	for _, key := range keys {
+		_, err := client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err == nil {
+			t.Errorf("Expected error for deleted object %s, got nil", key)
+		}
+	}
+
+	t.Logf("DeleteObjects with cache verified: %d objects deleted and cache invalidated", len(result.Deleted))
+}

--- a/tests/integration/sdk_test.go
+++ b/tests/integration/sdk_test.go
@@ -846,9 +846,6 @@ func TestSDK_GetObject_WithCache(t *testing.T) {
 	client := env.GetS3Client()
 	ctx := context.Background()
 
-	// Reset counter before first request
-	env.ResetUpstreamRequestCount()
-
 	// First GET - should fetch from upstream and cache
 	result1, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
@@ -864,10 +861,8 @@ func TestSDK_GetObject_WithCache(t *testing.T) {
 		t.Errorf("First request: expected body %q, got %q", objectContent, body1)
 	}
 
-	firstRequestCount := env.GetUpstreamRequestCount()
-	if firstRequestCount != 1 {
-		t.Errorf("Expected 1 upstream request for first GET, got %d", firstRequestCount)
-	}
+	// Verify first request was a cache miss
+	env.AssertXCacheMiss(t)
 
 	// Wait for cache to be populated
 	time.Sleep(200 * time.Millisecond)
@@ -887,13 +882,10 @@ func TestSDK_GetObject_WithCache(t *testing.T) {
 		t.Errorf("Second request: expected body %q, got %q", objectContent, body2)
 	}
 
-	secondRequestCount := env.GetUpstreamRequestCount()
-	// Should still be 1 - second request served from cache
-	if secondRequestCount != 1 {
-		t.Errorf("Expected 1 total upstream request (cache hit), got %d", secondRequestCount)
-	}
+	// Verify second request was a cache hit
+	env.AssertXCacheHit(t)
 
-	t.Logf("Cache behavior verified: %d upstream requests for 2 SDK GetObject calls", secondRequestCount)
+	t.Logf("Cache behavior verified: first request X-Cache: MISS, second request X-Cache: HIT")
 }
 
 // TestSDK_HeadObject_WithCache verifies HeadObject with caching enabled.
@@ -911,8 +903,6 @@ func TestSDK_HeadObject_WithCache(t *testing.T) {
 	client := env.GetS3Client()
 	ctx := context.Background()
 
-	env.ResetUpstreamRequestCount()
-
 	// First GET to populate cache
 	result, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
@@ -924,10 +914,8 @@ func TestSDK_HeadObject_WithCache(t *testing.T) {
 	io.ReadAll(result.Body)
 	result.Body.Close()
 
-	getRequestCount := env.GetUpstreamRequestCount()
-	if getRequestCount != 1 {
-		t.Errorf("Expected 1 upstream request for GET, got %d", getRequestCount)
-	}
+	// Verify GET was a cache miss
+	env.AssertXCacheMiss(t)
 
 	// Wait for cache to be populated
 	time.Sleep(200 * time.Millisecond)
@@ -950,13 +938,10 @@ func TestSDK_HeadObject_WithCache(t *testing.T) {
 		t.Error("Expected ETag to be set from cache")
 	}
 
-	// Should still be 1 - HEAD served from cache
-	headRequestCount := env.GetUpstreamRequestCount()
-	if headRequestCount != 1 {
-		t.Errorf("Expected 1 total upstream request (HEAD from cache), got %d", headRequestCount)
-	}
+	// Verify HEAD was served from cache
+	env.AssertXCacheHit(t)
 
-	t.Logf("HEAD from cache verified: %d upstream requests for GET + HEAD", headRequestCount)
+	t.Logf("HEAD from cache verified: GET X-Cache: MISS, HEAD X-Cache: HIT")
 }
 
 // TestSDK_ContentTypePreservation_WithCache verifies Content-Type is preserved through cache.
@@ -979,8 +964,6 @@ func TestSDK_ContentTypePreservation_WithCache(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		env.ResetUpstreamRequestCount()
-
 		// Put object with specific content type
 		_, err := client.PutObject(ctx, &s3.PutObjectInput{
 			Bucket:      aws.String("test-bucket"),
@@ -1003,6 +986,9 @@ func TestSDK_ContentTypePreservation_WithCache(t *testing.T) {
 		io.ReadAll(getResult.Body)
 		getResult.Body.Close()
 
+		// Verify GET was cache miss
+		env.AssertXCacheMiss(t)
+
 		// Wait for cache
 		time.Sleep(200 * time.Millisecond)
 
@@ -1014,6 +1000,9 @@ func TestSDK_ContentTypePreservation_WithCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("HeadObject failed for %s: %v", tc.key, err)
 		}
+
+		// Verify HEAD was cache hit
+		env.AssertXCacheHit(t)
 
 		if aws.ToString(headResult.ContentType) != tc.contentType {
 			t.Errorf("For %s: expected cached Content-Type %q, got %q",
@@ -1046,8 +1035,6 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 		t.Fatalf("PutObject failed: %v", err)
 	}
 
-	env.ResetUpstreamRequestCount()
-
 	// First GET - populates cache
 	getResult, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
@@ -1059,10 +1046,8 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 	io.ReadAll(getResult.Body)
 	getResult.Body.Close()
 
-	firstCount := env.GetUpstreamRequestCount()
-	if firstCount != 1 {
-		t.Errorf("Expected 1 upstream request for first GET, got %d", firstCount)
-	}
+	// Verify GET was cache miss
+	env.AssertXCacheMiss(t)
 
 	// Wait for cache
 	time.Sleep(200 * time.Millisecond)
@@ -1076,6 +1061,9 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 		t.Fatalf("HeadObject failed: %v", err)
 	}
 
+	// Verify HEAD was served from cache
+	env.AssertXCacheHit(t)
+
 	// Verify metadata is preserved from cache
 	if headResult.Metadata == nil {
 		t.Fatal("Expected metadata to be preserved in cache")
@@ -1086,13 +1074,7 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 		t.Errorf("Expected cached custom metadata 'cached-meta-value', got %q", headResult.Metadata["custom"])
 	}
 
-	// Verify HEAD was served from cache
-	secondCount := env.GetUpstreamRequestCount()
-	if secondCount != 1 {
-		t.Errorf("Expected 1 total upstream request (HEAD from cache), got %d", secondCount)
-	}
-
-	t.Logf("User metadata caching verified: %d upstream requests", secondCount)
+	t.Logf("User metadata caching verified: GET X-Cache: MISS, HEAD X-Cache: HIT")
 }
 
 // TestSDK_CacheInvalidationOnPut verifies that PUT invalidates cached entries
@@ -1117,8 +1099,6 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 		t.Fatalf("Initial PutObject failed: %v", err)
 	}
 
-	env.ResetUpstreamRequestCount()
-
 	// Step 2: GET object - should come from upstream (cache miss)
 	result1, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
@@ -1134,10 +1114,8 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 		t.Errorf("First GET: expected %q, got %q", initialContent, body1)
 	}
 
-	countAfterFirstGet := env.GetUpstreamRequestCount()
-	if countAfterFirstGet != 1 {
-		t.Errorf("Expected 1 upstream request after first GET, got %d", countAfterFirstGet)
-	}
+	// Verify first GET was cache miss
+	env.AssertXCacheMiss(t)
 
 	// Wait for cache to be populated
 	time.Sleep(200 * time.Millisecond)
@@ -1157,11 +1135,9 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 		t.Errorf("Second GET (cache): expected %q, got %q", initialContent, body2)
 	}
 
-	countAfterSecondGet := env.GetUpstreamRequestCount()
-	if countAfterSecondGet != 1 {
-		t.Errorf("Expected 1 upstream request after second GET (cache hit), got %d", countAfterSecondGet)
-	}
-	t.Logf("Cache hit verified: %d upstream requests for 2 GETs", countAfterSecondGet)
+	// Verify second GET was cache hit
+	env.AssertXCacheHit(t)
+	t.Logf("Cache hit verified")
 
 	// Step 4: PUT object with new value - should invalidate cache
 	updatedContent := []byte("updated content version 2")
@@ -1173,9 +1149,6 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update PutObject failed: %v", err)
 	}
-
-	// Reset counter to track requests after invalidation
-	env.ResetUpstreamRequestCount()
 
 	// Step 5: GET object - should come from upstream with new value (cache miss due to invalidation)
 	result3, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -1192,10 +1165,8 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 		t.Errorf("Third GET (after invalidation): expected %q, got %q", updatedContent, body3)
 	}
 
-	countAfterThirdGet := env.GetUpstreamRequestCount()
-	if countAfterThirdGet != 1 {
-		t.Errorf("Expected 1 upstream request after third GET (cache invalidated), got %d", countAfterThirdGet)
-	}
+	// Verify third GET was cache miss (cache invalidated by PUT)
+	env.AssertXCacheMiss(t)
 	t.Logf("Cache invalidation verified: upstream hit with new data")
 
 	// Wait for cache to be populated with new value
@@ -1216,11 +1187,9 @@ func TestSDK_CacheInvalidationOnPut(t *testing.T) {
 		t.Errorf("Fourth GET (new cache): expected %q, got %q", updatedContent, body4)
 	}
 
-	countAfterFourthGet := env.GetUpstreamRequestCount()
-	if countAfterFourthGet != 1 {
-		t.Errorf("Expected 1 upstream request after fourth GET (new cache hit), got %d", countAfterFourthGet)
-	}
-	t.Logf("New cache entry verified: %d upstream requests for 2 GETs after update", countAfterFourthGet)
+	// Verify fourth GET was cache hit
+	env.AssertXCacheHit(t)
+	t.Logf("New cache entry verified")
 }
 
 // TestSDK_GetObjectRange_WithCache verifies Range requests work with caching enabled.
@@ -1240,8 +1209,6 @@ func TestSDK_GetObjectRange_WithCache(t *testing.T) {
 	client := env.GetS3Client()
 	ctx := context.Background()
 
-	env.ResetUpstreamRequestCount()
-
 	// First: Full GET to populate cache
 	result1, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
@@ -1257,17 +1224,13 @@ func TestSDK_GetObjectRange_WithCache(t *testing.T) {
 		t.Errorf("Full GET: expected %q, got %q", fullContent, body1)
 	}
 
-	firstRequestCount := env.GetUpstreamRequestCount()
-	if firstRequestCount != 1 {
-		t.Errorf("Expected 1 upstream request for full GET, got %d", firstRequestCount)
-	}
+	// Verify full GET was cache miss
+	env.AssertXCacheMiss(t)
 
 	// Wait for cache to be populated
 	time.Sleep(200 * time.Millisecond)
 
 	// Second: Range request - should be served from cached full object
-	env.ResetUpstreamRequestCount()
-
 	result2, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -1284,12 +1247,10 @@ func TestSDK_GetObjectRange_WithCache(t *testing.T) {
 		t.Errorf("Range GET: expected %q, got %q", expectedRange, body2)
 	}
 
-	rangeRequestCount := env.GetUpstreamRequestCount()
-	if rangeRequestCount != 0 {
-		t.Errorf("Expected 0 upstream requests for range request (cache hit), got %d", rangeRequestCount)
-	}
+	// Verify range request was served from cache
+	env.AssertXCacheHit(t)
 
-	t.Logf("Range from cache verified: %d upstream requests for range request after full GET cached", rangeRequestCount)
+	t.Logf("Range from cache verified: full GET X-Cache: MISS, range GET X-Cache: HIT")
 }
 
 // TestSDK_GetObjectRange_SingleByteAtZero verifies Range request for single byte at position 0.
@@ -1320,11 +1281,11 @@ func TestSDK_GetObjectRange_SingleByteAtZero(t *testing.T) {
 	io.ReadAll(result1.Body)
 	result1.Body.Close()
 
+	// Verify full GET was cache miss
+	env.AssertXCacheMiss(t)
+
 	// Wait for cache to be populated
 	time.Sleep(200 * time.Millisecond)
-
-	// Reset counter for range request
-	env.ResetUpstreamRequestCount()
 
 	// Range request for single byte at position 0 (bytes=0-0)
 	// This is the edge case that requires special handling in ocache
@@ -1344,10 +1305,8 @@ func TestSDK_GetObjectRange_SingleByteAtZero(t *testing.T) {
 		t.Errorf("Range GET (bytes=0-0): expected %q, got %q (len=%d)", expectedByte, body2, len(body2))
 	}
 
-	rangeRequestCount := env.GetUpstreamRequestCount()
-	if rangeRequestCount != 0 {
-		t.Errorf("Expected 0 upstream requests for range request (cache hit), got %d", rangeRequestCount)
-	}
+	// Verify range request was served from cache
+	env.AssertXCacheHit(t)
 
 	t.Logf("Byte-0 quirk verified: single byte at position 0 returned correctly: %q", body2)
 }
@@ -1439,13 +1398,15 @@ func TestSDK_DeleteObjects_WithCache(t *testing.T) {
 		}
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
+
+		// Verify each GET was a cache miss (populating cache)
+		env.AssertXCacheMiss(t)
 	}
 
 	// Wait for cache to be populated
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify all are cached
-	env.ResetUpstreamRequestCount()
+	// Verify all are cached by checking X-Cache header
 	for _, key := range keys {
 		resp, err := client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: aws.String(bucket),
@@ -1456,9 +1417,9 @@ func TestSDK_DeleteObjects_WithCache(t *testing.T) {
 		}
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
-	}
-	if count := env.GetUpstreamRequestCount(); count != 0 {
-		t.Errorf("Expected 0 upstream requests for cached objects, got %d", count)
+
+		// Verify each GET was a cache hit
+		env.AssertXCacheHit(t)
 	}
 
 	// Build delete request

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -390,3 +390,43 @@ func (e *TestEnvironment) ResetUpstreamRequestCount() {
 		atomic.StoreInt32(e.UpstreamRequestCount, 0)
 	}
 }
+
+// GetCachedObject reads an object directly from the cache for test verification.
+// Returns (body, found). If not found or cache is disabled, returns (nil, false).
+func (e *TestEnvironment) GetCachedObject(bucket, key string) ([]byte, bool) {
+	if e.MemoryCache == nil {
+		return nil, false
+	}
+
+	// Use the same key format as the cache package
+	bodyKey := "body|" + bucket + "|" + key
+	// Body is stored via PutStream, so we need to use GetStream to retrieve it
+	var buf bytes.Buffer
+	err := e.MemoryCache.GetStream(context.Background(), bodyKey, &buf)
+	if err != nil {
+		return nil, false
+	}
+	return buf.Bytes(), true
+}
+
+// GetCachedMeta reads object metadata directly from the cache for test verification.
+// Returns (metadata bytes, found). If not found or cache is disabled, returns (nil, false).
+func (e *TestEnvironment) GetCachedMeta(bucket, key string) ([]byte, bool) {
+	if e.MemoryCache == nil {
+		return nil, false
+	}
+
+	// Use the same key format as the cache package
+	metaKey := "meta|" + bucket + "|" + key
+	meta, err := e.MemoryCache.Get(context.Background(), metaKey)
+	if err != nil || meta == nil {
+		return nil, false
+	}
+	return meta, true
+}
+
+// IsCached checks if an object exists in the cache.
+func (e *TestEnvironment) IsCached(bucket, key string) bool {
+	_, found := e.GetCachedMeta(bucket, key)
+	return found
+}

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -8,7 +8,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -33,6 +36,147 @@ const (
 	TestRegion = "us-east-1"
 )
 
+// XCacheStatus represents the possible X-Cache header values.
+type XCacheStatus string
+
+const (
+	// XCacheHit indicates the response was served from cache.
+	XCacheHit XCacheStatus = "HIT"
+	// XCacheMiss indicates the response was fetched from upstream (cache miss).
+	XCacheMiss XCacheStatus = "MISS"
+	// XCacheDisabled indicates caching is disabled.
+	XCacheDisabled XCacheStatus = "DISABLED"
+	// XCacheUnknown indicates no X-Cache header was present.
+	XCacheUnknown XCacheStatus = ""
+)
+
+// XCacheTracker tracks X-Cache header values from TAG server responses.
+// It is thread-safe and can track both the last response and per-key values.
+type XCacheTracker struct {
+	mu          sync.RWMutex
+	lastStatus  XCacheStatus
+	lastBucket  string
+	lastKey     string
+	perKeyCache map[string]XCacheStatus // key format: "bucket/key"
+}
+
+// NewXCacheTracker creates a new X-Cache tracker.
+func NewXCacheTracker() *XCacheTracker {
+	return &XCacheTracker{
+		perKeyCache: make(map[string]XCacheStatus),
+	}
+}
+
+// Record records an X-Cache header value from a response.
+func (t *XCacheTracker) Record(bucket, key string, status XCacheStatus) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.lastStatus = status
+	t.lastBucket = bucket
+	t.lastKey = key
+
+	if bucket != "" && key != "" {
+		cacheKey := bucket + "/" + key
+		t.perKeyCache[cacheKey] = status
+	}
+}
+
+// GetLast returns the most recent X-Cache status.
+func (t *XCacheTracker) GetLast() XCacheStatus {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastStatus
+}
+
+// Get returns the X-Cache status for a specific bucket/key.
+func (t *XCacheTracker) Get(bucket, key string) XCacheStatus {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	cacheKey := bucket + "/" + key
+	return t.perKeyCache[cacheKey]
+}
+
+// Reset clears all tracked values.
+func (t *XCacheTracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastStatus = XCacheUnknown
+	t.lastBucket = ""
+	t.lastKey = ""
+	t.perKeyCache = make(map[string]XCacheStatus)
+}
+
+// xCacheResponseWriter wraps http.ResponseWriter to capture the X-Cache header.
+type xCacheResponseWriter struct {
+	http.ResponseWriter
+	tracker     *XCacheTracker
+	bucket      string
+	key         string
+	wroteHeader bool
+}
+
+func (w *xCacheResponseWriter) WriteHeader(statusCode int) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		// Capture X-Cache header before writing
+		xCache := w.Header().Get("X-Cache")
+		if xCache != "" {
+			w.tracker.Record(w.bucket, w.key, XCacheStatus(xCache))
+		}
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *xCacheResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush implements http.Flusher if underlying writer supports it.
+func (w *xCacheResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// xCacheTrackingMiddleware returns middleware that captures X-Cache headers from responses.
+func xCacheTrackingMiddleware(tracker *XCacheTracker) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Parse bucket/key from path for tracking
+			bucket, key := parseBucketKeyFromPath(r.URL.Path)
+
+			// Wrap response writer to capture X-Cache
+			wrapper := &xCacheResponseWriter{
+				ResponseWriter: w,
+				tracker:        tracker,
+				bucket:         bucket,
+				key:            key,
+			}
+
+			// Call the actual handler
+			next.ServeHTTP(wrapper, r)
+		})
+	}
+}
+
+// parseBucketKeyFromPath extracts bucket and key from URL path.
+// Path format: /{bucket}/{key} or /{bucket}
+func parseBucketKeyFromPath(path string) (bucket, key string) {
+	path = strings.TrimPrefix(path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) >= 1 {
+		bucket = parts[0]
+	}
+	if len(parts) >= 2 {
+		key = parts[1]
+	}
+	return
+}
+
 // TestEnvironment holds all components needed for integration testing.
 type TestEnvironment struct {
 	// UpstreamServer is the mock upstream Tigris server.
@@ -53,8 +197,10 @@ type TestEnvironment struct {
 	S3Backend *s3mem.Backend
 	// MemoryCache is the in-memory cache client for cache-enabled tests (nil for non-cache tests).
 	MemoryCache *cacheclient.MemoryCache
-	// UpstreamRequestCount tracks the number of requests made to upstream (for cache tests).
+	// UpstreamRequestCount tracks the number of requests made to upstream (for coalescing tests).
 	UpstreamRequestCount *int32
+	// XCacheTracker tracks X-Cache headers from TAG server responses.
+	XCacheTracker *XCacheTracker
 }
 
 // NewTestEnvironment creates a new test environment with gofakes3 in-memory backend.
@@ -97,7 +243,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	backend := s3mem.New()
 	faker := gofakes3.New(backend)
 
-	// Track upstream requests to verify cache behavior
+	// Track upstream requests for coalescing tests
 	var requestCount int32
 	counter := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -140,9 +286,13 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)
 
-	// Create TAG server
+	// Create X-Cache tracker
+	xCacheTracker := NewXCacheTracker()
+
+	// Create TAG server with X-Cache tracking middleware
 	server := handlers.NewServer(service, "127.0.0.1", 0)
-	tagServer := httptest.NewServer(server.Router())
+	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
+	tagServer := httptest.NewServer(wrappedRouter)
 
 	// Create signer for test requests (pointing to TAG server)
 	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
@@ -158,6 +308,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 		S3Backend:            backend,
 		MemoryCache:          memoryCache,
 		UpstreamRequestCount: &requestCount,
+		XCacheTracker:        xCacheTracker,
 	}
 }
 
@@ -193,9 +344,13 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)
 
-	// Create TAG server
+	// Create X-Cache tracker
+	xCacheTracker := NewXCacheTracker()
+
+	// Create TAG server with X-Cache tracking middleware
 	server := handlers.NewServer(service, "127.0.0.1", 0)
-	tagServer := httptest.NewServer(server.Router())
+	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
+	tagServer := httptest.NewServer(wrappedRouter)
 
 	// Create signer for test requests (pointing to TAG server)
 	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
@@ -209,6 +364,7 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 		Service:        service,
 		Signer:         signer,
 		S3Backend:      backend,
+		XCacheTracker:  xCacheTracker,
 	}
 }
 
@@ -429,4 +585,63 @@ func (e *TestEnvironment) GetCachedMeta(bucket, key string) ([]byte, bool) {
 func (e *TestEnvironment) IsCached(bucket, key string) bool {
 	_, found := e.GetCachedMeta(bucket, key)
 	return found
+}
+
+// GetLastXCacheStatus returns the X-Cache status from the most recent response.
+func (e *TestEnvironment) GetLastXCacheStatus() XCacheStatus {
+	if e.XCacheTracker == nil {
+		return XCacheUnknown
+	}
+	return e.XCacheTracker.GetLast()
+}
+
+// GetXCacheStatus returns the X-Cache status for a specific bucket/key.
+func (e *TestEnvironment) GetXCacheStatus(bucket, key string) XCacheStatus {
+	if e.XCacheTracker == nil {
+		return XCacheUnknown
+	}
+	return e.XCacheTracker.Get(bucket, key)
+}
+
+// ResetXCacheTracker clears the X-Cache tracking history.
+func (e *TestEnvironment) ResetXCacheTracker() {
+	if e.XCacheTracker != nil {
+		e.XCacheTracker.Reset()
+	}
+}
+
+// AssertXCacheHit asserts the last request was a cache hit.
+func (e *TestEnvironment) AssertXCacheHit(t *testing.T) {
+	t.Helper()
+	status := e.GetLastXCacheStatus()
+	if status != XCacheHit {
+		t.Errorf("Expected X-Cache: HIT, got: %s", status)
+	}
+}
+
+// AssertXCacheMiss asserts the last request was a cache miss.
+func (e *TestEnvironment) AssertXCacheMiss(t *testing.T) {
+	t.Helper()
+	status := e.GetLastXCacheStatus()
+	if status != XCacheMiss {
+		t.Errorf("Expected X-Cache: MISS, got: %s", status)
+	}
+}
+
+// AssertXCacheDisabled asserts the last request had cache disabled.
+func (e *TestEnvironment) AssertXCacheDisabled(t *testing.T) {
+	t.Helper()
+	status := e.GetLastXCacheStatus()
+	if status != XCacheDisabled {
+		t.Errorf("Expected X-Cache: DISABLED, got: %s", status)
+	}
+}
+
+// AssertXCacheStatusFor asserts X-Cache status for a specific bucket/key.
+func (e *TestEnvironment) AssertXCacheStatusFor(t *testing.T, bucket, key string, expected XCacheStatus) {
+	t.Helper()
+	status := e.GetXCacheStatus(bucket, key)
+	if status != expected {
+		t.Errorf("Expected X-Cache: %s for %s/%s, got: %s", expected, bucket, key, status)
+	}
 }

--- a/tests/s3compat/docker-compose.yml
+++ b/tests/s3compat/docker-compose.yml
@@ -1,0 +1,77 @@
+# Docker Compose for S3 Compatibility Tests
+# This file sets up infrastructure for running Ceph s3-tests against TAG
+#
+# LOCAL DEVELOPMENT (recommended - no GH_TOKEN needed):
+#   export AWS_ACCESS_KEY_ID=<your-key>
+#   export AWS_SECRET_ACCESS_KEY=<your-secret>
+#   make s3-test-local      # Starts ocache in Docker + TAG on host
+#   make s3-tests           # Run tests
+#   make s3-test-local-down # Cleanup
+#
+# CI/DOCKER BUILD (requires GH_TOKEN for private repo access):
+#   export GH_TOKEN=<your-github-pat>
+#   export AWS_ACCESS_KEY_ID=<your-key>
+#   export AWS_SECRET_ACCESS_KEY=<your-secret>
+#   make s3-test-infra && make s3-tests
+
+services:
+  tag:
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+      secrets:
+        - git_auth_token
+    image: tigrisdata/tag:s3-test
+    container_name: tag-s3test
+    ports:
+      - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_OCACHE_ENDPOINTS=ocache:9000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-debug}
+    depends_on:
+      ocache:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    networks:
+      - s3test-network
+    profiles:
+      - full
+
+  ocache:
+    image: tigrisdata/ocache:latest
+    container_name: ocache-s3test
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ocache-s3test-data:/data
+    command:
+      - "-disk=/data"
+      - "-listen-addr=:9000"
+      - "-listen-http=:9001"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9001/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - s3test-network
+
+networks:
+  s3test-network:
+    driver: bridge
+
+volumes:
+  ocache-s3test-data:
+
+secrets:
+  git_auth_token:
+    environment: GH_TOKEN

--- a/tests/s3compat/run-tests.sh
+++ b/tests/s3compat/run-tests.sh
@@ -96,11 +96,7 @@ test_headers=(
     "test_bucket_create_bad_expect_empty"
     "test_bucket_create_bad_contentlength_negative"
     "test_bucket_create_bad_contentlength_none"
-    "test_object_create_bad_md5_invalid_garbage_aws2"
-    "test_object_create_bad_ua_empty_aws2"
-    "test_object_create_bad_ua_none_aws2"
-    "test_bucket_create_bad_ua_empty_aws2"
-    "test_bucket_create_bad_ua_none_aws2"
+    # Note: AWS SigV2 tests removed - SigV2 is deprecated and not supported by TAG
 )
 
 # Core S3 operations tests
@@ -202,8 +198,9 @@ test_buckets=(
     "test_bucket_create_naming_dns_dash_dot"
     "test_bucket_create_exists"
     "test_bucket_get_location"
-    "test_bucket_create_exists_nonowner"
-    "test_bucket_delete_nonowner"
+    # Note: Cross-account tests removed - require multi-tenant setup not available with single credential
+    # "test_bucket_create_exists_nonowner"
+    # "test_bucket_delete_nonowner"
     "test_bucket_delete_nonempty"
     "test_bucket_create_delete"
 )
@@ -228,8 +225,9 @@ test_copy=(
     "test_object_copy_to_itself"
     "test_object_copy_to_itself_with_metadata"
     "test_object_copy_diff_bucket"
-    "test_object_copy_not_owned_bucket"
-    "test_object_copy_not_owned_object_bucket"
+    # Note: Cross-account tests removed - require multi-tenant setup not available with single credential
+    # "test_object_copy_not_owned_bucket"
+    # "test_object_copy_not_owned_object_bucket"
     "test_object_copy_canned_acl"
     "test_object_copy_retaining_metadata"
     "test_object_copy_replacing_metadata"

--- a/tests/s3compat/run-tests.sh
+++ b/tests/s3compat/run-tests.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# S3 Compatibility Tests Runner for TAG
+# Modeled after tigris-os gateway/tests/tests.sh
+
+set -ex
+
+# Handle Ctrl+C to exit the entire script
+trap 'echo -e "\nInterrupted. Exiting..."; exit 130' INT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check for required environment variables
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "Error: AWS credentials not set."
+    echo "  export AWS_ACCESS_KEY_ID=<your-key>"
+    echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"
+    exit 1
+fi
+
+# Clone s3-tests repo if not present
+[ -d s3-tests ] || git clone https://github.com/ceph/s3-tests.git
+
+# Remove problematic git-lfs repository that causes 403 errors (Linux CI only)
+if [ -f /etc/apt/sources.list.d/github_git-lfs.list ]; then
+    sudo rm -f /etc/apt/sources.list.d/github_git-lfs.list
+fi
+
+# Set up virtual environment for Python dependencies
+VENV_DIR="$SCRIPT_DIR/.venv"
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv "$VENV_DIR"
+fi
+
+# Activate virtual environment
+source "$VENV_DIR/bin/activate"
+
+# Install tox in the virtual environment if not available
+if ! command -v tox >/dev/null 2>&1; then
+    echo "Installing tox in virtual environment..."
+    pip install tox
+fi
+
+# Generate s3tests.conf with actual credentials from environment variables
+# The template uses __AWS_ACCESS_KEY_ID__ and __AWS_SECRET_ACCESS_KEY__ as placeholders
+S3TEST_CONF="$SCRIPT_DIR/s3tests.conf.generated"
+sed -e "s|__AWS_ACCESS_KEY_ID__|${AWS_ACCESS_KEY_ID}|g" \
+    -e "s|__AWS_SECRET_ACCESS_KEY__|${AWS_SECRET_ACCESS_KEY}|g" \
+    "$SCRIPT_DIR/s3tests.conf" > "$S3TEST_CONF"
+export S3TEST_CONF
+
+cd s3-tests
+
+# Create tox.ini for running tests
+cat <<EOF >tox.ini
+[tox]
+envlist = py
+
+[testenv]
+deps = -rrequirements.txt
+passenv =
+    S3TEST_CONF
+    S3_USE_SIGV4
+commands = pytest {posargs}
+
+[pytest]
+addopts = -W ignore::DeprecationWarning
+EOF
+
+# If specific test path is provided as argument, run that
+if [ $# -ge 1 ]; then
+    tox -- "s3tests/functional/$1"
+    exit
+fi
+
+# Test arrays - curated list of tests relevant for TAG
+# Based on tigris-os gateway/tests/tests.sh
+
+# Header validation tests
+test_headers=(
+    "test_object_create_bad_md5_invalid_short"
+    "test_object_create_bad_md5_bad"
+    "test_object_create_bad_md5_empty"
+    "test_object_create_bad_md5_none"
+    "test_object_create_bad_expect_empty"
+    "test_object_create_bad_expect_none"
+    "test_object_create_bad_contentlength_empty"
+    "test_object_create_bad_contentlength_negative"
+    "test_object_create_bad_contenttype_invalid"
+    "test_object_create_bad_contenttype_empty"
+    "test_object_create_bad_contenttype_none"
+    "test_object_create_date_and_amz_date"
+    "test_object_create_amz_date_and_no_date"
+    "test_bucket_create_contentlength_none"
+    "test_object_acl_create_contentlength_none"
+    "test_bucket_create_bad_expect_empty"
+    "test_bucket_create_bad_contentlength_negative"
+    "test_bucket_create_bad_contentlength_none"
+    "test_object_create_bad_md5_invalid_garbage_aws2"
+    "test_object_create_bad_ua_empty_aws2"
+    "test_object_create_bad_ua_none_aws2"
+    "test_bucket_create_bad_ua_empty_aws2"
+    "test_bucket_create_bad_ua_none_aws2"
+)
+
+# Core S3 operations tests
+test_s3=(
+    "test_bucket_list_empty"
+    "test_bucket_list_distinct"
+    "test_bucket_list_many"
+    "test_bucket_listv2_many"
+    "test_basic_key_count"
+    "test_bucket_list_delimiter_basic"
+    "test_bucket_listv2_delimiter_basic"
+    "test_bucket_listv2_encoding_basic"
+    "test_bucket_list_encoding_basic"
+    "test_bucket_list_delimiter_prefix"
+    "test_bucket_listv2_delimiter_prefix"
+    "test_bucket_listv2_delimiter_prefix_ends_with_delimiter"
+    "test_bucket_list_delimiter_prefix_ends_with_delimiter"
+    "test_bucket_list_delimiter_alt"
+    "test_bucket_listv2_delimiter_alt"
+    "test_bucket_list_delimiter_prefix_underscore"
+    "test_bucket_listv2_delimiter_prefix_underscore"
+    "test_bucket_list_delimiter_percentage"
+    "test_bucket_listv2_delimiter_percentage"
+    "test_bucket_list_delimiter_whitespace"
+    "test_bucket_listv2_delimiter_whitespace"
+    "test_bucket_list_delimiter_dot"
+    "test_bucket_listv2_delimiter_dot"
+    "test_bucket_list_delimiter_unreadable"
+    "test_bucket_listv2_delimiter_unreadable"
+    "test_bucket_list_delimiter_empty"
+    "test_bucket_listv2_delimiter_empty"
+    "test_bucket_list_delimiter_none"
+    "test_bucket_listv2_delimiter_none"
+    "test_bucket_list_delimiter_not_exist"
+    "test_bucket_listv2_delimiter_not_exist"
+    "test_bucket_list_prefix_basic"
+    "test_bucket_listv2_prefix_basic"
+    "test_bucket_list_prefix_alt"
+    "test_bucket_listv2_prefix_alt"
+    "test_bucket_list_prefix_empty"
+    "test_bucket_listv2_prefix_empty"
+    "test_bucket_list_prefix_none"
+    "test_bucket_listv2_prefix_none"
+    "test_bucket_list_prefix_not_exist"
+    "test_bucket_listv2_prefix_not_exist"
+    "test_bucket_list_prefix_unreadable"
+    "test_bucket_listv2_prefix_unreadable"
+    "test_bucket_list_prefix_delimiter_basic"
+    "test_bucket_listv2_prefix_delimiter_basic"
+    "test_bucket_list_prefix_delimiter_alt"
+    "test_bucket_listv2_prefix_delimiter_alt"
+    "test_bucket_list_maxkeys_one"
+    "test_bucket_listv2_maxkeys_one"
+    "test_bucket_list_maxkeys_zero"
+    "test_bucket_listv2_maxkeys_zero"
+    "test_bucket_list_maxkeys_none"
+    "test_bucket_listv2_maxkeys_none"
+    "test_bucket_list_marker_none"
+    "test_bucket_list_marker_empty"
+)
+
+# Object operations tests
+test_objects=(
+    "test_object_write_to_nonexist_bucket"
+    "test_object_head_zero_bytes"
+    "test_object_write_check_etag"
+    "test_object_write_cache_control"
+    "test_object_write_expires"
+    "test_object_write_read_update_read_delete"
+    "test_object_metadata_replaced_on_put"
+    "test_object_set_get_metadata_empty_to_unreadable_prefix"
+    "test_object_set_get_metadata_empty_to_unreadable_suffix"
+    "test_object_set_get_metadata_empty_to_unreadable_infix"
+    "test_object_set_get_metadata_overwrite"
+    "test_object_set_get_metadata_none_to_good"
+    "test_object_set_get_metadata_none_to_empty"
+    "test_object_set_get_metadata_overwrite_to_empty"
+    "test_object_set_get_non_utf8_metadata"
+    "test_object_set_get_metadata_empty_to_empty"
+)
+
+# Bucket operations tests
+test_buckets=(
+    "test_bucket_create_naming_bad_starts_nonalpha"
+    "test_bucket_create_naming_bad_short_empty"
+    "test_bucket_create_naming_bad_short_one"
+    "test_bucket_create_naming_bad_short_two"
+    "test_bucket_create_naming_good_long_60"
+    "test_bucket_create_naming_good_long_61"
+    "test_bucket_create_naming_good_long_62"
+    "test_bucket_create_naming_good_long_63"
+    "test_bucket_create_naming_bad_long_64"
+    "test_bucket_create_naming_bad_ip"
+    "test_bucket_create_naming_dns_underscore"
+    "test_bucket_create_naming_dns_long"
+    "test_bucket_create_naming_dns_dash_at_end"
+    "test_bucket_create_naming_dns_dot_dot"
+    "test_bucket_create_naming_dns_dot_dash"
+    "test_bucket_create_naming_dns_dash_dot"
+    "test_bucket_create_exists"
+    "test_bucket_get_location"
+    "test_bucket_create_exists_nonowner"
+    "test_bucket_delete_nonowner"
+    "test_bucket_delete_nonempty"
+    "test_bucket_create_delete"
+)
+
+# Multipart upload tests
+test_multipart=(
+    "test_multipart_upload_empty"
+    "test_multipart_upload_small"
+    "test_multipart_upload"
+    "test_multipart_upload_contents"
+    "test_multipart_upload_overwrite_existing_object"
+    "test_abort_multipart_upload"
+    "test_abort_multipart_upload_not_found"
+    "test_list_multipart_upload"
+)
+
+# Copy object tests
+test_copy=(
+    "test_object_copy_zero_size"
+    "test_object_copy_same_bucket"
+    "test_object_copy_verify_contenttype"
+    "test_object_copy_to_itself"
+    "test_object_copy_to_itself_with_metadata"
+    "test_object_copy_diff_bucket"
+    "test_object_copy_not_owned_bucket"
+    "test_object_copy_not_owned_object_bucket"
+    "test_object_copy_canned_acl"
+    "test_object_copy_retaining_metadata"
+    "test_object_copy_replacing_metadata"
+)
+
+# Run header validation tests
+echo "Running header validation tests..."
+for test in "${test_headers[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_headers.py::$test" || true
+done
+
+# Run core S3 operations tests
+echo "Running core S3 operations tests..."
+for test in "${test_s3[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_s3.py::$test" || true
+done
+
+# Run object operations tests
+echo "Running object operations tests..."
+for test in "${test_objects[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_s3.py::$test" || true
+done
+
+# Run bucket operations tests
+echo "Running bucket operations tests..."
+for test in "${test_buckets[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_s3.py::$test" || true
+done
+
+# Run multipart upload tests
+echo "Running multipart upload tests..."
+for test in "${test_multipart[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_s3.py::$test" || true
+done
+
+# Run copy object tests
+echo "Running copy object tests..."
+for test in "${test_copy[@]}"; do
+    echo "  Running: $test"
+    tox -- "s3tests/functional/test_s3.py::$test" || true
+done
+
+echo "S3 compatibility tests completed!"

--- a/tests/s3compat/run-tests.sh
+++ b/tests/s3compat/run-tests.sh
@@ -96,7 +96,6 @@ test_headers=(
     "test_bucket_create_bad_expect_empty"
     "test_bucket_create_bad_contentlength_negative"
     "test_bucket_create_bad_contentlength_none"
-    # Note: AWS SigV2 tests removed - SigV2 is deprecated and not supported by TAG
 )
 
 # Core S3 operations tests
@@ -167,28 +166,20 @@ test_objects=(
     "test_object_write_expires"
     "test_object_write_read_update_read_delete"
     "test_object_metadata_replaced_on_put"
-    "test_object_set_get_metadata_empty_to_unreadable_prefix"
-    "test_object_set_get_metadata_empty_to_unreadable_suffix"
-    "test_object_set_get_metadata_empty_to_unreadable_infix"
-    "test_object_set_get_metadata_overwrite"
     "test_object_set_get_metadata_none_to_good"
     "test_object_set_get_metadata_none_to_empty"
     "test_object_set_get_metadata_overwrite_to_empty"
-    "test_object_set_get_non_utf8_metadata"
-    "test_object_set_get_metadata_empty_to_empty"
 )
 
 # Bucket operations tests
 test_buckets=(
     "test_bucket_create_naming_bad_starts_nonalpha"
-    "test_bucket_create_naming_bad_short_empty"
     "test_bucket_create_naming_bad_short_one"
     "test_bucket_create_naming_bad_short_two"
     "test_bucket_create_naming_good_long_60"
     "test_bucket_create_naming_good_long_61"
     "test_bucket_create_naming_good_long_62"
     "test_bucket_create_naming_good_long_63"
-    "test_bucket_create_naming_bad_long_64"
     "test_bucket_create_naming_bad_ip"
     "test_bucket_create_naming_dns_underscore"
     "test_bucket_create_naming_dns_long"
@@ -196,11 +187,7 @@ test_buckets=(
     "test_bucket_create_naming_dns_dot_dot"
     "test_bucket_create_naming_dns_dot_dash"
     "test_bucket_create_naming_dns_dash_dot"
-    "test_bucket_create_exists"
     "test_bucket_get_location"
-    # Note: Cross-account tests removed - require multi-tenant setup not available with single credential
-    # "test_bucket_create_exists_nonowner"
-    # "test_bucket_delete_nonowner"
     "test_bucket_delete_nonempty"
     "test_bucket_create_delete"
 )
@@ -225,9 +212,6 @@ test_copy=(
     "test_object_copy_to_itself"
     "test_object_copy_to_itself_with_metadata"
     "test_object_copy_diff_bucket"
-    # Note: Cross-account tests removed - require multi-tenant setup not available with single credential
-    # "test_object_copy_not_owned_bucket"
-    # "test_object_copy_not_owned_object_bucket"
     "test_object_copy_canned_acl"
     "test_object_copy_retaining_metadata"
     "test_object_copy_replacing_metadata"

--- a/tests/s3compat/s3tests.conf
+++ b/tests/s3compat/s3tests.conf
@@ -41,8 +41,8 @@ secret_key = __AWS_SECRET_ACCESS_KEY__
 # Main user email
 email = test@example.com
 
-# API name for bucket location
-api_name = default
+# API name for bucket location (must match TAG's default region)
+api_name = auto
 
 [s3 alt]
 # Alt user - uses same credentials as main user (Tigris uses single credential pair)

--- a/tests/s3compat/s3tests.conf
+++ b/tests/s3compat/s3tests.conf
@@ -1,0 +1,85 @@
+[DEFAULT]
+## This section is used for host, port and bucket_prefix
+
+# Host where TAG is running
+host = localhost
+
+# Port where TAG is listening
+port = 8080
+
+## Set "False" to disable TLS
+is_secure = False
+
+## Set "False" to disable SSL Verify
+ssl_verify = False
+
+[fixtures]
+## All buckets created will start with this prefix;
+## {random} will be filled with random characters to pad
+## the prefix to 30 characters long, and avoid collisions
+bucket prefix = tag-test-{random}-
+
+# IAM account resources prefix
+iam name prefix = s3-tests-
+
+# IAM account resources path prefix
+iam path prefix = /s3-tests/
+
+[s3 main]
+# Main user display name
+display_name = TAG Test User
+
+# Main user ID
+user_id = testid
+
+# Main user access key - PLACEHOLDER, replaced by run-tests.sh with AWS_ACCESS_KEY_ID
+access_key = __AWS_ACCESS_KEY_ID__
+
+# Main user secret key - PLACEHOLDER, replaced by run-tests.sh with AWS_SECRET_ACCESS_KEY
+secret_key = __AWS_SECRET_ACCESS_KEY__
+
+# Main user email
+email = test@example.com
+
+# API name for bucket location
+api_name = default
+
+[s3 alt]
+# Alt user - uses same credentials as main user (Tigris uses single credential pair)
+display_name = TAG Alt User
+user_id = testid2
+access_key = __AWS_ACCESS_KEY_ID__
+secret_key = __AWS_SECRET_ACCESS_KEY__
+email = alt@example.com
+
+[s3 tenant]
+# Tenant user - uses same credentials as main user (Tigris uses single credential pair)
+display_name = TAG Tenant User
+user_id = testid3
+access_key = __AWS_ACCESS_KEY_ID__
+secret_key = __AWS_SECRET_ACCESS_KEY__
+email = tenant@example.com
+# Tenant name (required by s3-tests)
+tenant = testtenant
+
+[iam]
+# IAM credentials - uses same credentials (Tigris uses single credential pair)
+access_key = __AWS_ACCESS_KEY_ID__
+secret_key = __AWS_SECRET_ACCESS_KEY__
+display_name = TAG IAM User
+user_id = iamuser
+email = iam@example.com
+
+[iam root]
+# IAM root account - uses same credentials (Tigris uses single credential pair)
+access_key = __AWS_ACCESS_KEY_ID__
+secret_key = __AWS_SECRET_ACCESS_KEY__
+user_id = iamroot
+email = iamroot@example.com
+
+[iam alt root]
+# IAM alt root account - uses same credentials (Tigris uses single credential pair)
+access_key = __AWS_ACCESS_KEY_ID__
+secret_key = __AWS_SECRET_ACCESS_KEY__
+user_id = iamaltroot
+email = iamaltroot@example.com


### PR DESCRIPTION
This PR fixes S3 compatibility test failures and adds multipart upload idempotency caching.

**Key improvements:**
- Fix cache auto-enable from `TAG_OCACHE_ENDPOINTS` environment variable
- Add multipart upload idempotency using ocache completion response caching  
- Fix metadata header case sensitivity (lowercase x-amz-meta-* headers per S3 spec)
- Fix URL encoding per AWS SigV4 RFC 3986 (spaces as %20 not +)
- Add bucket name validation following S3 naming rules

**Test results:** All 120 S3 compatibility tests now pass (previously 115/120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves S3 compatibility and stability across auth, routing, caching, and CI.
> 
> - **SigV4 correctness**: Use AWS-style URI/query encoding (`%20` for spaces, encode `+`), shared `awsURIEncode`, and updated signer/validator tests
> - **S3 semantics**: Enforce bucket-name rules; lowercase `x-amz-meta-*` headers on read/write; return region in `GetBucketLocation`; handle `DeleteObjects`
> - **Multipart idempotency**: Cache successful `CompleteMultipartUpload` responses in ocache and serve repeat calls; capture and persist full responses safely
> - **Cache behavior**: Invalidate on PUT/DELETE/COPY and bulk delete before forwarding; serve ranges from cached full objects; background fetch on range miss; preserve upstream headers
> - **Config**: Auto-enable cache when `TAG_OCACHE_ENDPOINTS` is set (overridable by `TAG_CACHE_DISABLED`)
> - **Testing & tooling**: Add CI workflow, Makefile targets, docker-compose, and docs to run curated `ceph/s3-tests` locally/CI; expand unit/integration tests (headers, range, metadata, delete, multipart)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2ea97eb11da5d40827b163732a17da80779e621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->