### PR TITLE
docs: add memory files documenting TAG architecture

### DIFF
--- a/.claude/rules/distributed-cache.md
+++ b/.claude/rules/distributed-cache.md
@@ -1,0 +1,70 @@
+# Distributed Cache Considerations
+
+## Embedded OCache Architecture
+
+TAG uses embedded OCache for local storage:
+
+- Each TAG node runs its own embedded cache
+- No external cache server required
+- Optional clustering for multi-node deployments
+
+## Cluster Mode
+
+When running multiple TAG nodes:
+
+- **Discovery**: Memberlist gossip protocol (default port 7000)
+- **Routing**: gRPC-based cache key routing (default port 9000)
+- **Hashing**: Consistent hashing distributes keys across nodes
+- **Local/Remote**: Requests for keys owned by other nodes forwarded via gRPC
+
+## Tombstone Pattern for Cache Invalidation
+
+Prevents stale async cache writes after invalidation:
+
+```
+1. DELETE arrives → Write tombstone with timestamp
+2. Delete meta and body keys
+3. Async cache writer checks tombstone before writing metadata
+4. If tombstone timestamp > write start time → skip metadata write
+5. Tombstones expire after 60 seconds (short TTL)
+```
+
+This ensures in-flight background cache writes don't resurrect deleted objects.
+
+## Stream Multiplexing > Batching
+
+For distributed caches, prefer stream multiplexing over explicit batching:
+
+- Batching adds complexity: must route keys to correct nodes
+- Stream multiplexing: one persistent stream per node connection
+- Each request goes directly to the right stream
+- No cross-node coordination needed
+
+## Error Handling for Streaming RPCs
+
+Robust error handling is critical:
+
+- Detect stream disconnections promptly
+- Fail pending requests immediately on disconnect
+- Clear reconnection strategy
+- Don't leave requests hanging indefinitely
+
+## Common Mistakes to Avoid
+
+### Ignoring Distributed Nature in Batching
+
+`BatchGet` seems simple but is complex in distributed environments. Consider node routing before implementing.
+
+### Underestimating Latency from Explicit Batching
+
+While beneficial for throughput, explicit batching (waiting for timeout or N items) adds visible latency. Prefer zero-latency approaches.
+
+### Missing Tombstone Checks in Async Writers
+
+Background cache writers must check for tombstones before finalizing writes to prevent stale data.
+
+## Best Practices
+
+- **Phased implementation**: Break optimization into phases (streaming, then batching, then OS-specific)
+- **Industry pattern research**: Study how etcd, Redis handle similar problems
+- **Focus on identified bottlenecks**: Target the specific issue (e.g., 42% syscalls)

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,0 +1,26 @@
+# Performance Optimization Patterns
+
+## sync.Pool for Buffer Reuse
+
+Reduce GC pressure by reusing buffers:
+
+```go
+var bufferPool = sync.Pool{
+    New: func() interface{} {
+        return new(bytes.Buffer)
+    },
+}
+
+// Usage
+buf := bufferPool.Get().(*bytes.Buffer)
+buf.Reset()
+defer bufferPool.Put(buf)
+```
+
+## Zero Added Latency Preference
+
+Avoid explicit batching delays:
+
+- Explicit batching (waiting for timeout or N items) adds latency
+- Prefer implicit pipelining via HTTP/2 layer
+- Let the transport handle batching naturally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# TAG (Tigris Access Gateway)
+
+High-performance S3-compatible caching proxy for Tigris object storage with embedded distributed cache.
+
+## Build & Test Commands
+
+```bash
+# Build
+make build          # Build the binary (auto-downloads dependencies)
+make install-deps   # Install system dependencies (compression libs)
+
+# Unit tests
+make test           # Run unit tests
+make test-auth      # Run auth package tests
+make test-cache     # Run cache package tests
+make test-proxy     # Run proxy package tests
+make test-race      # Run tests with race detector
+make test-coverage  # Generate coverage report
+
+# Integration tests
+make test-integration  # Run integration tests
+make test-all          # Run all tests (unit + integration)
+
+# Code quality
+make lint           # Run linters (vet, gofmt check, mod tidy)
+make lint-fix       # Fix linting issues
+make fmt            # Format code
+make check          # Run all checks (fmt, vet, test)
+
+# Run
+make run            # Run TAG with default options
+make run-verbose    # Run TAG with debug logging
+
+# S3 compatibility tests
+make s3-test-local  # Start TAG locally with embedded cache
+make s3-tests       # Run S3 compatibility tests (ceph s3-tests)
+make s3-test-local-down  # Stop local TAG and cleanup
+
+# Cleanup
+make clean          # Remove binary and generated files
+make clean-all      # Remove everything including cache data
+```
+
+Filter tests with `TEST` or `TESTRUN` variables:
+```bash
+TEST=TestGetObject make test
+TESTRUN="TestBroadcast" make test-proxy
+```
+
+## Core Architecture
+
+- **Embedded OCache**: Uses `github.com/tigrisdata/ocache/embedded` (no external cache server)
+- **Optional Clustering**: Memberlist gossip for discovery, gRPC for cache key routing between nodes
+- **Broadcast/Subscriber Pattern**: Request coalescing via `proxy/broadcast/` - streams chunks to multiple listeners simultaneously
+- **Two-Key Cache Storage**: Objects stored as `meta|bucket|key` (headers/ETag) and `body|bucket|key` (raw bytes)
+- **Tombstone Invalidation**: Writes tombstone marker before DELETE to prevent stale async cache writes
+- **Semaphore-Gated Background Ops**: `cacheSemaphore` (100 concurrent) limits background cache writes
+
+## Key Dependencies
+
+- `github.com/tigrisdata/ocache/embedded` - Embedded cache with RocksDB storage
+- `github.com/tigrisdata/ocache/client` - Cache client interface (CacheClient)
+- `github.com/goccy/go-json` - Fast JSON (replaces encoding/json)
+- `github.com/aws/aws-sdk-go-v2` - AWS SigV4 signing
+
+## User Preferences
+
+- **Prioritize impact over complexity**: Focus on significant improvements without over-engineering
+- **Zero added latency**: Prefer patterns like stream multiplexing over explicit batching delays
+- **Linux + macOS support**: OS-specific optimizations must have viable fallbacks
+- **Clear plan separation**: When changes span multiple codebases (OCache vs TAG), maintain distinct plans


### PR DESCRIPTION
Add CLAUDE.md with project overview and build/test commands. Include .claude/rules/ documentation covering gRPC streaming patterns, performance optimization, and distributed cache considerations with embedded OCache architecture.

## Changes
- CLAUDE.md: Project context, build commands, architecture overview
- .claude/rules/performance.md: Performance patterns (sync.Pool, zero-latency preference)
- .claude/rules/distributed-cache.md: Embedded OCache, clustering, tombstone invalidation

Reflects recent migration to embedded OCache v1.2.3 with RocksDB storage and optional clustering support.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or behavioral changes; risk is limited to potential stale/misleading guidance.
> 
> **Overview**
> Adds new documentation to capture TAG build/test workflows and architecture details in `CLAUDE.md`.
> 
> Introduces `.claude/rules/` guidance covering embedded/clustered cache behavior (including tombstone-based invalidation and streaming considerations) and basic performance patterns (e.g., `sync.Pool` buffer reuse and avoiding latency-inducing batching).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8cf2835e04ddf8efff3ceab4985a60d12fae461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->