### PR TITLE
docs: add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,193 @@
+TIGRIS DATA, INC.
+END-USER LICENSE AGREEMENT
+
+Copyright (c) 2026 Tigris Data, Inc. All Rights Reserved.
+
+IMPORTANT: PLEASE READ THIS END-USER LICENSE AGREEMENT ("AGREEMENT") CAREFULLY
+BEFORE USING THE SOFTWARE. BY DOWNLOADING, INSTALLING, COPYING, OR OTHERWISE
+USING THE SOFTWARE, YOU AGREE TO BE BOUND BY THE TERMS OF THIS AGREEMENT. IF YOU
+DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, DO NOT DOWNLOAD, INSTALL, COPY, OR
+USE THE SOFTWARE.
+
+This Agreement is a legal agreement between you (either an individual or an entity,
+referred to herein as "You" or "User") and Tigris Data, Inc., a Delaware corporation
+("Tigris Data," "we," "us," or "our"), for the use of Tigris Data's proprietary
+software, including any associated documentation, updates, and upgrades (collectively,
+the "Software").
+
+1. ACCEPTANCE OF TERMS
+
+By downloading, installing, accessing, or using the Software, You acknowledge that
+You have read, understood, and agree to be bound by this Agreement. If You are
+accepting this Agreement on behalf of a company or other legal entity, You represent
+and warrant that You have the authority to bind such entity to this Agreement.
+
+2. LICENSE GRANT
+
+Subject to the terms and conditions of this Agreement and Your compliance with all
+applicable subscription terms, Tigris Data grants You a limited, non-exclusive,
+non-transferable, non-sublicensable, revocable license to use the Software solely
+in binary executable form for Your internal business purposes during the applicable
+subscription term.
+
+This license does not include any right to:
+(a) use the Software beyond the scope of Your subscription;
+(b) receive or access the source code of the Software;
+(c) use the Software on behalf of any third party; or
+(d) use the Software in any manner not expressly permitted by this Agreement.
+
+3. RESTRICTIONS
+
+You shall not, and shall not permit any third party to:
+
+(a) distribute, sell, rent, lease, sublicense, assign, or otherwise transfer the
+    Software or any rights therein to any third party;
+
+(b) reverse engineer, decompile, disassemble, translate, or otherwise attempt to
+    derive the source code, underlying ideas, algorithms, structure, or organization
+    of the Software, except to the extent such activities are expressly permitted by
+    applicable law notwithstanding this limitation;
+
+(c) modify, adapt, alter, translate, or create derivative works based on the Software;
+
+(d) copy the Software except as expressly authorized under this Agreement;
+
+(e) remove, alter, or obscure any proprietary notices, labels, or marks on the Software;
+
+(f) use the Software to develop a competing product or service, or to assist any third
+    party in developing a competing product or service;
+
+(g) circumvent or attempt to circumvent any access restrictions, security measures,
+    or technological protection measures in the Software;
+
+(h) conduct any security testing, vulnerability testing, penetration testing, or
+    similar assessments of the Software without Tigris Data's prior written consent;
+
+(i) use the Software in any manner that violates any applicable law or regulation;
+
+(j) use the Software in any manner that could damage, disable, overburden, or impair
+    Tigris Data's systems or interfere with any other party's use of the Software;
+
+(k) transmit any viruses, worms, defects, Trojan horses, malware, or any items of a
+    destructive nature through the Software; or
+
+(l) use the Software for any purpose other than as expressly permitted under this
+    Agreement.
+
+4. INTELLECTUAL PROPERTY
+
+The Software and all copies thereof are proprietary to Tigris Data and title thereto
+remains exclusively with Tigris Data. The Software is protected by copyright laws
+and international treaty provisions. You acknowledge that the Software contains
+valuable trade secrets and proprietary information of Tigris Data.
+
+All rights in and to the Software not expressly granted to You in this Agreement are
+reserved by Tigris Data. No implied licenses are granted under this Agreement.
+
+You agree not to claim any ownership interest in or to the Software or any portion
+thereof, including any modifications, improvements, or derivative works. Any feedback,
+suggestions, or ideas You provide to Tigris Data regarding the Software may be used
+by Tigris Data without any obligation to You.
+
+5. DISCLAIMER OF WARRANTIES
+
+THE SOFTWARE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTY OF ANY KIND.
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, TIGRIS DATA DISCLAIMS ALL
+WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING BUT NOT
+LIMITED TO:
+
+(a) IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+    TITLE, AND NON-INFRINGEMENT;
+
+(b) ANY WARRANTY THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR EXPECTATIONS;
+
+(c) ANY WARRANTY THAT THE SOFTWARE WILL BE UNINTERRUPTED, TIMELY, SECURE, OR
+    ERROR-FREE;
+
+(d) ANY WARRANTY THAT THE RESULTS OBTAINED FROM THE USE OF THE SOFTWARE WILL BE
+    ACCURATE OR RELIABLE;
+
+(e) ANY WARRANTY THAT ANY ERRORS IN THE SOFTWARE WILL BE CORRECTED.
+
+YOU ASSUME ALL RISK ARISING FROM YOUR USE OF THE SOFTWARE.
+
+6. LIMITATION OF LIABILITY
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW:
+
+(a) IN NO EVENT SHALL TIGRIS DATA BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL,
+    CONSEQUENTIAL, PUNITIVE, OR EXEMPLARY DAMAGES, INCLUDING BUT NOT LIMITED TO
+    DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA, OR OTHER INTANGIBLE LOSSES,
+    ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT OR THE USE OR INABILITY TO
+    USE THE SOFTWARE, REGARDLESS OF THE THEORY OF LIABILITY (CONTRACT, TORT,
+    NEGLIGENCE, STRICT LIABILITY, OR OTHERWISE) AND EVEN IF TIGRIS DATA HAS BEEN
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+(b) IN NO EVENT SHALL TIGRIS DATA'S TOTAL AGGREGATE LIABILITY ARISING OUT OF OR IN
+    CONNECTION WITH THIS AGREEMENT OR THE SOFTWARE EXCEED THE GREATER OF (I) THE
+    AMOUNTS PAID BY YOU TO TIGRIS DATA FOR THE SOFTWARE IN THE TWELVE (12) MONTHS
+    PRECEDING THE CLAIM, OR (II) ONE HUNDRED DOLLARS (US$100).
+
+(c) THE LIMITATIONS IN THIS SECTION SHALL APPLY NOTWITHSTANDING ANY FAILURE OF THE
+    ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.
+
+7. TERMINATION
+
+(a) This Agreement is effective until terminated. Your rights under this Agreement
+    will terminate automatically and without notice if You fail to comply with any
+    term of this Agreement.
+
+(b) This Agreement will terminate upon expiration or termination of Your subscription
+    with Tigris Data.
+
+(c) Upon termination, You must immediately cease all use of the Software and destroy
+    or delete all copies of the Software in Your possession or control.
+
+(d) Sections 3, 4, 5, 6, 7, 8, and 9 shall survive any termination of this Agreement.
+
+8. GOVERNING LAW AND JURISDICTION
+
+This Agreement is governed by the laws of the State of California without regard to
+conflict of law principles. You and Tigris Data submit to the personal and exclusive
+jurisdiction of the state courts and federal courts located within Santa Clara County,
+California for resolution of any lawsuit or court proceeding permitted under this
+Agreement.
+
+9. GENERAL PROVISIONS
+
+(a) Entire Agreement. This Agreement constitutes the entire agreement between You and
+    Tigris Data with respect to the Software and supersedes all prior or contemporaneous
+    communications, representations, or agreements, whether oral or written, regarding
+    the subject matter hereof.
+
+(b) Severability. If any provision of this Agreement is held to be invalid or
+    unenforceable, such provision shall be struck and the remaining provisions shall
+    remain in full force and effect.
+
+(c) No Waiver. The failure of Tigris Data to enforce any right or provision of this
+    Agreement shall not constitute a waiver of such right or provision.
+
+(d) Assignment. You may not assign or transfer this Agreement or any rights granted
+    hereunder without the prior written consent of Tigris Data. Tigris Data may
+    assign this Agreement without restriction.
+
+(e) Export Compliance. You agree to comply with all applicable export and import
+    laws and regulations in Your use of the Software.
+
+(f) U.S. Government Rights. If You are a U.S. Government end user, the Software is
+    a "commercial item" as defined in 48 C.F.R. 2.101, consisting of "commercial
+    computer software" and "commercial computer software documentation" as such
+    terms are used in 48 C.F.R. 12.212 and 48 C.F.R. 227.7202. The Software is
+    licensed to U.S. Government end users only as commercial items and with only
+    those rights as are granted to all other end users under this Agreement.
+
+(g) Contact Information. If You have any questions about this Agreement, please
+    contact Tigris Data at:
+
+    Tigris Data, Inc.
+    1250 Borregas Ave, #87
+    Sunnyvale, CA 94089
+    Email: legal@tigrisdata.com
+
+BY USING THE SOFTWARE, YOU ACKNOWLEDGE THAT YOU HAVE READ THIS AGREEMENT, UNDERSTAND
+IT, AND AGREE TO BE BOUND BY ITS TERMS AND CONDITIONS.


### PR DESCRIPTION
Add proprietary End-User License Agreement (EULA) for Tigris Data software. This establishes the legal terms for commercial use of the software under a subscription model. The license includes standard provisions for intellectual property, warranty disclaimers, and limitation of liability. Uses California law for governance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a proprietary EULA to formalize licensing terms.
> 
> - Adds `LICENSE` file outlining license grant, usage restrictions, IP ownership, warranty disclaimers, liability limits, termination, and governing law (California)
> - Applies to binary use under a subscription model; no source code rights granted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498880c3c7df876e42d8c41aa0180468c472c04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->