### PR TITLE
feat: emit all defined metrics

### DIFF
--- a/handlers/server.go
+++ b/handlers/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy"
 )
 
@@ -34,10 +35,22 @@ func NewServer(service *proxy.Service, bindIP string, port int) *Server {
 	return s
 }
 
+// connectionTrackingMiddleware tracks active HTTP connections.
+func (s *Server) connectionTrackingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metrics.ActiveConnections.Inc()
+		defer metrics.ActiveConnections.Dec()
+		next.ServeHTTP(w, r)
+	})
+}
+
 // setupRouter configures the S3-compatible routes.
 func (s *Server) setupRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.SkipClean(true) // Preserve path for S3 compatibility
+
+	// Apply connection tracking middleware
+	r.Use(s.connectionTrackingMiddleware)
 
 	// Health check endpoint
 	r.HandleFunc("/health", s.handleHealth).Methods("GET")

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tag/auth"
+	"github.com/tigrisdata/tag/metrics"
 )
 
 // AuthErrorCode represents the type of authentication error.
@@ -49,23 +50,33 @@ func mapAuthError(err error) *AuthError {
 		return nil
 	}
 
+	var reason string
+	var code AuthErrorCode
+
 	// Check for specific auth errors
 	if errors.Is(err, auth.ErrSignatureMismatch) {
-		return &AuthError{Code: ErrCodeSignatureMismatch, Err: err}
-	}
-	if errors.Is(err, auth.ErrUnknownAccessKey) {
-		return &AuthError{Code: ErrCodeInvalidAccessKey, Err: err}
-	}
-	if errors.Is(err, auth.ErrExpiredRequest) {
-		return &AuthError{Code: ErrCodeExpiredRequest, Err: err}
-	}
-	if errors.Is(err, auth.ErrMissingAuth) || errors.Is(err, auth.ErrInvalidAuthFormat) ||
+		reason = "signature_mismatch"
+		code = ErrCodeSignatureMismatch
+	} else if errors.Is(err, auth.ErrUnknownAccessKey) {
+		reason = "unknown_access_key"
+		code = ErrCodeInvalidAccessKey
+	} else if errors.Is(err, auth.ErrExpiredRequest) {
+		reason = "expired_request"
+		code = ErrCodeExpiredRequest
+	} else if errors.Is(err, auth.ErrMissingAuth) || errors.Is(err, auth.ErrInvalidAuthFormat) ||
 		errors.Is(err, auth.ErrUnsupportedAuthScheme) || errors.Is(err, auth.ErrMissingContentHash) {
-		return &AuthError{Code: ErrCodeMalformedAuth, Err: err}
+		reason = "malformed_auth"
+		code = ErrCodeMalformedAuth
+	} else {
+		// Default to internal error
+		reason = "internal_error"
+		code = ErrCodeInternal
 	}
 
-	// Default to internal error
-	return &AuthError{Code: ErrCodeInternal, Err: err}
+	// Record the auth failure metric
+	metrics.RecordAuthFailure(reason)
+
+	return &AuthError{Code: code, Err: err}
 }
 
 // IsAuthError checks if the error is an AuthError and returns it.
@@ -138,8 +149,15 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 		fwdReq.ContentLength = r.ContentLength
 	}
 
+	// Track bytes in from request body
+	if r.ContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	}
+
 	// Forward to Tigris
+	upstreamStart := time.Now()
 	resp, err := f.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
 		return err
@@ -149,9 +167,12 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 	// Stream response back to client
 	copyHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
-	if _, err := io.Copy(w, resp.Body); err != nil {
-		log.Warn().Err(err).Msg("Failed to copy response body to client")
+	n, copyErr := io.Copy(w, resp.Body)
+	if copyErr != nil {
+		log.Warn().Err(copyErr).Msg("Failed to copy response body to client")
 	}
+	// Track bytes out from response body
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
 
 	return nil
 }
@@ -193,8 +214,15 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 		fwdReq.ContentLength = r.ContentLength
 	}
 
+	// Track bytes in from request body
+	if r.ContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	}
+
 	// Forward to Tigris
+	upstreamStart := time.Now()
 	resp, err := f.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
 		return nil, err
@@ -220,6 +248,9 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 	} else {
 		capture.Complete = true
 	}
+
+	// Track bytes out from response body
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(len(capture.Body)))
 
 	return capture, nil
 }
@@ -288,7 +319,14 @@ func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, acc
 		fwdReq.ContentLength = r.ContentLength
 	}
 
+	// Track bytes in from request body
+	if r.ContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	}
+
+	upstreamStart := time.Now()
 	resp, err := f.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
 		return nil, err
@@ -309,7 +347,9 @@ func (f *Forwarder) DoFullObjectRequest(ctx context.Context, bucket, key, access
 		return nil, err
 	}
 
+	upstreamStart := time.Now()
 	resp, err := f.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest("GET", time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background fetch failed")
 		return nil, err

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -16,6 +16,18 @@ import (
 	"github.com/tigrisdata/tag/proxy/broadcast"
 )
 
+// countingWriter wraps an io.Writer to count bytes written.
+type countingWriter struct {
+	w       io.Writer
+	written int64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.written += int64(n)
+	return n, err
+}
+
 // HandleGetObject handles GET requests for objects with cache-first logic.
 // Uses streaming broadcast for request coalescing to reduce upstream load.
 // Supports conditional requests (If-None-Match, If-Modified-Since).
@@ -319,6 +331,13 @@ func (s *Service) writeChunksToResponse(
 
 	// Receive and write chunks
 	var totalBytesOut int64
+	defer func() {
+		// Track bytes out to client, even on error
+		if totalBytesOut > 0 {
+			metrics.BytesTransferred.WithLabelValues("out").Add(float64(totalBytesOut))
+		}
+	}()
+
 	for chunk := range listener.Chunks() {
 		if chunk.Err != nil {
 			if chunk.Err == broadcast.ErrSlowConsumer {
@@ -339,9 +358,6 @@ func (s *Service) writeChunksToResponse(
 			}
 		}
 	}
-
-	// Track bytes out to client
-	metrics.BytesTransferred.WithLabelValues("out").Add(float64(totalBytesOut))
 
 	return nil
 }
@@ -478,17 +494,22 @@ func (s *Service) serveRangeFromCache(
 	w.Header().Set(XCacheHeader, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
 
-	// Stream range from cache
-	if err := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, w); err != nil {
-		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).
+	// Stream range from cache using counting writer to track actual bytes
+	cw := &countingWriter{w: w}
+	streamErr := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, cw)
+
+	// Track bytes out (even on error, some bytes may have been written)
+	if cw.written > 0 {
+		metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+	}
+
+	if streamErr != nil {
+		log.Warn().Err(streamErr).Str("bucket", bucket).Str("key", key).
 			Int64("start", rng.start).Int64("end", rng.end).
 			Msg("Failed to stream range from cache")
 		// Headers already sent, can't return error to client
-		return err
+		return streamErr
 	}
-
-	// Track bytes out (range served from cache)
-	metrics.BytesTransferred.WithLabelValues("out").Add(float64(contentLength))
 
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -94,7 +94,9 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			w.Header().Set(XCacheHeader, XCacheHit)
 			w.WriteHeader(meta.StatusCode)
 			if bodyReader != nil {
-				if _, copyErr := io.Copy(w, bodyReader); copyErr != nil {
+				n, copyErr := io.Copy(w, bodyReader)
+				metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+				if copyErr != nil {
 					log.Warn().Err(copyErr).Msg("Failed to copy cached content to response")
 				}
 			}
@@ -316,6 +318,7 @@ func (s *Service) writeChunksToResponse(
 	w.WriteHeader(status)
 
 	// Receive and write chunks
+	var totalBytesOut int64
 	for chunk := range listener.Chunks() {
 		if chunk.Err != nil {
 			if chunk.Err == broadcast.ErrSlowConsumer {
@@ -325,7 +328,9 @@ func (s *Service) writeChunksToResponse(
 		}
 
 		if len(chunk.Data) > 0 {
-			if _, writeErr := w.Write(chunk.Data); writeErr != nil {
+			n, writeErr := w.Write(chunk.Data)
+			totalBytesOut += int64(n)
+			if writeErr != nil {
 				return writeErr
 			}
 			// Flush if ResponseWriter supports it
@@ -334,6 +339,9 @@ func (s *Service) writeChunksToResponse(
 			}
 		}
 	}
+
+	// Track bytes out to client
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(totalBytesOut))
 
 	return nil
 }
@@ -479,6 +487,9 @@ func (s *Service) serveRangeFromCache(
 		return err
 	}
 
+	// Track bytes out (range served from cache)
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(contentLength))
+
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
 	return nil
@@ -525,7 +536,9 @@ func (s *Service) handleRangeWithBackgroundCache(
 	w.WriteHeader(resp.StatusCode)
 
 	// Stream Range response body to client
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	n, err := io.Copy(w, resp.Body)
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+	if err != nil {
 		log.Warn().Err(err).Msg("Failed to copy range response body")
 		return err
 	}


### PR DESCRIPTION
## Summary

Add instrumentation to record metrics that were defined but not emitted in the codebase:
- `tag_upstream_request_duration_seconds` and `tag_upstream_errors_total` for Tigris request tracking
- `tag_auth_failures_total` with reason labels (signature_mismatch, unknown_access_key, expired_request, malformed_auth, internal_error)
- `tag_active_connections` gauge via HTTP middleware
- `tag_bytes_transferred_total` counter with direction labels (in/out) for all requests

All metrics now appear in the `/metrics` endpoint and provide visibility into gateway operations, upstream performance, authentication issues, and data transfer volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing instrumentation to expose all defined metrics and improve observability of proxy behavior.
> 
> - Introduces HTTP middleware to track `metrics.ActiveConnections` on all routes
> - Records auth failure reasons in `mapAuthError` via `metrics.RecordAuthFailure`
> - Measures upstream request latency/errors in forwarder methods with `metrics.RecordUpstreamRequest`
> - Accounts for data transfer using `metrics.BytesTransferred` (direction `in`/`out`) in streaming paths: direct forward, captured responses, broadcast writes, cache hits, and range handling
> - Adds `countingWriter` to accurately track bytes when serving ranges from cache
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fdf55a17a34276a41b26cf212c38c49a341b357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->