### PR TITLE
feat: add s3-bench-local make target for local benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Go build artifacts
 /tag
 
+# Downloaded binaries for local benchmarking
+.bin/
+
 # S3 compatibility tests (cloned repo, venv, and generated config with credentials)
 tests/s3compat/s3-tests/
 tests/s3compat/.venv/

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CMD_PATH := ./cmd/tag
 OCACHE_VERSION ?= v1.2.2
 OCACHE_BINARY := ocache
 OCACHE_BIN_DIR := .bin
+OCACHE_BIN_PATH := $(OCACHE_BIN_DIR)/$(OCACHE_BINARY)-$(OCACHE_VERSION)
 OCACHE_RELEASES_URL := https://ocache-releases.t3.storage.dev
 OCACHE_DATA_DIR := /tmp/ocache-bench-data
 
@@ -284,14 +285,14 @@ s3-bench-local: build
 		exit 1; \
 	fi
 	@mkdir -p $(OCACHE_BIN_DIR)
-	@if [ ! -x $(OCACHE_BIN_DIR)/$(OCACHE_BINARY) ]; then \
+	@if [ ! -x $(OCACHE_BIN_PATH) ]; then \
 		echo "Downloading ocache $(OCACHE_VERSION) for $(OCACHE_OS)-$(OCACHE_ARCH)..."; \
-		curl -fsSL "$(OCACHE_RELEASES_URL)/$(OCACHE_VERSION)/$(OCACHE_BINARY)-$(OCACHE_OS)-$(OCACHE_ARCH)" -o $(OCACHE_BIN_DIR)/$(OCACHE_BINARY) && \
-		chmod +x $(OCACHE_BIN_DIR)/$(OCACHE_BINARY); \
+		curl -fsSL "$(OCACHE_RELEASES_URL)/$(OCACHE_VERSION)/$(OCACHE_BINARY)-$(OCACHE_OS)-$(OCACHE_ARCH)" -o $(OCACHE_BIN_PATH) && \
+		chmod +x $(OCACHE_BIN_PATH); \
 	fi
 	@mkdir -p $(OCACHE_DATA_DIR)
 	@echo "Starting ocache locally..."
-	@$(OCACHE_BIN_DIR)/$(OCACHE_BINARY) -disk=$(OCACHE_DATA_DIR) -listen-addr=:9000 -listen-http=:9001 &
+	@$(OCACHE_BIN_PATH) -disk=$(OCACHE_DATA_DIR) -listen-addr=:9000 -listen-http=:9001 &
 	@echo "Waiting for ocache to be ready..."
 	@timeout 30 bash -c 'until curl -s http://localhost:9001/health > /dev/null 2>&1; do sleep 1; done' || \
 		(echo "ocache failed to start"; exit 1)
@@ -311,7 +312,7 @@ s3-bench-local: build
 s3-bench-local-down:
 	@echo "Stopping S3 bench infrastructure (local mode)..."
 	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
-	-@pkill -f "$(OCACHE_BIN_DIR)/$(OCACHE_BINARY)" 2>/dev/null || true
+	-@pkill -f "$(OCACHE_BIN_PATH)" 2>/dev/null || true
 	@echo "Cleaning up ocache data directory..."
 	-@rm -rf $(OCACHE_DATA_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,17 @@
 BINARY_NAME := tag
 CMD_PATH := ./cmd/tag
 
+# ocache binary configuration for s3-bench-local
+OCACHE_VERSION ?= v1.2.2
+OCACHE_BINARY := ocache
+OCACHE_BIN_DIR := .bin
+OCACHE_RELEASES_URL := https://ocache-releases.t3.storage.dev
+OCACHE_DATA_DIR := /tmp/ocache-bench-data
+
+# Detect OS and architecture for ocache binary download
+OCACHE_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+OCACHE_ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+
 # Allow specifying specific tests with TEST variable (e.g., make test TEST=TestMyFunction)
 # or with TESTRUN for pattern matching (e.g., make test TESTRUN=MyFunction)
 TEST ?=
@@ -189,6 +200,8 @@ help:
 	@echo "S3 compatibility test targets:"
 	@echo "  s3-test-local      - Start local S3 test env (TAG on host, ocache in Docker)"
 	@echo "  s3-test-local-down - Stop local S3 test environment"
+	@echo "  s3-bench-local     - Start local S3 bench env (TAG + ocache binaries on host)"
+	@echo "  s3-bench-local-down - Stop local S3 bench environment"
 	@echo "  s3-tests           - Run S3 compatibility tests (ceph s3-tests)"
 	@echo "  s3-tests-clean     - Remove cloned s3-tests repository"
 	@echo ""
@@ -259,6 +272,48 @@ s3-test-local-down:
 	@echo "Stopping S3 test infrastructure (local mode)..."
 	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
 	$(S3_TEST_COMPOSE) down -v
+
+# Local benchmarking: Run both TAG and ocache binaries on host (no Docker)
+.PHONY: s3-bench-local
+s3-bench-local: build
+	@echo "Starting S3 bench infrastructure (local mode, no Docker)..."
+	@if [ -z "$$AWS_ACCESS_KEY_ID" ] || [ -z "$$AWS_SECRET_ACCESS_KEY" ]; then \
+		echo "Error: AWS credentials not set."; \
+		echo "  export AWS_ACCESS_KEY_ID=<your-key>"; \
+		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
+		exit 1; \
+	fi
+	@mkdir -p $(OCACHE_BIN_DIR)
+	@if [ ! -x $(OCACHE_BIN_DIR)/$(OCACHE_BINARY) ]; then \
+		echo "Downloading ocache $(OCACHE_VERSION) for $(OCACHE_OS)-$(OCACHE_ARCH)..."; \
+		curl -fsSL "$(OCACHE_RELEASES_URL)/$(OCACHE_VERSION)/$(OCACHE_BINARY)-$(OCACHE_OS)-$(OCACHE_ARCH)" -o $(OCACHE_BIN_DIR)/$(OCACHE_BINARY) && \
+		chmod +x $(OCACHE_BIN_DIR)/$(OCACHE_BINARY); \
+	fi
+	@mkdir -p $(OCACHE_DATA_DIR)
+	@echo "Starting ocache locally..."
+	@$(OCACHE_BIN_DIR)/$(OCACHE_BINARY) -disk=$(OCACHE_DATA_DIR) -listen-addr=:9000 -listen-http=:9001 &
+	@echo "Waiting for ocache to be ready..."
+	@timeout 30 bash -c 'until curl -s http://localhost:9001/health > /dev/null 2>&1; do sleep 1; done' || \
+		(echo "ocache failed to start"; exit 1)
+	@echo "ocache is ready at http://localhost:9000"
+	@echo "Starting TAG locally..."
+	@TAG_UPSTREAM_ENDPOINT=$${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev} \
+		TAG_OCACHE_ENDPOINTS=localhost:9000 \
+		TAG_LOG_LEVEL=$${TAG_LOG_LEVEL:-info} \
+		TAG_PPROF_ENABLED=true \
+		./$(BINARY_NAME) &
+	@echo "Waiting for TAG to be ready..."
+	@timeout 30 bash -c 'until curl -s http://localhost:8080/health > /dev/null 2>&1; do sleep 1; done' || \
+		(echo "TAG failed to start"; exit 1)
+	@echo "TAG is ready at http://localhost:8080"
+
+.PHONY: s3-bench-local-down
+s3-bench-local-down:
+	@echo "Stopping S3 bench infrastructure (local mode)..."
+	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
+	-@pkill -f "$(OCACHE_BIN_DIR)/$(OCACHE_BINARY)" 2>/dev/null || true
+	@echo "Cleaning up ocache data directory..."
+	-@rm -rf $(OCACHE_DATA_DIR)
 
 .PHONY: s3-tests
 s3-tests:

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,11 @@ s3-bench-local: build
 		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
 		exit 1; \
 	fi
+	@# Stop any existing processes on the required ports
+	-@lsof -ti:9000 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9001 | xargs kill 2>/dev/null || true
+	-@lsof -ti:8080 | xargs kill 2>/dev/null || true
+	@sleep 1
 	@mkdir -p $(OCACHE_BIN_DIR)
 	@if [ ! -x $(OCACHE_BIN_PATH) ]; then \
 		echo "Downloading ocache $(OCACHE_VERSION) for $(OCACHE_OS)-$(OCACHE_ARCH)..."; \
@@ -311,8 +316,9 @@ s3-bench-local: build
 .PHONY: s3-bench-local-down
 s3-bench-local-down:
 	@echo "Stopping S3 bench infrastructure (local mode)..."
-	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
-	-@pkill -f "$(OCACHE_BIN_PATH)" 2>/dev/null || true
+	-@lsof -ti:8080 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9000 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9001 | xargs kill 2>/dev/null || true
 	@echo "Cleaning up ocache data directory..."
 	-@rm -rf $(OCACHE_DATA_DIR)
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -267,6 +267,35 @@ func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectM
 	return meta, true, nil
 }
 
+// GetBodyStream streams the cached object body directly to the provided writer.
+// This avoids buffering the entire object in memory, which is critical for large objects.
+// Use this after GetMeta() to stream the body directly to the HTTP response.
+// Returns ErrNotFound if the body is not in cache.
+func (c *Cache) GetBodyStream(ctx context.Context, bucket, key string, w io.Writer) error {
+	if !c.IsEnabled() {
+		return ErrCacheDisabled
+	}
+
+	bodyKey := MakeBodyKey(bucket, key)
+
+	// Stream body directly to writer - no intermediate buffer
+	err := c.client.GetStream(ctx, bodyKey, w)
+	if err != nil {
+		if isNotFoundError(err) {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
+			return ErrNotFound
+		}
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
+		return err
+	}
+
+	log.Debug().
+		Str("bucket", bucket).
+		Str("key", key).
+		Msg("Cache hit (body streamed)")
+	return nil
+}
+
 // DeleteWithMeta removes both metadata and body from cache.
 func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	if !c.IsEnabled() {

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -58,16 +58,10 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 	// 2. Check cache (fast path) - now also works for range requests!
 	// For range requests: check if full object is in cache, then serve range from it.
+	// Uses two-phase approach: GetMeta first, then GetBodyStream for direct streaming.
 	if !noCacheRead && s.cache.IsEnabled() {
-		meta, bodyReader, found, cacheErr := s.cache.GetWithMeta(ctx, bucket, key)
+		meta, found, cacheErr := s.cache.GetMeta(ctx, bucket, key)
 		if cacheErr == nil && found && meta != nil {
-			// Close body reader if we got one (we may serve range instead)
-			if bodyReader != nil {
-				if closer, ok := bodyReader.(io.Closer); ok {
-					defer closer.Close()
-				}
-			}
-
 			// If this is a Range request and we have the full object cached,
 			// serve the range from the cached object
 			if rangeHeader != "" {
@@ -100,17 +94,21 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			}
 
 			// Serve full response from cache with proper headers
+			// Stream body directly to response writer - no intermediate buffer!
 			metrics.RecordCacheHit()
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata")
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata (direct stream)")
 			meta.WriteHeaders(w)
 			w.Header().Set(XCacheHeader, XCacheHit)
 			w.WriteHeader(meta.StatusCode)
-			if bodyReader != nil {
-				n, copyErr := io.Copy(w, bodyReader)
-				metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
-				if copyErr != nil {
-					log.Warn().Err(copyErr).Msg("Failed to copy cached content to response")
-				}
+
+			// Use counting writer to track bytes transferred
+			cw := &countingWriter{w: w}
+			streamErr := s.cache.GetBodyStream(ctx, bucket, key, cw)
+			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+
+			if streamErr != nil {
+				// Headers already sent, log warning but don't return error to client
+				log.Warn().Err(streamErr).Str("bucket", bucket).Str("key", key).Msg("Failed to stream cached content to response")
 			}
 			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
 			return nil

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -94,7 +94,18 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			}
 
 			// Serve full response from cache with proper headers
-			// Use io.Pipe to verify body exists BEFORE writing headers (avoid corrupt responses)
+			// Handle zero-byte objects directly (no body to verify)
+			if meta.ContentLength == 0 {
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving zero-byte object from cache")
+				meta.WriteHeaders(w)
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(meta.StatusCode)
+				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				return nil
+			}
+
+			// Non-zero object: use io.Pipe to verify body exists BEFORE writing headers
 			pr, pw := io.Pipe()
 			go func() {
 				err := s.cache.GetBodyStream(ctx, bucket, key, pw)

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -94,24 +94,43 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			}
 
 			// Serve full response from cache with proper headers
-			// Stream body directly to response writer - no intermediate buffer!
-			metrics.RecordCacheHit()
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata (direct stream)")
-			meta.WriteHeaders(w)
-			w.Header().Set(XCacheHeader, XCacheHit)
-			w.WriteHeader(meta.StatusCode)
+			// Use io.Pipe to verify body exists BEFORE writing headers (avoid corrupt responses)
+			pr, pw := io.Pipe()
+			go func() {
+				err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+				if err != nil {
+					pw.CloseWithError(err)
+				} else {
+					pw.Close()
+				}
+			}()
 
-			// Use counting writer to track bytes transferred
-			cw := &countingWriter{w: w}
-			streamErr := s.cache.GetBodyStream(ctx, bucket, key, cw)
-			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+			// Read first byte to verify body exists before committing headers
+			firstByte := make([]byte, 1)
+			n, readErr := pr.Read(firstByte)
+			if readErr != nil {
+				// Body missing or error - close pipe and fall through to upstream
+				pr.Close()
+				log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).Msg("Cache body missing, falling back to upstream")
+				// Fall through to cache miss handling below
+			} else {
+				// Body verified - safe to write headers and stream
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata (verified stream)")
+				meta.WriteHeaders(w)
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(meta.StatusCode)
 
-			if streamErr != nil {
-				// Headers already sent, log warning but don't return error to client
-				log.Warn().Err(streamErr).Str("bucket", bucket).Str("key", key).Msg("Failed to stream cached content to response")
+				// Write first byte and stream the rest
+				cw := &countingWriter{w: w}
+				cw.Write(firstByte[:n])
+				io.Copy(cw, pr)
+				pr.Close()
+
+				metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				return nil
 			}
-			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-			return nil
 		}
 		metrics.RecordCacheMiss()
 	}


### PR DESCRIPTION
## Summary
Add `s3-bench-local` and `s3-bench-local-down` make targets for running TAG and ocache binaries directly on the host machine without Docker. The ocache binary is automatically downloaded from the Tigris releases bucket to the `.bin/` directory.

## Key Features
- Automatic platform detection (darwin/linux, arm64/amd64)
- Automatic binary download from `https://ocache-releases.t3.storage.dev`
- Configurable ocache version via `OCACHE_VERSION` environment variable
- Health checks for both ocache and TAG services
- Clean shutdown with data directory cleanup

## Usage
```bash
export AWS_ACCESS_KEY_ID=<your-key>
export AWS_SECRET_ACCESS_KEY=<your-secret>
make s3-bench-local      # Start services
make s3-tests            # Run S3 compatibility tests
make s3-bench-local-down # Stop services
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces local S3 benchmarking targets and refactors cache read path to stream bodies without buffering.
> 
> - **Makefile**: Adds `s3-bench-local`/`s3-bench-local-down` to run TAG + `ocache` binaries on host with auto platform detection, binary download to `.bin/`, health checks, port cleanup, and data dir cleanup; updates help. Adds `.bin/` to `.gitignore`.
> - **cache**: Adds `GetBodyStream(ctx, bucket, key, w)` to stream body directly from ocache; keeps existing meta/body split API.
> - **proxy/get_object**: Replaces `GetWithMeta` usage with two-phase `GetMeta` then `GetBodyStream`; verifies body availability via `io.Pipe` before writing headers; optimizes zero-byte objects; preserves range-cache flow (`serveRangeFromCache`, background fetch on miss) and metrics updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977f9ecf412d7496e90161e6c02b1c3cc0590bbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->