### PR TITLE
docs: clarify that only path-style S3 access is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ See [docs/deployment.md](docs/deployment.md) for complete deployment guide inclu
 
 TAG supports all S3 API endpoints supported by Tigris, including bucket operations, object operations, multipart uploads, and more. See the [Tigris S3 API documentation](https://www.tigrisdata.com/docs/api/s3/) for the complete list of supported operations.
 
+### S3 Addressing Style
+
+TAG supports **path-style** S3 access only. Virtual-hosted style requests are not supported.
+
+| Style | URL Format | Supported |
+|-------|------------|-----------|
+| Path-style | `http://localhost:8080/bucket/key` | Yes |
+| Virtual-hosted | `http://bucket.localhost:8080/key` | No |
+
+When configuring S3 clients, ensure path-style addressing is enabled. See [docs/usage.md](docs/usage.md) for SDK-specific configuration.
+
 ### Response Headers
 
 | Header | Description |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,13 +96,15 @@ pip install boto3
 
 ```python
 import boto3
+from botocore.config import Config
 
-# Create S3 client with TAG endpoint
+# Create S3 client with TAG endpoint (path-style required)
 s3 = boto3.client(
     's3',
     endpoint_url='http://localhost:8080',
     aws_access_key_id='your_access_key',
     aws_secret_access_key='your_secret_key',
+    config=Config(s3={'addressing_style': 'path'}),
 )
 ```
 
@@ -110,6 +112,7 @@ s3 = boto3.client(
 
 ```python
 import boto3
+from botocore.config import Config
 import os
 
 # Credentials from environment variables
@@ -118,6 +121,7 @@ import os
 s3 = boto3.client(
     's3',
     endpoint_url=os.getenv('TAG_ENDPOINT', 'http://localhost:8080'),
+    config=Config(s3={'addressing_style': 'path'}),
 )
 ```
 
@@ -179,13 +183,15 @@ print(f"Last Modified: {response['LastModified']}")
 
 ```python
 import boto3
+from botocore.config import Config
 
-# Create S3 resource
+# Create S3 resource (path-style required)
 s3 = boto3.resource(
     's3',
     endpoint_url='http://localhost:8080',
     aws_access_key_id='your_access_key',
     aws_secret_access_key='your_secret_key',
+    config=Config(s3={'addressing_style': 'path'}),
 )
 
 # Get bucket
@@ -270,7 +276,21 @@ from botocore.config import Config
 config = Config(
     connect_timeout=30,
     read_timeout=300,
+    s3={'addressing_style': 'path'},
 )
 
 s3 = boto3.client('s3', endpoint_url='http://localhost:8080', config=config)
 ```
+
+### 405 Method Not Allowed on CreateBucket
+
+If you receive a 405 error when creating buckets, ensure path-style addressing is configured:
+
+```python
+from botocore.config import Config
+
+config = Config(s3={'addressing_style': 'path'})
+s3 = boto3.client('s3', endpoint_url='http://localhost:8080', config=config)
+```
+
+TAG does not support virtual-hosted style requests (e.g., `bucket.localhost:8080`).


### PR DESCRIPTION
## Summary

This PR clarifies that TAG only supports path-style S3 access and does not support virtual-hosted style addressing. AWS SDK v2 defaults to virtual-hosted style, which causes 405 errors when creating buckets unless explicitly configured. All boto3 examples have been updated to include `Config(s3={'addressing_style': 'path'})`, and a new troubleshooting section addresses common 405 errors.

## Changes

- Added "S3 Addressing Style" section to README.md API Reference
- Updated all boto3 examples in docs/usage.md to include path-style configuration
- Added troubleshooting section for 405 Method Not Allowed errors

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies S3 addressing requirements and updates Python examples to prevent 405 errors.
> 
> - Adds **S3 Addressing Style** section to `README.md`, specifying TAG supports only `path-style` addressing and not virtual-hosted
> - Updates all `boto3` client/resource examples in `docs/usage.md` to include `Config(s3={'addressing_style': 'path'})`
> - Adds troubleshooting guidance for 405 errors on `CreateBucket`, with example configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39f92333e567f342a033cf1d91d9f7914c4868a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->