### PR TITLE
Release

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -41,10 +41,15 @@ func NewCache(cfg *config.CacheConfig) (*Cache, error) {
 	log.Info().
 		Strs("endpoints", cfg.Endpoints).
 		Dur("default_ttl", cfg.TTL).
+		Int("connection_pool_size", cfg.ConnectionPoolSize).
 		Msg("Connecting to ocache cluster")
 
-	// Create client connecting to ocache cluster
-	client, err := cacheclient.New(cfg.Endpoints...)
+	// Create client with custom connection pool size for high-throughput workloads
+	clientConfig := &cacheclient.ClientConfig{
+		Addrs:              cfg.Endpoints,
+		ConnectionPoolSize: cfg.ConnectionPoolSize,
+	}
+	client, err := cacheclient.NewWithConfig(clientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	// 3. Initialize forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
 
 	// 4. Initialize proxy service
 	service := proxy.NewService(forwarder, objectCache, cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,10 @@ const (
 	// DefaultCacheSizeThreshold is the max object size to cache (1GB).
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
 
+	// DefaultCacheConnectionPoolSize is the default number of gRPC connections per ocache node.
+	// Higher values improve throughput for high-concurrency workloads.
+	DefaultCacheConnectionPoolSize = 4
+
 	// DefaultLogLevel is the default log level.
 	DefaultLogLevel = "info"
 
@@ -41,6 +46,10 @@ const (
 
 	// DefaultBroadcastChannelBuffer is the default buffer size per listener (32 chunks = ~2MB).
 	DefaultBroadcastChannelBuffer = 32
+
+	// DefaultMaxIdleConnsPerHost is the default HTTP connection pool size per upstream host.
+	// Higher values improve throughput for cache miss scenarios with high concurrency.
+	DefaultMaxIdleConnsPerHost = 100
 )
 
 // Config holds all configuration for TAG.
@@ -62,8 +71,9 @@ type ServerConfig struct {
 
 // UpstreamConfig holds Tigris endpoint configuration.
 type UpstreamConfig struct {
-	Endpoint string `yaml:"endpoint"` // Tigris S3 endpoint (e.g., https://fly.storage.tigris.dev)
-	Region   string `yaml:"region"`   // AWS region for signing (default: auto)
+	Endpoint            string `yaml:"endpoint"`               // Tigris S3 endpoint (e.g., https://fly.storage.tigris.dev)
+	Region              string `yaml:"region"`                 // AWS region for signing (default: auto)
+	MaxIdleConnsPerHost int    `yaml:"max_idle_conns_per_host"` // HTTP connection pool size per host (default: 100)
 }
 
 // CredentialsConfig holds credential store configuration.
@@ -74,10 +84,11 @@ type CredentialsConfig struct {
 
 // CacheConfig holds ocache client configuration.
 type CacheConfig struct {
-	Enabled       bool          `yaml:"enabled"`        // Enable caching (auto-enabled if endpoints configured)
-	Endpoints     []string      `yaml:"endpoints"`      // ocache cluster endpoints (e.g., ["ocache-0:9000", "ocache-1:9000"])
-	TTL           time.Duration `yaml:"ttl"`            // Default cache TTL (default: 60m)
-	SizeThreshold int64         `yaml:"size_threshold"` // Max object size to cache in bytes (default: 1GB)
+	Enabled            bool          `yaml:"enabled"`              // Enable caching (auto-enabled if endpoints configured)
+	Endpoints          []string      `yaml:"endpoints"`            // ocache cluster endpoints (e.g., ["ocache-0:9000", "ocache-1:9000"])
+	TTL                time.Duration `yaml:"ttl"`                  // Default cache TTL (default: 60m)
+	SizeThreshold      int64         `yaml:"size_threshold"`       // Max object size to cache in bytes (default: 1GB)
+	ConnectionPoolSize int           `yaml:"connection_pool_size"` // Number of gRPC connections per ocache node (default: 4)
 }
 
 // BroadcastConfig holds streaming broadcast configuration for request coalescing.
@@ -140,6 +151,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Upstream.Region == "" {
 		cfg.Upstream.Region = DefaultUpstreamRegion
 	}
+	if cfg.Upstream.MaxIdleConnsPerHost == 0 {
+		cfg.Upstream.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	}
 
 	// Cache defaults - auto-enabled when endpoints are configured.
 	// Use TAG_CACHE_DISABLED=true environment variable to disable.
@@ -151,6 +165,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Cache.SizeThreshold == 0 {
 		cfg.Cache.SizeThreshold = DefaultCacheSizeThreshold
+	}
+	if cfg.Cache.ConnectionPoolSize == 0 {
+		cfg.Cache.ConnectionPoolSize = DefaultCacheConnectionPoolSize
 	}
 
 	// Broadcast defaults
@@ -177,6 +194,13 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Upstream.Endpoint = endpoint
 	}
 
+	// Override upstream HTTP connection pool size from environment
+	if poolSize := os.Getenv("TAG_MAX_IDLE_CONNS_PER_HOST"); poolSize != "" {
+		if size, err := strconv.Atoi(poolSize); err == nil && size > 0 {
+			cfg.Upstream.MaxIdleConnsPerHost = size
+		}
+	}
+
 	// Override ocache endpoints from environment (comma-separated)
 	if endpoints := os.Getenv("TAG_OCACHE_ENDPOINTS"); endpoints != "" {
 		cfg.Cache.Endpoints = splitEndpoints(endpoints)
@@ -191,6 +215,13 @@ func applyEnvOverrides(cfg *Config) {
 	// Disable cache from environment (explicit disable takes precedence)
 	if disabled := os.Getenv("TAG_CACHE_DISABLED"); disabled == "true" || disabled == "1" {
 		cfg.Cache.Enabled = false
+	}
+
+	// Override ocache connection pool size from environment
+	if poolSize := os.Getenv("TAG_OCACHE_CONNECTION_POOL_SIZE"); poolSize != "" {
+		if size, err := strconv.Atoi(poolSize); err == nil && size > 0 {
+			cfg.Cache.ConnectionPoolSize = size
+		}
 	}
 
 	// Override log level from environment

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,9 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `AWS_ACCESS_KEY_ID` | S3 access key for authentication | (required) |
 | `AWS_SECRET_ACCESS_KEY` | S3 secret key for authentication | (required) |
 | `TAG_UPSTREAM_ENDPOINT` | Tigris S3 endpoint URL | `https://t3.storage.dev` |
+| `TAG_MAX_IDLE_CONNS_PER_HOST` | HTTP connection pool size per upstream host | `100` |
 | `TAG_OCACHE_ENDPOINTS` | Comma-separated ocache endpoints | (none) |
+| `TAG_OCACHE_CONNECTION_POOL_SIZE` | Number of gRPC connections per ocache node | `4` |
 | `TAG_CACHE_DISABLED` | Disable caching (`true` or `1`) | `false` |
 | `TAG_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 | `TAG_LOG_FORMAT` | Log format: `json` or `console` | `json` |
@@ -50,6 +52,11 @@ upstream:
   # Default: "auto"
   region: "auto"
 
+  # HTTP connection pool size per upstream host
+  # Higher values improve throughput for cache miss scenarios
+  # Default: 100
+  max_idle_conns_per_host: 100
+
 # Cache configuration
 cache:
   # Enable caching
@@ -71,6 +78,11 @@ cache:
   # Objects larger than this are not cached
   # Default: 1073741824 (1GB)
   size_threshold: 1073741824
+
+  # Number of gRPC connections per ocache node
+  # Higher values improve throughput for high-concurrency workloads
+  # Default: 4
+  connection_pool_size: 4
 
 # Broadcast configuration (request coalescing)
 broadcast:
@@ -114,6 +126,7 @@ Configures the connection to upstream Tigris storage.
 |-------|------|---------|-------------|
 | `endpoint` | string | `"https://t3.storage.dev"` | Tigris S3 endpoint URL |
 | `region` | string | `"auto"` | AWS region for request signing |
+| `max_idle_conns_per_host` | int | `100` | HTTP connection pool size per host |
 
 **Endpoint Options:**
 - `https://t3.storage.dev` - Default Tigris endpoint
@@ -128,6 +141,7 @@ Controls the caching behavior and ocache cluster connection.
 | `endpoints` | []string | `[]` | ocache cluster endpoints |
 | `ttl` | duration | `60m` | Default TTL for cached objects |
 | `size_threshold` | int64 | `1073741824` | Max object size to cache (bytes) |
+| `connection_pool_size` | int | `4` | Number of gRPC connections per ocache node |
 
 **TTL Format:**
 - `60m` - 60 minutes (default)
@@ -238,13 +252,18 @@ log:
 server:
   http_port: 8080
 
+upstream:
+  endpoint: "https://t3.storage.dev"
+  max_idle_conns_per_host: 500  # Increase for high cache-miss concurrency
+
 cache:
   enabled: true
   endpoints:
     - "ocache-0:9000"
     - "ocache-1:9000"
   ttl: 1h
-  size_threshold: 1073741824  # 1GB
+  size_threshold: 1073741824    # 1GB
+  connection_pool_size: 128     # Increase for high cache-hit concurrency
 
 broadcast:
   chunk_size: 131072    # 128KB chunks

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -96,16 +96,20 @@ type Forwarder struct {
 	httpClient *http.Client
 }
 
-// NewForwarder creates a new forwarder.
-func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string) *Forwarder {
+// NewForwarder creates a new forwarder with configurable HTTP connection pool.
+func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string, maxIdleConnsPerHost int) *Forwarder {
+	if maxIdleConnsPerHost <= 0 {
+		maxIdleConnsPerHost = 100 // Default
+	}
+
 	return &Forwarder{
 		credStore: credStore,
 		validator: auth.NewRequestValidator(credStore),
 		signer:    auth.NewRequestSigner(tigrisEndpoint, region),
 		httpClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 100,
+				MaxIdleConns:        maxIdleConnsPerHost,
+				MaxIdleConnsPerHost: maxIdleConnsPerHost,
 				IdleConnTimeout:     90 * time.Second,
 			},
 			Timeout: 5 * time.Minute,

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -15,6 +17,30 @@ import (
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy/broadcast"
 )
+
+// bufferPool provides reusable buffers for small object caching.
+// Reduces allocations and GC pressure at high QPS.
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+// smallObjectThreshold defines the max size for direct buffered serving.
+// Objects at or below this size buffer the body directly instead of using
+// io.Pipe + goroutine. This eliminates per-request goroutine spawn, io.Pipe
+// allocation, and synchronization overhead for small objects.
+const smallObjectThreshold = 64 * 1024 // 64KB
+
+// putBuffer returns a buffer to the pool only if it hasn't grown too large.
+// This prevents memory bloat from oversized buffers (e.g., if cached body
+// exceeds metadata claims due to corruption/inconsistency).
+func putBuffer(buf *bytes.Buffer) {
+	if buf.Cap() <= smallObjectThreshold {
+		bufferPool.Put(buf)
+	}
+	// Otherwise let it be garbage collected
+}
 
 // countingWriter wraps an io.Writer to count bytes written.
 type countingWriter struct {
@@ -105,42 +131,67 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				return nil
 			}
 
-			// Non-zero object: use io.Pipe to verify body exists BEFORE writing headers
-			pr, pw := io.Pipe()
-			go func() {
-				err := s.cache.GetBodyStream(ctx, bucket, key, pw)
-				if err != nil {
-					pw.CloseWithError(err)
-				} else {
-					pw.Close()
+			// Small objects: buffer body directly (no goroutine/io.Pipe overhead)
+			// Uses GetBodyStream to buffer, reusing metadata from GetMeta above (2 gRPC calls total)
+			if meta.ContentLength <= smallObjectThreshold {
+				// Get buffer from pool to reduce allocations
+				bodyBuf := bufferPool.Get().(*bytes.Buffer)
+				bodyBuf.Reset()
+
+				bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
+				if bodyErr == nil {
+					metrics.RecordCacheHit()
+					log.Debug().Str("bucket", bucket).Str("key", key).Int64("size", meta.ContentLength).Msg("Serving small object from cache (fast path)")
+					meta.WriteHeaders(w)
+					w.Header().Set(XCacheHeader, XCacheHit)
+					w.WriteHeader(meta.StatusCode)
+					n, _ := w.Write(bodyBuf.Bytes())
+					metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+					putBuffer(bodyBuf) // Return buffer to pool
+					return nil
 				}
-			}()
-
-			// Read first byte to verify body exists before committing headers
-			firstByte := make([]byte, 1)
-			n, readErr := pr.Read(firstByte)
-			if readErr != nil {
-				// Body missing or error - close pipe and fall through to upstream
-				pr.Close()
-				log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).Msg("Cache body missing, falling back to upstream")
-				// Fall through to cache miss handling below
+				putBuffer(bodyBuf) // Return buffer to pool even on error
+				// Fall through to upstream (cache miss handling below)
+				log.Debug().Err(bodyErr).Str("bucket", bucket).Str("key", key).Msg("GetBodyStream failed for small object, falling back to upstream")
 			} else {
-				// Body verified - safe to write headers and stream
-				metrics.RecordCacheHit()
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving from cache with metadata (verified stream)")
-				meta.WriteHeaders(w)
-				w.Header().Set(XCacheHeader, XCacheHit)
-				w.WriteHeader(meta.StatusCode)
+				// Large objects: use io.Pipe for streaming (avoids buffering entire object)
+				pr, pw := io.Pipe()
+				go func() {
+					err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+					if err != nil {
+						pw.CloseWithError(err)
+					} else {
+						pw.Close()
+					}
+				}()
 
-				// Write first byte and stream the rest
-				cw := &countingWriter{w: w}
-				cw.Write(firstByte[:n])
-				io.Copy(cw, pr)
-				pr.Close()
+				// Read first byte to verify body exists before committing headers
+				firstByte := make([]byte, 1)
+				n, readErr := pr.Read(firstByte)
+				if readErr != nil {
+					// Body missing or error - close pipe and fall through to upstream
+					pr.Close()
+					log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).Msg("Cache body missing, falling back to upstream")
+					// Fall through to cache miss handling below
+				} else {
+					// Body verified - safe to write headers and stream
+					metrics.RecordCacheHit()
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving large object from cache (streaming)")
+					meta.WriteHeaders(w)
+					w.Header().Set(XCacheHeader, XCacheHit)
+					w.WriteHeader(meta.StatusCode)
 
-				metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
-				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-				return nil
+					// Write first byte and stream the rest
+					cw := &countingWriter{w: w}
+					cw.Write(firstByte[:n])
+					io.Copy(cw, pr)
+					pr.Close()
+
+					metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+					return nil
+				}
 			}
 		}
 		metrics.RecordCacheMiss()

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -281,7 +281,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	testCache := cache.NewCacheWithClient(memoryCache, &cfg.Cache)
 
 	// Create forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
 
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)
@@ -339,7 +339,7 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	testCache, _ := cache.NewCache(&cfg.Cache)
 
 	// Create forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
 
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Performance and configurability improvements**
> 
> - Add `upstream.max_idle_conns_per_host` (env: `TAG_MAX_IDLE_CONNS_PER_HOST`) and `cache.connection_pool_size` (env: `TAG_OCACHE_CONNECTION_POOL_SIZE`) with sensible defaults; documented in `docs/configuration.md`
> - `Forwarder` now accepts max idle conns; HTTP transport `MaxIdleConns`/`MaxIdleConnsPerHost` set from config; all call sites/tests updated
> - `cache.NewCache` now uses `cacheclient.NewWithConfig` with `ConnectionPoolSize` and logs `connection_pool_size`
> - `GetObject` adds a 64KB small-object fast path using a buffer pool; large objects continue streaming via `io.Pipe`; preserves headers/metrics and improves cache-hit latency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66620b1c0afcdd629f5e49b06cb23b64f938b866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->