### PR TITLE
Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Go build artifacts
 /tag
 
+# Downloaded binaries for local benchmarking
+.bin/
+
 # S3 compatibility tests (cloned repo, venv, and generated config with credentials)
 tests/s3compat/s3-tests/
 tests/s3compat/.venv/

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ s3-test-local: build
 	@TAG_UPSTREAM_ENDPOINT=$${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev} \
 		TAG_OCACHE_ENDPOINTS=localhost:9000 \
 		TAG_LOG_LEVEL=$${TAG_LOG_LEVEL:-debug} \
+		TAG_PPROF_ENABLED=true \
 		./$(BINARY_NAME) &
 	@echo "Waiting for TAG to be ready..."
 	@timeout 30 bash -c 'until curl -s http://localhost:8080/health > /dev/null 2>&1; do sleep 1; done' || \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,18 @@
 BINARY_NAME := tag
 CMD_PATH := ./cmd/tag
 
+# ocache binary configuration for s3-bench-local
+OCACHE_VERSION ?= v1.2.2
+OCACHE_BINARY := ocache
+OCACHE_BIN_DIR := .bin
+OCACHE_BIN_PATH := $(OCACHE_BIN_DIR)/$(OCACHE_BINARY)-$(OCACHE_VERSION)
+OCACHE_RELEASES_URL := https://ocache-releases.t3.storage.dev
+OCACHE_DATA_DIR := /tmp/ocache-bench-data
+
+# Detect OS and architecture for ocache binary download
+OCACHE_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+OCACHE_ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+
 # Allow specifying specific tests with TEST variable (e.g., make test TEST=TestMyFunction)
 # or with TESTRUN for pattern matching (e.g., make test TESTRUN=MyFunction)
 TEST ?=
@@ -189,6 +201,8 @@ help:
 	@echo "S3 compatibility test targets:"
 	@echo "  s3-test-local      - Start local S3 test env (TAG on host, ocache in Docker)"
 	@echo "  s3-test-local-down - Stop local S3 test environment"
+	@echo "  s3-bench-local     - Start local S3 bench env (TAG + ocache binaries on host)"
+	@echo "  s3-bench-local-down - Stop local S3 bench environment"
 	@echo "  s3-tests           - Run S3 compatibility tests (ceph s3-tests)"
 	@echo "  s3-tests-clean     - Remove cloned s3-tests repository"
 	@echo ""
@@ -259,6 +273,54 @@ s3-test-local-down:
 	@echo "Stopping S3 test infrastructure (local mode)..."
 	-@pkill -f "./$(BINARY_NAME)" 2>/dev/null || true
 	$(S3_TEST_COMPOSE) down -v
+
+# Local benchmarking: Run both TAG and ocache binaries on host (no Docker)
+.PHONY: s3-bench-local
+s3-bench-local: build
+	@echo "Starting S3 bench infrastructure (local mode, no Docker)..."
+	@if [ -z "$$AWS_ACCESS_KEY_ID" ] || [ -z "$$AWS_SECRET_ACCESS_KEY" ]; then \
+		echo "Error: AWS credentials not set."; \
+		echo "  export AWS_ACCESS_KEY_ID=<your-key>"; \
+		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
+		exit 1; \
+	fi
+	@# Stop any existing processes on the required ports
+	-@lsof -ti:9000 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9001 | xargs kill 2>/dev/null || true
+	-@lsof -ti:8080 | xargs kill 2>/dev/null || true
+	@sleep 1
+	@mkdir -p $(OCACHE_BIN_DIR)
+	@if [ ! -x $(OCACHE_BIN_PATH) ]; then \
+		echo "Downloading ocache $(OCACHE_VERSION) for $(OCACHE_OS)-$(OCACHE_ARCH)..."; \
+		curl -fsSL "$(OCACHE_RELEASES_URL)/$(OCACHE_VERSION)/$(OCACHE_BINARY)-$(OCACHE_OS)-$(OCACHE_ARCH)" -o $(OCACHE_BIN_PATH) && \
+		chmod +x $(OCACHE_BIN_PATH); \
+	fi
+	@mkdir -p $(OCACHE_DATA_DIR)
+	@echo "Starting ocache locally..."
+	@$(OCACHE_BIN_PATH) -disk=$(OCACHE_DATA_DIR) -listen-addr=:9000 -listen-http=:9001 &
+	@echo "Waiting for ocache to be ready..."
+	@timeout 30 bash -c 'until curl -s http://localhost:9001/health > /dev/null 2>&1; do sleep 1; done' || \
+		(echo "ocache failed to start"; exit 1)
+	@echo "ocache is ready at http://localhost:9000"
+	@echo "Starting TAG locally..."
+	@TAG_UPSTREAM_ENDPOINT=$${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev} \
+		TAG_OCACHE_ENDPOINTS=localhost:9000 \
+		TAG_LOG_LEVEL=$${TAG_LOG_LEVEL:-info} \
+		TAG_PPROF_ENABLED=true \
+		./$(BINARY_NAME) &
+	@echo "Waiting for TAG to be ready..."
+	@timeout 30 bash -c 'until curl -s http://localhost:8080/health > /dev/null 2>&1; do sleep 1; done' || \
+		(echo "TAG failed to start"; exit 1)
+	@echo "TAG is ready at http://localhost:8080"
+
+.PHONY: s3-bench-local-down
+s3-bench-local-down:
+	@echo "Stopping S3 bench infrastructure (local mode)..."
+	-@lsof -ti:8080 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9000 | xargs kill 2>/dev/null || true
+	-@lsof -ti:9001 | xargs kill 2>/dev/null || true
+	@echo "Cleaning up ocache data directory..."
+	-@rm -rf $(OCACHE_DATA_DIR)
 
 .PHONY: s3-tests
 s3-tests:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ See [docs/deployment.md](docs/deployment.md) for complete deployment guide inclu
 
 TAG supports all S3 API endpoints supported by Tigris, including bucket operations, object operations, multipart uploads, and more. See the [Tigris S3 API documentation](https://www.tigrisdata.com/docs/api/s3/) for the complete list of supported operations.
 
+### S3 Addressing Style
+
+TAG supports **path-style** S3 access only. Virtual-hosted style requests are not supported.
+
+| Style | URL Format | Supported |
+|-------|------------|-----------|
+| Path-style | `http://localhost:8080/bucket/key` | Yes |
+| Virtual-hosted | `http://bucket.localhost:8080/key` | No |
+
+When configuring S3 clients, ensure path-style addressing is enabled. See [docs/usage.md](docs/usage.md) for SDK-specific configuration.
+
 ### Response Headers
 
 | Header | Description |

--- a/auth/parser.go
+++ b/auth/parser.go
@@ -20,6 +20,15 @@ var (
 	// credentialRegex extracts the access key from AWS SigV4 Authorization header.
 	// Format: AWS4-HMAC-SHA256 Credential=<access_key>/<date>/<region>/<service>/aws4_request, ...
 	credentialRegex = regexp.MustCompile(`Credential=([^/]+)/`)
+
+	// scopeRegex extracts the full credential scope from Authorization header.
+	scopeRegex = regexp.MustCompile(`Credential=([^,]+)`)
+
+	// signedHeadersRegex extracts the SignedHeaders from Authorization header.
+	signedHeadersRegex = regexp.MustCompile(`SignedHeaders=([^,]+)`)
+
+	// signatureRegex extracts the Signature from Authorization header.
+	signatureRegex = regexp.MustCompile(`Signature=([a-f0-9]+)`)
 )
 
 // AuthInfo contains parsed authentication information from a request.
@@ -108,7 +117,6 @@ func parseFromHeader(auth string) (*AuthInfo, error) {
 	info.AccessKey = credMatch[1]
 
 	// Extract full credential scope to get region and date
-	scopeRegex := regexp.MustCompile(`Credential=([^,]+)`)
 	scopeMatch := scopeRegex.FindStringSubmatch(auth)
 	if len(scopeMatch) >= 2 {
 		parts := strings.Split(scopeMatch[1], "/")
@@ -119,15 +127,13 @@ func parseFromHeader(auth string) (*AuthInfo, error) {
 	}
 
 	// Extract SignedHeaders
-	headersRegex := regexp.MustCompile(`SignedHeaders=([^,]+)`)
-	headersMatch := headersRegex.FindStringSubmatch(auth)
+	headersMatch := signedHeadersRegex.FindStringSubmatch(auth)
 	if len(headersMatch) >= 2 {
 		info.SignedHeaders = strings.Split(headersMatch[1], ";")
 	}
 
 	// Extract Signature
-	sigRegex := regexp.MustCompile(`Signature=([a-f0-9]+)`)
-	sigMatch := sigRegex.FindStringSubmatch(auth)
+	sigMatch := signatureRegex.FindStringSubmatch(auth)
 	if len(sigMatch) >= 2 {
 		info.Signature = sigMatch[1]
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -267,6 +267,35 @@ func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectM
 	return meta, true, nil
 }
 
+// GetBodyStream streams the cached object body directly to the provided writer.
+// This avoids buffering the entire object in memory, which is critical for large objects.
+// Use this after GetMeta() to stream the body directly to the HTTP response.
+// Returns ErrNotFound if the body is not in cache.
+func (c *Cache) GetBodyStream(ctx context.Context, bucket, key string, w io.Writer) error {
+	if !c.IsEnabled() {
+		return ErrCacheDisabled
+	}
+
+	bodyKey := MakeBodyKey(bucket, key)
+
+	// Stream body directly to writer - no intermediate buffer
+	err := c.client.GetStream(ctx, bodyKey, w)
+	if err != nil {
+		if isNotFoundError(err) {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
+			return ErrNotFound
+		}
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
+		return err
+	}
+
+	log.Debug().
+		Str("bucket", bucket).
+		Str("key", key).
+		Msg("Cache hit (body streamed)")
+	return nil
+}
+
 // DeleteWithMeta removes both metadata and body from cache.
 func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	if !c.IsEnabled() {

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -26,23 +26,27 @@ func main() {
 	disableCache := flag.Bool("disable-cache", false, "Disable caching (pass-through mode)")
 	flag.Parse()
 
-	// Initialize logger
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-
-	// Load configuration
+	// Load configuration first (before setting up logger, so we can use log format from config)
 	var cfg *config.Config
 	var err error
 
 	if *configPath != "" {
 		cfg, err = config.Load(*configPath)
 		if err != nil {
+			// Use console writer for startup errors since config isn't loaded yet
+			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 			log.Fatal().Err(err).Str("path", *configPath).Msg("Failed to load configuration")
 		}
 	} else {
 		cfg = config.NewDefault()
-		log.Info().Msg("Using default configuration")
 	}
+
+	// Initialize logger based on configuration
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	if cfg.Log.Format == "console" {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
+	// Default is JSON format (zerolog's default), which is much faster
 
 	// Set log level
 	switch cfg.Log.Level {
@@ -54,6 +58,10 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+
+	if *configPath == "" {
+		log.Info().Msg("Using default configuration")
 	}
 
 	// Override cache enabled from command line flag
@@ -109,7 +117,7 @@ func main() {
 	service := proxy.NewService(forwarder, objectCache, cfg)
 
 	// 5. Initialize HTTP server
-	server := handlers.NewServer(service, cfg.Server.BindIP, cfg.Server.HTTPPort)
+	server := handlers.NewServer(service, cfg.Server.BindIP, cfg.Server.HTTPPort, cfg.Server.PprofEnabled)
 
 	// Start HTTP server in goroutine
 	go func() {

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,10 @@ const (
 	// DefaultLogLevel is the default log level.
 	DefaultLogLevel = "info"
 
+	// DefaultLogFormat is the default log format.
+	// Use "json" for production (fast) or "console" for development (human-readable).
+	DefaultLogFormat = "json"
+
 	// DefaultBroadcastChunkSize is the default chunk size for streaming (64KB).
 	DefaultBroadcastChunkSize = 64 * 1024
 
@@ -51,8 +55,9 @@ type Config struct {
 
 // ServerConfig holds HTTP server configuration.
 type ServerConfig struct {
-	HTTPPort int    `yaml:"http_port"` // S3 API port (default: 8080)
-	BindIP   string `yaml:"bind_ip"`   // Bind address (default: 0.0.0.0)
+	HTTPPort     int    `yaml:"http_port"`     // S3 API port (default: 8080)
+	BindIP       string `yaml:"bind_ip"`       // Bind address (default: 0.0.0.0)
+	PprofEnabled bool   `yaml:"pprof_enabled"` // Enable pprof endpoints (default: false)
 }
 
 // UpstreamConfig holds Tigris endpoint configuration.
@@ -83,7 +88,8 @@ type BroadcastConfig struct {
 
 // LogConfig holds logging configuration.
 type LogConfig struct {
-	Level string `yaml:"level"` // Log level: debug, info, warn, error
+	Level  string `yaml:"level"`  // Log level: debug, info, warn, error
+	Format string `yaml:"format"` // Log format: json (default, fast) or console (human-readable)
 }
 
 // Load reads configuration from a YAML file.
@@ -124,6 +130,8 @@ func applyDefaults(cfg *Config) {
 	if cfg.Server.BindIP == "" {
 		cfg.Server.BindIP = DefaultBindIP
 	}
+	// PprofEnabled defaults to false (disabled for security)
+	// Use TAG_PPROF_ENABLED=true to enable
 
 	// Upstream defaults
 	if cfg.Upstream.Endpoint == "" {
@@ -157,6 +165,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Log.Level == "" {
 		cfg.Log.Level = DefaultLogLevel
 	}
+	if cfg.Log.Format == "" {
+		cfg.Log.Format = DefaultLogFormat
+	}
 }
 
 // applyEnvOverrides applies environment variable overrides to configuration.
@@ -185,6 +196,16 @@ func applyEnvOverrides(cfg *Config) {
 	// Override log level from environment
 	if logLevel := os.Getenv("TAG_LOG_LEVEL"); logLevel != "" {
 		cfg.Log.Level = logLevel
+	}
+
+	// Override log format from environment (json or console)
+	if logFormat := os.Getenv("TAG_LOG_FORMAT"); logFormat != "" {
+		cfg.Log.Format = logFormat
+	}
+
+	// Enable pprof from environment (disabled by default for security)
+	if enabled := os.Getenv("TAG_PPROF_ENABLED"); enabled == "true" || enabled == "1" {
+		cfg.Server.PprofEnabled = true
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_OCACHE_ENDPOINTS` | Comma-separated ocache endpoints | (none) |
 | `TAG_CACHE_DISABLED` | Disable caching (`true` or `1`) | `false` |
 | `TAG_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
+| `TAG_LOG_FORMAT` | Log format: `json` or `console` | `json` |
+| `TAG_PPROF_ENABLED` | Enable pprof endpoints (`true` or `1`) | `false` |
 
 ## Configuration File
 
@@ -33,6 +35,10 @@ server:
   # IP address to bind to
   # Default: "0.0.0.0" (all interfaces)
   bind_ip: "0.0.0.0"
+
+  # Enable pprof profiling endpoints
+  # Default: false (disabled for security)
+  pprof_enabled: false
 
 # Upstream Tigris configuration
 upstream:
@@ -82,6 +88,10 @@ log:
   # Log level: debug, info, warn, error
   # Default: "info"
   level: "info"
+
+  # Log format: json (fast) or console (human-readable)
+  # Default: "json"
+  format: "json"
 ```
 
 ## Configuration Sections
@@ -94,6 +104,7 @@ Controls the HTTP server settings.
 |-------|------|---------|-------------|
 | `http_port` | int | `8080` | Port for the S3 API |
 | `bind_ip` | string | `"0.0.0.0"` | IP address to bind to |
+| `pprof_enabled` | bool | `false` | Enable pprof profiling endpoints |
 
 ### Upstream
 
@@ -153,12 +164,34 @@ Controls logging output.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `level` | string | `"info"` | Log level |
+| `format` | string | `"json"` | Log format: `json` or `console` |
 
 **Log Levels:**
 - `debug` - Verbose debugging information
 - `info` - Normal operation messages
 - `warn` - Warning conditions
 - `error` - Error conditions only
+
+### Profiling
+
+TAG exposes pprof endpoints for performance profiling when enabled. **Disabled by default** for security (exposes runtime internals).
+
+```bash
+# Enable pprof
+TAG_PPROF_ENABLED=true ./tag
+```
+
+**Endpoints** (when enabled):
+- `/debug/pprof/` - Index
+- `/debug/pprof/profile?seconds=30` - CPU profile
+- `/debug/pprof/heap` - Heap profile
+- `/debug/pprof/goroutine` - Goroutine stacks
+
+**Usage with go tool pprof:**
+```bash
+go tool pprof http://localhost:8080/debug/pprof/profile?seconds=30
+go tool pprof http://localhost:8080/debug/pprof/heap
+```
 
 ## Example Configurations
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,13 +96,15 @@ pip install boto3
 
 ```python
 import boto3
+from botocore.config import Config
 
-# Create S3 client with TAG endpoint
+# Create S3 client with TAG endpoint (path-style required)
 s3 = boto3.client(
     's3',
     endpoint_url='http://localhost:8080',
     aws_access_key_id='your_access_key',
     aws_secret_access_key='your_secret_key',
+    config=Config(s3={'addressing_style': 'path'}),
 )
 ```
 
@@ -110,6 +112,7 @@ s3 = boto3.client(
 
 ```python
 import boto3
+from botocore.config import Config
 import os
 
 # Credentials from environment variables
@@ -118,6 +121,7 @@ import os
 s3 = boto3.client(
     's3',
     endpoint_url=os.getenv('TAG_ENDPOINT', 'http://localhost:8080'),
+    config=Config(s3={'addressing_style': 'path'}),
 )
 ```
 
@@ -179,13 +183,15 @@ print(f"Last Modified: {response['LastModified']}")
 
 ```python
 import boto3
+from botocore.config import Config
 
-# Create S3 resource
+# Create S3 resource (path-style required)
 s3 = boto3.resource(
     's3',
     endpoint_url='http://localhost:8080',
     aws_access_key_id='your_access_key',
     aws_secret_access_key='your_secret_key',
+    config=Config(s3={'addressing_style': 'path'}),
 )
 
 # Get bucket
@@ -270,7 +276,21 @@ from botocore.config import Config
 config = Config(
     connect_timeout=30,
     read_timeout=300,
+    s3={'addressing_style': 'path'},
 )
 
 s3 = boto3.client('s3', endpoint_url='http://localhost:8080', config=config)
 ```
+
+### 405 Method Not Allowed on CreateBucket
+
+If you receive a 405 error when creating buckets, ensure path-style addressing is configured:
+
+```python
+from botocore.config import Config
+
+config = Config(s3={'addressing_style': 'path'})
+s3 = boto3.client('s3', endpoint_url='http://localhost:8080', config=config)
+```
+
+TAG does not support virtual-hosted style requests (e.g., `bucket.localhost:8080`).

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,17 +19,19 @@ import (
 
 // Server is the HTTP server for S3-compatible API.
 type Server struct {
-	service    *proxy.Service
-	router     *mux.Router
-	httpServer *http.Server
-	bindAddr   string
+	service      *proxy.Service
+	router       *mux.Router
+	httpServer   *http.Server
+	bindAddr     string
+	pprofEnabled bool
 }
 
 // NewServer creates a new HTTP server.
-func NewServer(service *proxy.Service, bindIP string, port int) *Server {
+func NewServer(service *proxy.Service, bindIP string, port int, pprofEnabled bool) *Server {
 	s := &Server{
-		service:  service,
-		bindAddr: fmt.Sprintf("%s:%d", bindIP, port),
+		service:      service,
+		bindAddr:     fmt.Sprintf("%s:%d", bindIP, port),
+		pprofEnabled: pprofEnabled,
 	}
 
 	s.router = s.setupRouter()
@@ -57,6 +60,22 @@ func (s *Server) setupRouter() *mux.Router {
 
 	// Metrics endpoint for Prometheus
 	r.Handle("/metrics", promhttp.Handler()).Methods("GET")
+
+	// pprof endpoints for profiling (if enabled)
+	if s.pprofEnabled {
+		r.HandleFunc("/debug/pprof/", pprof.Index)
+		r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		r.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		r.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		r.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		r.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+		r.Handle("/debug/pprof/block", pprof.Handler("block"))
+		r.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+		r.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		log.Info().Msg("pprof endpoints enabled at /debug/pprof/")
+	}
 
 	// S3 API routes - path style
 	// The order matters - more specific routes should come first

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -58,16 +58,10 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 	// 2. Check cache (fast path) - now also works for range requests!
 	// For range requests: check if full object is in cache, then serve range from it.
+	// Uses two-phase approach: GetMeta first, then GetBodyStream for direct streaming.
 	if !noCacheRead && s.cache.IsEnabled() {
-		meta, bodyReader, found, cacheErr := s.cache.GetWithMeta(ctx, bucket, key)
+		meta, found, cacheErr := s.cache.GetMeta(ctx, bucket, key)
 		if cacheErr == nil && found && meta != nil {
-			// Close body reader if we got one (we may serve range instead)
-			if bodyReader != nil {
-				if closer, ok := bodyReader.(io.Closer); ok {
-					defer closer.Close()
-				}
-			}
-
 			// If this is a Range request and we have the full object cached,
 			// serve the range from the cached object
 			if rangeHeader != "" {
@@ -100,20 +94,54 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			}
 
 			// Serve full response from cache with proper headers
-			metrics.RecordCacheHit()
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata")
-			meta.WriteHeaders(w)
-			w.Header().Set(XCacheHeader, XCacheHit)
-			w.WriteHeader(meta.StatusCode)
-			if bodyReader != nil {
-				n, copyErr := io.Copy(w, bodyReader)
-				metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
-				if copyErr != nil {
-					log.Warn().Err(copyErr).Msg("Failed to copy cached content to response")
-				}
+			// Handle zero-byte objects directly (no body to verify)
+			if meta.ContentLength == 0 {
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving zero-byte object from cache")
+				meta.WriteHeaders(w)
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(meta.StatusCode)
+				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				return nil
 			}
-			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-			return nil
+
+			// Non-zero object: use io.Pipe to verify body exists BEFORE writing headers
+			pr, pw := io.Pipe()
+			go func() {
+				err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+				if err != nil {
+					pw.CloseWithError(err)
+				} else {
+					pw.Close()
+				}
+			}()
+
+			// Read first byte to verify body exists before committing headers
+			firstByte := make([]byte, 1)
+			n, readErr := pr.Read(firstByte)
+			if readErr != nil {
+				// Body missing or error - close pipe and fall through to upstream
+				pr.Close()
+				log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).Msg("Cache body missing, falling back to upstream")
+				// Fall through to cache miss handling below
+			} else {
+				// Body verified - safe to write headers and stream
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata (verified stream)")
+				meta.WriteHeaders(w)
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(meta.StatusCode)
+
+				// Write first byte and stream the rest
+				cw := &countingWriter{w: w}
+				cw.Write(firstByte[:n])
+				io.Copy(cw, pr)
+				pr.Close()
+
+				metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				return nil
+			}
 		}
 		metrics.RecordCacheMiss()
 	}

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -290,7 +290,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	xCacheTracker := NewXCacheTracker()
 
 	// Create TAG server with X-Cache tracking middleware
-	server := handlers.NewServer(service, "127.0.0.1", 0)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 	tagServer := httptest.NewServer(wrappedRouter)
 
@@ -348,7 +348,7 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	xCacheTracker := NewXCacheTracker()
 
 	// Create TAG server with X-Cache tracking middleware
-	server := handlers.NewServer(service, "127.0.0.1", 0)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 	tagServer := httptest.NewServer(wrappedRouter)
 

--- a/tests/s3compat/docker-compose.yml
+++ b/tests/s3compat/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
       - TAG_OCACHE_ENDPOINTS=ocache:9000
       - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-debug}
+      - TAG_PPROF_ENABLED=true
     depends_on:
       ocache:
         condition: service_healthy


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Highlights**
> 
> - Cache/Proxy: Serve objects from cache via streaming without buffering entire bodies (`cache.GetBodyStream`) and update `GetObject` to use meta-first + verified stream; improves large object handling and keeps range-from-cache support.
> - Server/Config: Optional pprof endpoints behind `server.pprof_enabled`/`TAG_PPROF_ENABLED`; add `log.format` (`json`/`console`) and env override `TAG_LOG_FORMAT`; logger now configured after loading config.
> 
> **Tooling & tests**
> 
> - Makefile: New `s3-bench-local`/`s3-bench-local-down` targets that download `ocache` locally; `.bin/` ignored in `.gitignore`.
> - Tests/compose: Update `NewServer` signature with pprof flag; enable pprof in s3-compat compose.
> 
> **Docs**
> 
> - Add path-style–only S3 addressing guidance and boto3 examples; document profiling endpoints and log format options in `docs/configuration.md` and `docs/usage.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a50093489dc05e9b49aea4e5431fcdf1cd9fe596. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->