### PR TITLE
feat: support AWS chunked transfer encoding for S3 bucket operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ TESTRUN="TestBroadcast" make test-proxy
 - `github.com/goccy/go-json` - Fast JSON (replaces encoding/json)
 - `github.com/aws/aws-sdk-go-v2` - AWS SigV4 signing
 
+## Commit & PR Conventions
+
+PR titles and commit messages must use [Conventional Commits](https://www.conventionalcommits.org/) format with one of these prefixes: `feat`, `fix`, `perf`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert`. Example: `feat: add chunked transfer encoding support`.
+
 ## User Preferences
 
 - **Prioritize impact over complexity**: Focus on significant improvements without over-engineering

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -151,8 +151,10 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	// CHECK TOMBSTONE before writing metadata
 	// If a tombstone exists with timestamp > writeStartTime, the key was invalidated
 	// after this write started, so we should NOT write metadata (keeps entry invisible)
+	// NOTE: To avoid race conditions, we use >= instead of > to handle the case where
+	// the tombstone is written at the same time as the write started
 	tombTs := c.GetTombstoneTimestamp(ctx, bucket, key)
-	if tombTs > writeStartTime {
+	if tombTs >= writeStartTime {
 		log.Debug().Str("bucket", bucket).Str("key", key).
 			Int64("tombstone_ts", tombTs).
 			Int64("write_start", writeStartTime).

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -142,25 +142,22 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		return err
 	}
 
-	// Stream body to cache FIRST
-	if err := c.client.PutStream(ctx, bodyKey, body, int64(ttl)); err != nil {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body put error")
-		return err
-	}
-
-	// CHECK TOMBSTONE before writing metadata
-	// If a tombstone exists with timestamp > writeStartTime, the key was invalidated
-	// after this write started, so we should NOT write metadata (keeps entry invisible)
-	// NOTE: To avoid race conditions, we use >= instead of > to handle the case where
-	// the tombstone is written at the same time as the write started
+	// CHECK TOMBSTONE BEFORE writing anything to cache
+	// If a tombstone exists with timestamp >= writeStartTime, the key was invalidated
+	// after this write started, so we should NOT write at all (prevents orphaned bodies)
 	tombTs := c.GetTombstoneTimestamp(ctx, bucket, key)
 	if tombTs >= writeStartTime {
 		log.Debug().Str("bucket", bucket).Str("key", key).
 			Int64("tombstone_ts", tombTs).
 			Int64("write_start", writeStartTime).
-			Msg("Skipping metadata write - tombstone detected (key was invalidated)")
-		// Body is orphaned but will be overwritten by next write or expire via TTL
+			Msg("Skipping cache write - tombstone detected (key was invalidated)")
 		return nil
+	}
+
+	// Stream body to cache
+	if err := c.client.PutStream(ctx, bodyKey, body, int64(ttl)); err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body put error")
+		return err
 	}
 
 	// Write metadata AFTER body (makes entry visible)

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -1,0 +1,126 @@
+# S3 API Compatibility
+
+TAG implements all the commonly used bucket and object APIs from the Amazon S3 REST API, acting as a caching proxy between S3 clients and Tigris object storage. All requests are authenticated using AWS Signature Version 4, re-signed, and forwarded to the Tigris upstream endpoint.
+
+## Supported Operations
+
+### Service
+
+| Operation   | Method | Path | Notes |
+| ----------- | ------ | ---- | ----- |
+| ListBuckets | GET    | `/`  |       |
+
+### Bucket
+
+All bucket operations support both `/{bucket}` and `/{bucket}/` path forms for compatibility with clients that send trailing slashes.
+
+| Operation            | Method             | Path / Query            | Notes                                                |
+| -------------------- | ------------------ | ----------------------- | ---------------------------------------------------- |
+| CreateBucket         | PUT                | `/{bucket}`             |                                                      |
+| DeleteBucket         | DELETE             | `/{bucket}`             |                                                      |
+| HeadBucket           | HEAD               | `/{bucket}`             |                                                      |
+| ListObjects V1       | GET                | `/{bucket}`             |                                                      |
+| ListObjects V2       | GET                | `/{bucket}?list-type=2` |                                                      |
+| ListMultipartUploads | GET                | `/{bucket}?uploads`     |                                                      |
+| GetBucketLocation    | GET                | `/{bucket}?location`    | Returns configured region                            |
+| GetBucketVersioning  | GET / PUT          | `/{bucket}?versioning`  | Forwarded to Tigris                                  |
+| GetBucketACL         | GET / PUT          | `/{bucket}?acl`         | Forwarded to Tigris                                  |
+| GetBucketPolicy      | GET / PUT / DELETE | `/{bucket}?policy`      | Forwarded to Tigris                                  |
+| GetBucketCORS        | GET / PUT / DELETE | `/{bucket}?cors`        | Forwarded to Tigris                                  |
+| GetBucketTagging     | GET / PUT / DELETE | `/{bucket}?tagging`     | Forwarded to Tigris                                  |
+| GetBucketLifecycle   | GET / PUT / DELETE | `/{bucket}?lifecycle`   | Forwarded to Tigris                                  |
+| DeleteObjects        | POST               | `/{bucket}?delete`      | Bulk delete with XML body; invalidates cache entries |
+
+### Object
+
+| Operation           | Method | Path / Query              | Notes                                                                  |
+| ------------------- | ------ | ------------------------- | ---------------------------------------------------------------------- |
+| GetObject           | GET    | `/{bucket}/{key}`         | Cache-first; supports Range and conditional headers                    |
+| HeadObject          | HEAD   | `/{bucket}/{key}`         | Served from cached metadata when available                             |
+| PutObject           | PUT    | `/{bucket}/{key}`         | Invalidates cache before forwarding                                    |
+| DeleteObject        | DELETE | `/{bucket}/{key}`         | Invalidates cache before forwarding                                    |
+| CopyObject          | PUT    | `/{bucket}/{key}`         | Detected via `X-Amz-Copy-Source` header; invalidates destination cache |
+| GetObjectTagging    | GET    | `/{bucket}/{key}?tagging` |                                                                        |
+| PutObjectTagging    | PUT    | `/{bucket}/{key}?tagging` |                                                                        |
+| DeleteObjectTagging | DELETE | `/{bucket}/{key}?tagging` |                                                                        |
+| GetObjectACL        | GET    | `/{bucket}/{key}?acl`     |                                                                        |
+| PutObjectACL        | PUT    | `/{bucket}/{key}?acl`     |                                                                        |
+
+### Multipart Upload
+
+| Operation               | Method | Path / Query                            | Notes                                      |
+| ----------------------- | ------ | --------------------------------------- | ------------------------------------------ |
+| InitiateMultipartUpload | POST   | `/{bucket}/{key}?uploads`               |                                            |
+| UploadPart              | PUT    | `/{bucket}/{key}?uploadId=&partNumber=` |                                            |
+| UploadPartCopy          | PUT    | `/{bucket}/{key}?uploadId=&partNumber=` | Detected via `X-Amz-Copy-Source` header    |
+| CompleteMultipartUpload | POST   | `/{bucket}/{key}?uploadId=`             | Idempotent — successful completions cached |
+| AbortMultipartUpload    | DELETE | `/{bucket}/{key}?uploadId=`             |                                            |
+| ListParts               | GET    | `/{bucket}/{key}?uploadId=`             |                                            |
+
+## AWS Chunked Transfer Encoding
+
+TAG supports AWS chunked transfer encoding (streaming SigV4), used by tools like [warp](https://github.com/minio/warp) and many AWS SDKs for large uploads.
+
+When a client sends a PUT with `X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD`, the body is wrapped in an AWS-proprietary chunked format where each chunk includes a signature chained from the request-level seed signature. Because TAG re-signs requests with the upstream Tigris hostname (changing the `Host` header), these per-chunk signatures become invalid.
+
+TAG handles this by decoding the chunked body on-the-fly — stripping the chunk framing and signatures — and forwarding the raw payload as `UNSIGNED-PAYLOAD`. The decoded content length is read from the `X-Amz-Decoded-Content-Length` header. This is a streaming operation with no buffering of the full object.
+
+## Caching Behavior
+
+TAG adds a caching layer for read operations. The `X-Cache` response header indicates cache status:
+
+| Value      | Meaning                                                  |
+| ---------- | -------------------------------------------------------- |
+| `HIT`      | Served entirely from cache                               |
+| `MISS`     | Fetched from Tigris and cached                           |
+| `BYPASS`   | Caching skipped (e.g., conditional request returned 304) |
+| `DISABLED` | Caching is turned off                                    |
+
+Key caching behaviors:
+
+- **Request coalescing** — Multiple concurrent GETs for the same object are coalesced into a single upstream fetch using a broadcast/subscriber pattern.
+- **Range requests** — If the full object is cached, range requests are served from cache. On a range cache miss, the range is served directly from Tigris while a background fetch populates the cache with the full object.
+- **Conditional requests** — `If-None-Match` and `If-Modified-Since` are evaluated against cached metadata and can return 304 without hitting Tigris.
+- **Write-through invalidation** — PUT, DELETE, CopyObject, and DeleteObjects invalidate the cache _before_ forwarding to Tigris to prevent stale reads.
+- **Tombstone protection** — A short-lived tombstone is written on DELETE to prevent in-flight background cache writes from resurrecting deleted objects.
+
+## Addressing Style
+
+TAG uses **path-style** addressing only (`http://host:port/bucket/key`). Virtual-hosted style (`http://bucket.host:port/key`) is not supported.
+
+## Authentication
+
+All requests must be signed with AWS Signature Version 4 (header-based). TAG validates the incoming signature against its credential store, then re-signs the request with the same credentials for the Tigris upstream endpoint.
+
+Presigned URL authentication (`X-Amz-Algorithm` query parameter) is supported for request validation.
+
+## Not Supported
+
+The following S3 features are not implemented by TAG and will be forwarded as-is to Tigris or may return errors:
+
+- Object versioning (version-specific GET/DELETE)
+- Server-side encryption (SSE-C, SSE-S3, SSE-KMS)
+- Object Lock / WORM retention
+- POST object (browser-based HTML form uploads)
+- Public Access Block configuration
+- Bucket ownership controls
+- Multi-range requests (single Range header only)
+- Virtual-hosted style addressing
+- Website hosting configuration
+- Replication configuration
+- Inventory, analytics, and metrics configuration
+- Storage class transitions (Glacier, Intelligent Tiering)
+
+## S3 Compatibility Tests
+
+TAG validates compatibility using a curated subset of 214 tests from the [ceph/s3-tests](https://github.com/ceph/s3-tests) suite. See [s3-compatibility-testing.md](s3-compatibility-testing.md) for how to run them.
+
+| Category             | Tests | Coverage                                                |
+| -------------------- | ----- | ------------------------------------------------------- |
+| Header validation    | 48    | Content-Type, MD5, Content-Length, dates, authorization |
+| Core list operations | 55    | Prefix, delimiter, max-keys, marker, continuation       |
+| Object operations    | 34    | Read, write, metadata, ETags, ranges, conditionals      |
+| Bucket operations    | 33    | Create, delete, list, naming rules                      |
+| Multipart uploads    | 20    | Initiate, upload, complete, abort, copy parts           |
+| Copy operations      | 9     | Same-bucket, cross-bucket, metadata handling            |
+| Tagging              | 15    | Object and bucket tag CRUD                              |

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -295,9 +295,17 @@ func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
 	// AWS chunked encoding: Content-Length reflects wire size (with chunk framing),
 	// and the actual payload size is in X-Amz-Decoded-Content-Length.
 	if r.Header.Get("X-Amz-Content-Sha256") == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
-		if r.Header.Get("X-Amz-Decoded-Content-Length") != "" {
-			return true
+		v := r.Header.Get("X-Amz-Decoded-Content-Length")
+		if v == "" {
+			WriteError(w, r, ErrMissingContentLength)
+			return false
 		}
+		decodedLen, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || decodedLen < 0 {
+			WriteError(w, r, ErrBadContentLength)
+			return false
+		}
+		return true
 	}
 
 	v := r.Header.Get("Content-Length")

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -294,7 +294,7 @@ func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
 	// AWS chunked encoding: Content-Length reflects wire size (with chunk framing),
 	// and the actual payload size is in X-Amz-Decoded-Content-Length.
-	if r.Header.Get("X-Amz-Content-Sha256") == proxy.StreamingPayloadHash {
+	if proxy.IsStreamingPayload(r.Header.Get("X-Amz-Content-Sha256")) {
 		v := r.Header.Get("X-Amz-Decoded-Content-Length")
 		if v == "" {
 			WriteError(w, r, ErrMissingContentLength)

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -294,7 +294,7 @@ func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
 	// AWS chunked encoding: Content-Length reflects wire size (with chunk framing),
 	// and the actual payload size is in X-Amz-Decoded-Content-Length.
-	if r.Header.Get("X-Amz-Content-Sha256") == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
+	if r.Header.Get("X-Amz-Content-Sha256") == proxy.StreamingPayloadHash {
 		v := r.Header.Get("X-Amz-Decoded-Content-Length")
 		if v == "" {
 			WriteError(w, r, ErrMissingContentLength)

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -118,49 +118,55 @@ func (s *Server) setupRouter() *mux.Router {
 	// Handled in handleObject based on header presence
 
 	// Bucket operations with query parameters
-	r.HandleFunc("/{bucket}", s.handleBucketMultipartUploads).
-		Queries("uploads", "").
-		Methods("GET")
+	// Each route is registered for both /{bucket} and /{bucket}/ because S3 clients
+	// like warp send bucket-level requests with trailing slashes. We cannot strip
+	// trailing slashes via middleware because that would break SigV4 signature
+	// validation (the client signs the request with the original path).
+	for _, prefix := range []string{"/{bucket}", "/{bucket}/"} {
+		r.HandleFunc(prefix, s.handleBucketMultipartUploads).
+			Queries("uploads", "").
+			Methods("GET")
 
-	r.HandleFunc("/{bucket}", s.handleListObjectsV2).
-		Queries("list-type", "2").
-		Methods("GET")
+		r.HandleFunc(prefix, s.handleListObjectsV2).
+			Queries("list-type", "2").
+			Methods("GET")
 
-	r.HandleFunc("/{bucket}", s.handleBucketVersioning).
-		Queries("versioning", "").
-		Methods("GET", "PUT")
+		r.HandleFunc(prefix, s.handleBucketVersioning).
+			Queries("versioning", "").
+			Methods("GET", "PUT")
 
-	r.HandleFunc("/{bucket}", s.handleBucketACL).
-		Queries("acl", "").
-		Methods("GET", "PUT")
+		r.HandleFunc(prefix, s.handleBucketACL).
+			Queries("acl", "").
+			Methods("GET", "PUT")
 
-	r.HandleFunc("/{bucket}", s.handleBucketLifecycle).
-		Queries("lifecycle", "").
-		Methods("GET", "PUT", "DELETE")
+		r.HandleFunc(prefix, s.handleBucketLifecycle).
+			Queries("lifecycle", "").
+			Methods("GET", "PUT", "DELETE")
 
-	r.HandleFunc("/{bucket}", s.handleBucketPolicy).
-		Queries("policy", "").
-		Methods("GET", "PUT", "DELETE")
+		r.HandleFunc(prefix, s.handleBucketPolicy).
+			Queries("policy", "").
+			Methods("GET", "PUT", "DELETE")
 
-	r.HandleFunc("/{bucket}", s.handleBucketCORS).
-		Queries("cors", "").
-		Methods("GET", "PUT", "DELETE")
+		r.HandleFunc(prefix, s.handleBucketCORS).
+			Queries("cors", "").
+			Methods("GET", "PUT", "DELETE")
 
-	r.HandleFunc("/{bucket}", s.handleBucketTagging).
-		Queries("tagging", "").
-		Methods("GET", "PUT", "DELETE")
+		r.HandleFunc(prefix, s.handleBucketTagging).
+			Queries("tagging", "").
+			Methods("GET", "PUT", "DELETE")
 
-	r.HandleFunc("/{bucket}", s.handleBucketLocation).
-		Queries("location", "").
-		Methods("GET")
+		r.HandleFunc(prefix, s.handleBucketLocation).
+			Queries("location", "").
+			Methods("GET")
 
-	// DeleteObjects (multi-object delete)
-	r.HandleFunc("/{bucket}", s.handleDeleteObjects).
-		Queries("delete", "").
-		Methods("POST")
+		// DeleteObjects (multi-object delete)
+		r.HandleFunc(prefix, s.handleDeleteObjects).
+			Queries("delete", "").
+			Methods("POST")
 
-	// Basic bucket operations (ListObjects V1, CreateBucket, DeleteBucket, HeadBucket)
-	r.HandleFunc("/{bucket}", s.handleBucket).Methods("GET", "HEAD", "PUT", "DELETE")
+		// Basic bucket operations (ListObjects V1, CreateBucket, DeleteBucket, HeadBucket)
+		r.HandleFunc(prefix, s.handleBucket).Methods("GET", "HEAD", "PUT", "DELETE")
+	}
 
 	// List buckets (service level)
 	r.HandleFunc("/", s.handleListBuckets).Methods("GET")
@@ -283,7 +289,17 @@ func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 
 // validateContentLength validates the Content-Length header for PUT requests.
 // Returns true if valid, false if invalid (error already written to response).
+// For AWS chunked transfer encoding (streaming SigV4), the decoded content length
+// is provided in X-Amz-Decoded-Content-Length instead of Content-Length.
 func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
+	// AWS chunked encoding: Content-Length reflects wire size (with chunk framing),
+	// and the actual payload size is in X-Amz-Decoded-Content-Length.
+	if r.Header.Get("X-Amz-Content-Sha256") == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
+		if r.Header.Get("X-Amz-Decoded-Content-Length") != "" {
+			return true
+		}
+	}
+
 	v := r.Header.Get("Content-Length")
 	if v == "" {
 		WriteError(w, r, ErrMissingContentLength)

--- a/handlers/trailing_slash_test.go
+++ b/handlers/trailing_slash_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// TestBucketRoutesMatchTrailingSlash verifies that bucket-level routes match
+// paths with and without trailing slashes. S3 clients like warp send
+// bucket-level requests with trailing slashes (e.g., "GET /bucket/?location=").
+func TestBucketRoutesMatchTrailingSlash(t *testing.T) {
+	// Build a router with the same structure as setupRouter but with simple test handlers.
+	r := mux.NewRouter()
+	r.SkipClean(true)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Register routes the same way setupRouter does (both /{bucket} and /{bucket}/)
+	for _, prefix := range []string{"/{bucket}", "/{bucket}/"} {
+		r.HandleFunc(prefix, handler).Queries("location", "").Methods("GET")
+		r.HandleFunc(prefix, handler).Queries("uploads", "").Methods("GET")
+		r.HandleFunc(prefix, handler).Queries("list-type", "2").Methods("GET")
+		r.HandleFunc(prefix, handler).Methods("GET", "HEAD", "PUT", "DELETE")
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+	}{
+		// Without trailing slash
+		{name: "GET bucket location", method: "GET", path: "/mybucket?location=", wantStatus: 200},
+		{name: "HEAD bucket", method: "HEAD", path: "/mybucket", wantStatus: 200},
+		{name: "PUT bucket", method: "PUT", path: "/mybucket", wantStatus: 200},
+		{name: "DELETE bucket", method: "DELETE", path: "/mybucket", wantStatus: 200},
+		{name: "GET bucket uploads", method: "GET", path: "/mybucket?uploads=", wantStatus: 200},
+		{name: "GET bucket list-type=2", method: "GET", path: "/mybucket?list-type=2", wantStatus: 200},
+
+		// With trailing slash
+		{name: "GET bucket location trailing slash", method: "GET", path: "/mybucket/?location=", wantStatus: 200},
+		{name: "HEAD bucket trailing slash", method: "HEAD", path: "/mybucket/", wantStatus: 200},
+		{name: "PUT bucket trailing slash", method: "PUT", path: "/mybucket/", wantStatus: 200},
+		{name: "DELETE bucket trailing slash", method: "DELETE", path: "/mybucket/", wantStatus: 200},
+		{name: "GET bucket uploads trailing slash", method: "GET", path: "/mybucket/?uploads=", wantStatus: 200},
+		{name: "GET bucket list-type=2 trailing slash", method: "GET", path: "/mybucket/?list-type=2", wantStatus: 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "http://localhost"+tt.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestBucketTrailingSlashPreservesVars verifies that mux.Vars["bucket"] is
+// set correctly for both /{bucket} and /{bucket}/ route patterns.
+func TestBucketTrailingSlashPreservesVars(t *testing.T) {
+	r := mux.NewRouter()
+	r.SkipClean(true)
+
+	var capturedBucket string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBucket = mux.Vars(r)["bucket"]
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for _, prefix := range []string{"/{bucket}", "/{bucket}/"} {
+		r.HandleFunc(prefix, handler).Methods("GET", "HEAD", "PUT")
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantBucket string
+	}{
+		{name: "without trailing slash", path: "/warp", wantBucket: "warp"},
+		{name: "with trailing slash", path: "/warp/", wantBucket: "warp"},
+		{name: "long bucket name", path: "/my-test-bucket/", wantBucket: "my-test-bucket"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedBucket = ""
+			req := httptest.NewRequest(http.MethodGet, "http://localhost"+tt.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if capturedBucket != tt.wantBucket {
+				t.Errorf("bucket = %q, want %q", capturedBucket, tt.wantBucket)
+			}
+		})
+	}
+}
+
+// TestBucketTrailingSlashPreservesURLPath verifies that r.URL.Path is NOT
+// modified when using duplicate routes (important for SigV4 validation).
+func TestBucketTrailingSlashPreservesURLPath(t *testing.T) {
+	r := mux.NewRouter()
+	r.SkipClean(true)
+
+	var capturedPath string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for _, prefix := range []string{"/{bucket}", "/{bucket}/"} {
+		r.HandleFunc(prefix, handler).Methods("GET", "HEAD", "PUT")
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantPath string
+	}{
+		{name: "path without slash preserved", path: "/warp", wantPath: "/warp"},
+		{name: "path with slash preserved", path: "/warp/", wantPath: "/warp/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedPath = ""
+			req := httptest.NewRequest(http.MethodGet, "http://localhost"+tt.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if capturedPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", capturedPath, tt.wantPath)
+			}
+		})
+	}
+}

--- a/handlers/validate_content_length_test.go
+++ b/handlers/validate_content_length_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValidateContentLength_Regular(t *testing.T) {
+	tests := []struct {
+		name          string
+		contentLength string
+		wantValid     bool
+	}{
+		{name: "valid", contentLength: "100", wantValid: true},
+		{name: "zero", contentLength: "0", wantValid: true},
+		{name: "missing", contentLength: "", wantValid: false},
+		{name: "negative", contentLength: "-1", wantValid: false},
+		{name: "non-numeric", contentLength: "abc", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+			if tt.contentLength != "" {
+				req.Header.Set("Content-Length", tt.contentLength)
+			}
+			w := httptest.NewRecorder()
+
+			got := validateContentLength(w, req)
+			if got != tt.wantValid {
+				t.Errorf("validateContentLength() = %v, want %v", got, tt.wantValid)
+			}
+		})
+	}
+}
+
+func TestValidateContentLength_Chunked(t *testing.T) {
+	tests := []struct {
+		name         string
+		decodedLen   string // X-Amz-Decoded-Content-Length value; empty = omit header
+		wantValid    bool
+	}{
+		{name: "valid length", decodedLen: "1048576", wantValid: true},
+		{name: "zero byte upload", decodedLen: "0", wantValid: true},
+		{name: "missing header", decodedLen: "", wantValid: false},
+		{name: "negative value", decodedLen: "-5", wantValid: false},
+		{name: "non-numeric", decodedLen: "abc", wantValid: false},
+		{name: "float value", decodedLen: "1.5", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+			req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+			req.Header.Set("Content-Length", "5000") // wire size, should be ignored
+			if tt.decodedLen != "" {
+				req.Header.Set("X-Amz-Decoded-Content-Length", tt.decodedLen)
+			}
+			w := httptest.NewRecorder()
+
+			got := validateContentLength(w, req)
+			if got != tt.wantValid {
+				t.Errorf("validateContentLength() = %v, want %v", got, tt.wantValid)
+			}
+		})
+	}
+}

--- a/handlers/validate_content_length_test.go
+++ b/handlers/validate_content_length_test.go
@@ -38,21 +38,25 @@ func TestValidateContentLength_Regular(t *testing.T) {
 func TestValidateContentLength_Chunked(t *testing.T) {
 	tests := []struct {
 		name         string
+		bodyHash     string // X-Amz-Content-Sha256 value
 		decodedLen   string // X-Amz-Decoded-Content-Length value; empty = omit header
 		wantValid    bool
 	}{
-		{name: "valid length", decodedLen: "1048576", wantValid: true},
-		{name: "zero byte upload", decodedLen: "0", wantValid: true},
-		{name: "missing header", decodedLen: "", wantValid: false},
-		{name: "negative value", decodedLen: "-5", wantValid: false},
-		{name: "non-numeric", decodedLen: "abc", wantValid: false},
-		{name: "float value", decodedLen: "1.5", wantValid: false},
+		{name: "valid length", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "1048576", wantValid: true},
+		{name: "zero byte upload", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "0", wantValid: true},
+		{name: "missing header", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "", wantValid: false},
+		{name: "negative value", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "-5", wantValid: false},
+		{name: "non-numeric", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "abc", wantValid: false},
+		{name: "float value", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "1.5", wantValid: false},
+		{name: "unsigned trailer valid", bodyHash: "STREAMING-UNSIGNED-PAYLOAD-TRAILER", decodedLen: "512", wantValid: true},
+		{name: "unsigned trailer zero", bodyHash: "STREAMING-UNSIGNED-PAYLOAD-TRAILER", decodedLen: "0", wantValid: true},
+		{name: "unsigned trailer missing", bodyHash: "STREAMING-UNSIGNED-PAYLOAD-TRAILER", decodedLen: "", wantValid: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
-			req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+			req.Header.Set("X-Amz-Content-Sha256", tt.bodyHash)
 			req.Header.Set("Content-Length", "5000") // wire size, should be ignored
 			if tt.decodedLen != "" {
 				req.Header.Set("X-Amz-Decoded-Content-Length", tt.decodedLen)

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 )
 
-const streamingPayloadHash = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+// StreamingPayloadHash is the X-Amz-Content-Sha256 value used by AWS SDKs
+// to indicate AWS chunked transfer encoding (streaming SigV4).
+const StreamingPayloadHash = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
 
 // awsChunkedReader decodes AWS S3 chunked transfer encoding.
 //
@@ -123,7 +125,7 @@ func (r *awsChunkedReader) readTrailingCRLF() error {
 func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string, contentLength int64, chunked bool) {
 	bodyHash = r.Header.Get("X-Amz-Content-Sha256")
 
-	if bodyHash != streamingPayloadHash {
+	if bodyHash != StreamingPayloadHash {
 		return r.Body, bodyHash, r.ContentLength, false
 	}
 

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -13,21 +13,35 @@ import (
 // to indicate AWS chunked transfer encoding (streaming SigV4).
 const StreamingPayloadHash = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
 
+// StreamingUnsignedTrailerHash is the X-Amz-Content-Sha256 value used by
+// AWS SDK v2 for unsigned chunked encoding with trailing checksums.
+const StreamingUnsignedTrailerHash = "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+
+// IsStreamingPayload returns true if the given body hash indicates
+// AWS chunked transfer encoding (either signed or unsigned variant).
+func IsStreamingPayload(bodyHash string) bool {
+	return bodyHash == StreamingPayloadHash || bodyHash == StreamingUnsignedTrailerHash
+}
+
 // awsChunkedReader decodes AWS S3 chunked transfer encoding.
 //
-// Wire format per chunk:
+// Signed wire format per chunk (STREAMING-AWS4-HMAC-SHA256-PAYLOAD):
 //
 //	<hex-chunk-size>;chunk-signature=<signature>\r\n
 //	<chunk-data>\r\n
 //
-// Terminal chunk:
+// Unsigned wire format per chunk (STREAMING-UNSIGNED-PAYLOAD-TRAILER):
 //
-//	0;chunk-signature=<signature>\r\n
-//	\r\n
+//	<hex-chunk-size>\r\n
+//	<chunk-data>\r\n
+//
+// Terminal chunk (both formats):
+//
+//	0[;chunk-signature=<signature>]\r\n
 //
 // The reader strips the framing and returns only the raw chunk data.
-// Chunk signatures are not validated (the request-level signature was
-// already verified by the auth validator).
+// Chunk signatures and trailing checksums are not validated (the
+// request-level signature was already verified by the auth validator).
 type awsChunkedReader struct {
 	reader    *bufio.Reader
 	remaining int
@@ -144,10 +158,13 @@ func (r *awsChunkedReader) readTrailingCRLF() error {
 // If so, returns a decoded body reader, UNSIGNED-PAYLOAD as the body hash, the
 // decoded content length, and chunked=true. Otherwise returns the original values
 // unchanged with chunked=false.
+//
+// Supports both signed (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) and unsigned
+// (STREAMING-UNSIGNED-PAYLOAD-TRAILER) chunked formats.
 func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string, contentLength int64, chunked bool) {
 	bodyHash = r.Header.Get("X-Amz-Content-Sha256")
 
-	if bodyHash != StreamingPayloadHash {
+	if !IsStreamingPayload(bodyHash) {
 		return r.Body, bodyHash, r.ContentLength, false
 	}
 

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -74,16 +74,19 @@ func (r *awsChunkedReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// maxChunkHeaderLen is the maximum allowed length of a chunk header line.
+// AWS chunk headers contain a hex size and a signature (~88 chars for the
+// signature), so 256 bytes is generous. This prevents memory exhaustion
+// from a malicious request body containing no newlines.
+const maxChunkHeaderLen = 256
+
 // readChunkHeader reads a line like "<hex-size>;chunk-signature=<sig>\r\n"
 // and sets r.remaining to the chunk data size. Sets r.done if size is 0.
 func (r *awsChunkedReader) readChunkHeader() error {
-	line, err := r.reader.ReadString('\n')
+	line, err := r.readLine()
 	if err != nil {
 		return fmt.Errorf("reading chunk header: %w", err)
 	}
-
-	// Trim \r\n
-	line = strings.TrimRight(line, "\r\n")
 
 	// Extract hex size before the semicolon
 	sizeStr := line
@@ -96,13 +99,32 @@ func (r *awsChunkedReader) readChunkHeader() error {
 		return fmt.Errorf("parsing chunk size %q: %w", sizeStr, err)
 	}
 
-	if size == 0 {
+	if size <= 0 {
 		r.done = true
 		return nil
 	}
 
 	r.remaining = int(size)
 	return nil
+}
+
+// readLine reads a single \n-terminated line from the reader, enforcing
+// maxChunkHeaderLen to prevent unbounded memory allocation.
+func (r *awsChunkedReader) readLine() (string, error) {
+	var line []byte
+	for {
+		b, err := r.reader.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		if b == '\n' {
+			return strings.TrimRight(string(line), "\r"), nil
+		}
+		line = append(line, b)
+		if len(line) > maxChunkHeaderLen {
+			return "", fmt.Errorf("chunk header exceeds maximum length (%d bytes)", maxChunkHeaderLen)
+		}
+	}
 }
 
 // readTrailingCRLF consumes and validates the \r\n after chunk data.

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -1,0 +1,136 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const streamingPayloadHash = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+
+// awsChunkedReader decodes AWS S3 chunked transfer encoding.
+//
+// Wire format per chunk:
+//
+//	<hex-chunk-size>;chunk-signature=<signature>\r\n
+//	<chunk-data>\r\n
+//
+// Terminal chunk:
+//
+//	0;chunk-signature=<signature>\r\n
+//	\r\n
+//
+// The reader strips the framing and returns only the raw chunk data.
+// Chunk signatures are not validated (the request-level signature was
+// already verified by the auth validator).
+type awsChunkedReader struct {
+	reader    *bufio.Reader
+	remaining int
+	done      bool
+}
+
+func newAWSChunkedReader(r io.Reader) *awsChunkedReader {
+	return &awsChunkedReader{
+		reader: bufio.NewReaderSize(r, 64*1024),
+	}
+}
+
+func (r *awsChunkedReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+
+	// If no data remaining in current chunk, read next chunk header.
+	if r.remaining == 0 {
+		if err := r.readChunkHeader(); err != nil {
+			return 0, err
+		}
+		if r.done {
+			return 0, io.EOF
+		}
+	}
+
+	// Read up to remaining bytes from current chunk.
+	toRead := len(p)
+	if toRead > r.remaining {
+		toRead = r.remaining
+	}
+
+	n, err := r.reader.Read(p[:toRead])
+	r.remaining -= n
+
+	// When we've consumed the entire chunk, read the trailing \r\n.
+	if r.remaining == 0 && err == nil {
+		if err := r.readTrailingCRLF(); err != nil {
+			return n, err
+		}
+	}
+
+	return n, err
+}
+
+// readChunkHeader reads a line like "<hex-size>;chunk-signature=<sig>\r\n"
+// and sets r.remaining to the chunk data size. Sets r.done if size is 0.
+func (r *awsChunkedReader) readChunkHeader() error {
+	line, err := r.reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading chunk header: %w", err)
+	}
+
+	// Trim \r\n
+	line = strings.TrimRight(line, "\r\n")
+
+	// Extract hex size before the semicolon
+	sizeStr := line
+	if idx := strings.IndexByte(line, ';'); idx != -1 {
+		sizeStr = line[:idx]
+	}
+
+	size, err := strconv.ParseInt(strings.TrimSpace(sizeStr), 16, 64)
+	if err != nil {
+		return fmt.Errorf("parsing chunk size %q: %w", sizeStr, err)
+	}
+
+	if size == 0 {
+		r.done = true
+		return nil
+	}
+
+	r.remaining = int(size)
+	return nil
+}
+
+// readTrailingCRLF consumes the \r\n after chunk data.
+func (r *awsChunkedReader) readTrailingCRLF() error {
+	var buf [2]byte
+	_, err := io.ReadFull(r.reader, buf[:])
+	if err != nil {
+		return fmt.Errorf("reading chunk trailer: %w", err)
+	}
+	return nil
+}
+
+// decodeChunkedIfNeeded checks if the request uses AWS chunked transfer encoding.
+// If so, returns a decoded body reader, UNSIGNED-PAYLOAD as the body hash, and
+// the decoded content length. Otherwise returns the original values unchanged.
+func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string, contentLength int64) {
+	bodyHash = r.Header.Get("X-Amz-Content-Sha256")
+
+	if bodyHash != streamingPayloadHash {
+		return r.Body, bodyHash, r.ContentLength
+	}
+
+	// Parse decoded content length from header
+	contentLength = -1
+	if v := r.Header.Get("X-Amz-Decoded-Content-Length"); v != "" {
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
+			contentLength = parsed
+		}
+	}
+
+	decoded := newAWSChunkedReader(r.Body)
+	return io.NopCloser(decoded), "UNSIGNED-PAYLOAD", contentLength
+}

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -103,24 +103,28 @@ func (r *awsChunkedReader) readChunkHeader() error {
 	return nil
 }
 
-// readTrailingCRLF consumes the \r\n after chunk data.
+// readTrailingCRLF consumes and validates the \r\n after chunk data.
 func (r *awsChunkedReader) readTrailingCRLF() error {
 	var buf [2]byte
 	_, err := io.ReadFull(r.reader, buf[:])
 	if err != nil {
 		return fmt.Errorf("reading chunk trailer: %w", err)
 	}
+	if buf[0] != '\r' || buf[1] != '\n' {
+		return fmt.Errorf("invalid chunk trailer: expected CRLF, got %q", buf)
+	}
 	return nil
 }
 
 // decodeChunkedIfNeeded checks if the request uses AWS chunked transfer encoding.
-// If so, returns a decoded body reader, UNSIGNED-PAYLOAD as the body hash, and
-// the decoded content length. Otherwise returns the original values unchanged.
-func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string, contentLength int64) {
+// If so, returns a decoded body reader, UNSIGNED-PAYLOAD as the body hash, the
+// decoded content length, and chunked=true. Otherwise returns the original values
+// unchanged with chunked=false.
+func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string, contentLength int64, chunked bool) {
 	bodyHash = r.Header.Get("X-Amz-Content-Sha256")
 
 	if bodyHash != streamingPayloadHash {
-		return r.Body, bodyHash, r.ContentLength
+		return r.Body, bodyHash, r.ContentLength, false
 	}
 
 	// Parse decoded content length from header
@@ -132,5 +136,5 @@ func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string
 	}
 
 	decoded := newAWSChunkedReader(r.Body)
-	return io.NopCloser(decoded), "UNSIGNED-PAYLOAD", contentLength
+	return io.NopCloser(decoded), "UNSIGNED-PAYLOAD", contentLength, true
 }

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -328,3 +328,29 @@ func TestPrepareForwardedRequest_PreservesNonAWSContentEncoding(t *testing.T) {
 		t.Errorf("Content-Encoding = %q, want %q", req.Header.Get("Content-Encoding"), "gzip")
 	}
 }
+
+func TestPrepareForwardedRequest_CombinedContentEncoding(t *testing.T) {
+	// AWS S3 allows "aws-chunked,gzip" — strip aws-chunked, keep gzip.
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.Header.Set("X-Amz-Decoded-Content-Length", "1024")
+	req.Header.Set("Content-Encoding", "aws-chunked,gzip")
+	req.ContentLength = 2000
+
+	prepareForwardedRequest(req, 1024, true)
+
+	if got := req.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}
+
+func TestPrepareForwardedRequest_CombinedContentEncodingWithSpaces(t *testing.T) {
+	// Handle whitespace around tokens.
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.Header.Set("Content-Encoding", "aws-chunked , gzip")
+
+	prepareForwardedRequest(req, 1024, true)
+
+	if got := req.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -109,8 +109,11 @@ func TestDecodeChunkedIfNeeded_NotChunked(t *testing.T) {
 	req.Header.Set("X-Amz-Content-Sha256", "abc123hash")
 	req.ContentLength = 5
 
-	gotBody, gotHash, gotLen := decodeChunkedIfNeeded(req)
+	gotBody, gotHash, gotLen, gotChunked := decodeChunkedIfNeeded(req)
 
+	if gotChunked {
+		t.Error("chunked = true, want false")
+	}
 	if gotHash != "abc123hash" {
 		t.Errorf("bodyHash = %q, want %q", gotHash, "abc123hash")
 	}
@@ -132,8 +135,11 @@ func TestDecodeChunkedIfNeeded_Chunked(t *testing.T) {
 	req.Header.Set("X-Amz-Decoded-Content-Length", "4")
 	req.ContentLength = int64(len(chunkedBody))
 
-	gotBody, gotHash, gotLen := decodeChunkedIfNeeded(req)
+	gotBody, gotHash, gotLen, gotChunked := decodeChunkedIfNeeded(req)
 
+	if !gotChunked {
+		t.Error("chunked = false, want true")
+	}
 	if gotHash != "UNSIGNED-PAYLOAD" {
 		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
 	}
@@ -157,12 +163,29 @@ func TestDecodeChunkedIfNeeded_MissingDecodedLength(t *testing.T) {
 	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
 	// No X-Amz-Decoded-Content-Length header
 
-	_, gotHash, gotLen := decodeChunkedIfNeeded(req)
+	_, gotHash, gotLen, gotChunked := decodeChunkedIfNeeded(req)
 
+	if !gotChunked {
+		t.Error("chunked = false, want true")
+	}
 	if gotHash != "UNSIGNED-PAYLOAD" {
 		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
 	}
 	if gotLen != -1 {
 		t.Errorf("contentLength = %d, want -1", gotLen)
+	}
+}
+
+func TestAWSChunkedReader_InvalidTrailer(t *testing.T) {
+	// Chunk data followed by invalid trailer (not \r\n)
+	input := "3;chunk-signature=sig1\r\nfooXX"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	_, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("expected error for invalid chunk trailer")
+	}
+	if !strings.Contains(err.Error(), "expected CRLF") {
+		t.Errorf("error = %q, want it to mention expected CRLF", err.Error())
 	}
 }

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -1,0 +1,168 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAWSChunkedReader_SingleChunk(t *testing.T) {
+	// 4 bytes of data + terminal chunk
+	input := "4;chunk-signature=abc123\r\ntest\r\n0;chunk-signature=def456\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "test" {
+		t.Errorf("got %q, want %q", string(data), "test")
+	}
+}
+
+func TestAWSChunkedReader_MultipleChunks(t *testing.T) {
+	input := "4;chunk-signature=sig1\r\ntest\r\n5;chunk-signature=sig2\r\nhello\r\n0;chunk-signature=sig3\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "testhello" {
+		t.Errorf("got %q, want %q", string(data), "testhello")
+	}
+}
+
+func TestAWSChunkedReader_EmptyBody(t *testing.T) {
+	input := "0;chunk-signature=sig1\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("got %d bytes, want 0", len(data))
+	}
+}
+
+func TestAWSChunkedReader_LargeChunk(t *testing.T) {
+	// 64KB chunk
+	payload := strings.Repeat("A", 65536)
+	input := "10000;chunk-signature=sig1\r\n" + payload + "\r\n0;chunk-signature=sig2\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 65536 {
+		t.Errorf("got %d bytes, want 65536", len(data))
+	}
+	if string(data) != payload {
+		t.Error("payload mismatch")
+	}
+}
+
+func TestAWSChunkedReader_SmallReads(t *testing.T) {
+	input := "a;chunk-signature=sig1\r\n0123456789\r\n0;chunk-signature=sig2\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	// Read 3 bytes at a time
+	var result []byte
+	buf := make([]byte, 3)
+	for {
+		n, err := reader.Read(buf)
+		result = append(result, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if string(result) != "0123456789" {
+		t.Errorf("got %q, want %q", string(result), "0123456789")
+	}
+}
+
+func TestAWSChunkedReader_LongSignature(t *testing.T) {
+	// Real-world signatures are 64 hex chars
+	sig := strings.Repeat("ab", 32)
+	input := "3;chunk-signature=" + sig + "\r\nfoo\r\n0;chunk-signature=" + sig + "\r\n\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "foo" {
+		t.Errorf("got %q, want %q", string(data), "foo")
+	}
+}
+
+func TestDecodeChunkedIfNeeded_NotChunked(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("hello"))
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", body)
+	req.Header.Set("X-Amz-Content-Sha256", "abc123hash")
+	req.ContentLength = 5
+
+	gotBody, gotHash, gotLen := decodeChunkedIfNeeded(req)
+
+	if gotHash != "abc123hash" {
+		t.Errorf("bodyHash = %q, want %q", gotHash, "abc123hash")
+	}
+	if gotLen != 5 {
+		t.Errorf("contentLength = %d, want 5", gotLen)
+	}
+
+	data, _ := io.ReadAll(gotBody)
+	if string(data) != "hello" {
+		t.Errorf("body = %q, want %q", string(data), "hello")
+	}
+}
+
+func TestDecodeChunkedIfNeeded_Chunked(t *testing.T) {
+	chunkedBody := "4;chunk-signature=sig1\r\ntest\r\n0;chunk-signature=sig2\r\n\r\n"
+	body := io.NopCloser(strings.NewReader(chunkedBody))
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", body)
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+	req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+	req.ContentLength = int64(len(chunkedBody))
+
+	gotBody, gotHash, gotLen := decodeChunkedIfNeeded(req)
+
+	if gotHash != "UNSIGNED-PAYLOAD" {
+		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
+	}
+	if gotLen != 4 {
+		t.Errorf("contentLength = %d, want 4", gotLen)
+	}
+
+	data, err := io.ReadAll(gotBody)
+	if err != nil {
+		t.Fatalf("reading decoded body: %v", err)
+	}
+	if string(data) != "test" {
+		t.Errorf("body = %q, want %q", string(data), "test")
+	}
+}
+
+func TestDecodeChunkedIfNeeded_MissingDecodedLength(t *testing.T) {
+	chunkedBody := "3;chunk-signature=sig1\r\nfoo\r\n0;chunk-signature=sig2\r\n\r\n"
+	body := io.NopCloser(strings.NewReader(chunkedBody))
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", body)
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+	// No X-Amz-Decoded-Content-Length header
+
+	_, gotHash, gotLen := decodeChunkedIfNeeded(req)
+
+	if gotHash != "UNSIGNED-PAYLOAD" {
+		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
+	}
+	if gotLen != -1 {
+		t.Errorf("contentLength = %d, want -1", gotLen)
+	}
+}

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -265,6 +265,12 @@ func TestPrepareForwardedRequest_ChunkedZeroByte(t *testing.T) {
 	if req.Header.Get("X-Amz-Decoded-Content-Length") != "" {
 		t.Error("X-Amz-Decoded-Content-Length should be removed")
 	}
+	// Body must be http.NoBody so Go's HTTP transport sends "Content-Length: 0"
+	// instead of "Transfer-Encoding: chunked" (which happens when ContentLength == 0
+	// but Body is a non-nil reader).
+	if req.Body != http.NoBody {
+		t.Error("Body should be http.NoBody for zero-byte chunked request")
+	}
 }
 
 func TestPrepareForwardedRequest_NonChunked(t *testing.T) {

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -290,6 +290,34 @@ func TestPrepareForwardedRequest_NonChunkedNoBody(t *testing.T) {
 	}
 }
 
+func TestAWSChunkedReader_NegativeChunkSize(t *testing.T) {
+	// Negative hex size should be treated as terminal (size <= 0), not panic.
+	input := "-1;chunk-signature=sig1\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("got %d bytes, want 0", len(data))
+	}
+}
+
+func TestAWSChunkedReader_UnboundedHeaderLine(t *testing.T) {
+	// A body with no newline should hit the max header length limit, not OOM.
+	input := strings.Repeat("A", maxChunkHeaderLen+10)
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	_, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("expected error for oversized chunk header")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum length") {
+		t.Errorf("error = %q, want it to mention exceeds maximum length", err.Error())
+	}
+}
+
 func TestPrepareForwardedRequest_PreservesNonAWSContentEncoding(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
 	req.Header.Set("Content-Encoding", "gzip")

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -189,3 +189,114 @@ func TestAWSChunkedReader_InvalidTrailer(t *testing.T) {
 		t.Errorf("error = %q, want it to mention expected CRLF", err.Error())
 	}
 }
+
+func TestAWSChunkedReader_InvalidChunkSize(t *testing.T) {
+	input := "ZZZZ;chunk-signature=sig1\r\n"
+	reader := newAWSChunkedReader(strings.NewReader(input))
+
+	_, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("expected error for invalid hex chunk size")
+	}
+	if !strings.Contains(err.Error(), "parsing chunk size") {
+		t.Errorf("error = %q, want it to mention parsing chunk size", err.Error())
+	}
+}
+
+func TestDecodeChunkedIfNeeded_ZeroByteChunked(t *testing.T) {
+	// Zero-byte upload via chunked encoding: only a terminal chunk
+	chunkedBody := "0;chunk-signature=sig1\r\n\r\n"
+	body := io.NopCloser(strings.NewReader(chunkedBody))
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", body)
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+	req.Header.Set("X-Amz-Decoded-Content-Length", "0")
+	req.ContentLength = int64(len(chunkedBody))
+
+	gotBody, gotHash, gotLen, gotChunked := decodeChunkedIfNeeded(req)
+
+	if !gotChunked {
+		t.Error("chunked = false, want true")
+	}
+	if gotHash != "UNSIGNED-PAYLOAD" {
+		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
+	}
+	if gotLen != 0 {
+		t.Errorf("contentLength = %d, want 0", gotLen)
+	}
+
+	data, err := io.ReadAll(gotBody)
+	if err != nil {
+		t.Fatalf("reading decoded body: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("body length = %d, want 0", len(data))
+	}
+}
+
+func TestPrepareForwardedRequest_Chunked(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.Header.Set("X-Amz-Decoded-Content-Length", "1024")
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.ContentLength = 2000 // wire size
+
+	prepareForwardedRequest(req, 1024, true)
+
+	if req.ContentLength != 1024 {
+		t.Errorf("ContentLength = %d, want 1024", req.ContentLength)
+	}
+	if req.Header.Get("X-Amz-Decoded-Content-Length") != "" {
+		t.Error("X-Amz-Decoded-Content-Length should be removed")
+	}
+	if req.Header.Get("Content-Encoding") != "" {
+		t.Error("Content-Encoding: aws-chunked should be removed")
+	}
+}
+
+func TestPrepareForwardedRequest_ChunkedZeroByte(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.Header.Set("X-Amz-Decoded-Content-Length", "0")
+	req.ContentLength = 100 // wire size with chunk framing
+
+	prepareForwardedRequest(req, 0, true)
+
+	if req.ContentLength != 0 {
+		t.Errorf("ContentLength = %d, want 0", req.ContentLength)
+	}
+	if req.Header.Get("X-Amz-Decoded-Content-Length") != "" {
+		t.Error("X-Amz-Decoded-Content-Length should be removed")
+	}
+}
+
+func TestPrepareForwardedRequest_NonChunked(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.ContentLength = 0
+
+	prepareForwardedRequest(req, 512, false)
+
+	if req.ContentLength != 512 {
+		t.Errorf("ContentLength = %d, want 512", req.ContentLength)
+	}
+}
+
+func TestPrepareForwardedRequest_NonChunkedNoBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/bucket/key", nil)
+	req.ContentLength = 0
+
+	prepareForwardedRequest(req, 0, false)
+
+	// Should not change ContentLength for non-chunked with 0/negative length
+	if req.ContentLength != 0 {
+		t.Errorf("ContentLength = %d, want 0", req.ContentLength)
+	}
+}
+
+func TestPrepareForwardedRequest_PreservesNonAWSContentEncoding(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	prepareForwardedRequest(req, 1024, true)
+
+	if req.Header.Get("Content-Encoding") != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", req.Header.Get("Content-Encoding"), "gzip")
+	}
+}

--- a/proxy/chunked_reader_test.go
+++ b/proxy/chunked_reader_test.go
@@ -324,6 +324,54 @@ func TestAWSChunkedReader_UnboundedHeaderLine(t *testing.T) {
 	}
 }
 
+func TestDecodeChunkedIfNeeded_UnsignedTrailer(t *testing.T) {
+	// Unsigned chunked format used by AWS SDK v2 (no per-chunk signatures)
+	chunkedBody := "4\r\ntest\r\n0\r\n\r\n"
+	body := io.NopCloser(strings.NewReader(chunkedBody))
+	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", body)
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+	req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+	req.ContentLength = int64(len(chunkedBody))
+
+	gotBody, gotHash, gotLen, gotChunked := decodeChunkedIfNeeded(req)
+
+	if !gotChunked {
+		t.Error("chunked = false, want true")
+	}
+	if gotHash != "UNSIGNED-PAYLOAD" {
+		t.Errorf("bodyHash = %q, want %q", gotHash, "UNSIGNED-PAYLOAD")
+	}
+	if gotLen != 4 {
+		t.Errorf("contentLength = %d, want 4", gotLen)
+	}
+
+	data, err := io.ReadAll(gotBody)
+	if err != nil {
+		t.Fatalf("reading decoded body: %v", err)
+	}
+	if string(data) != "test" {
+		t.Errorf("body = %q, want %q", string(data), "test")
+	}
+}
+
+func TestIsStreamingPayload(t *testing.T) {
+	tests := []struct {
+		hash string
+		want bool
+	}{
+		{"STREAMING-AWS4-HMAC-SHA256-PAYLOAD", true},
+		{"STREAMING-UNSIGNED-PAYLOAD-TRAILER", true},
+		{"UNSIGNED-PAYLOAD", false},
+		{"e3b0c44298fc1c149afbf4c8996fb924", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsStreamingPayload(tt.hash); got != tt.want {
+			t.Errorf("IsStreamingPayload(%q) = %v, want %v", tt.hash, got, tt.want)
+		}
+	}
+}
+
 func TestPrepareForwardedRequest_PreservesNonAWSContentEncoding(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "http://localhost/bucket/key", nil)
 	req.Header.Set("Content-Encoding", "gzip")

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -123,7 +123,7 @@ func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string
 // is decoded on-the-fly and forwarded as UNSIGNED-PAYLOAD.
 func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
 
 	// Validate incoming request signature
 	accessKey, err := f.validator.ValidateRequest(r)
@@ -150,15 +150,17 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 		return err
 	}
 
-	// Set content length for the forwarded request
-	if contentLength > 0 {
+	// For chunked requests, always override Content-Length with decoded size
+	// (the original Content-Length reflects wire size including chunk framing).
+	// For non-chunked requests, set Content-Length if known.
+	if chunked {
 		fwdReq.ContentLength = contentLength
-	}
-
-	// Strip chunked-encoding headers that don't apply to the decoded body
-	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-		fwdReq.Header.Del("Content-Encoding")
+		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+			fwdReq.Header.Del("Content-Encoding")
+		}
+	} else if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
 	}
 
 	// Track bytes in from request body
@@ -195,7 +197,7 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 // If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
 func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
 	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
 
 	// Validate incoming request signature
 	accessKey, err := f.validator.ValidateRequest(r)
@@ -222,15 +224,17 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 		return nil, err
 	}
 
-	// Set content length for the forwarded request
-	if contentLength > 0 {
+	// For chunked requests, always override Content-Length with decoded size
+	// (the original Content-Length reflects wire size including chunk framing).
+	// For non-chunked requests, set Content-Length if known.
+	if chunked {
 		fwdReq.ContentLength = contentLength
-	}
-
-	// Strip chunked-encoding headers that don't apply to the decoded body
-	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-		fwdReq.Header.Del("Content-Encoding")
+		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+			fwdReq.Header.Del("Content-Encoding")
+		}
+	} else if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
 	}
 
 	// Track bytes in from request body
@@ -324,7 +328,7 @@ func (f *Forwarder) ValidateAndGetCredentials(r *http.Request) (accessKey, secre
 // If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
 func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
 	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
 
 	path := r.URL.Path
 	if r.URL.RawQuery != "" {
@@ -336,14 +340,17 @@ func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, acc
 		return nil, err
 	}
 
-	if contentLength > 0 {
+	// For chunked requests, always override Content-Length with decoded size
+	// (the original Content-Length reflects wire size including chunk framing).
+	// For non-chunked requests, set Content-Length if known.
+	if chunked {
 		fwdReq.ContentLength = contentLength
-	}
-
-	// Strip chunked-encoding headers that don't apply to the decoded body
-	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-		fwdReq.Header.Del("Content-Encoding")
+		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+			fwdReq.Header.Del("Content-Encoding")
+		}
+	} else if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
 	}
 
 	// Track bytes in from request body

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -117,6 +117,20 @@ func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string
 	}
 }
 
+// prepareForwardedRequest sets Content-Length on the forwarded request and strips
+// AWS chunked-encoding headers when the request body was decoded from chunked format.
+func prepareForwardedRequest(fwdReq *http.Request, contentLength int64, chunked bool) {
+	if chunked {
+		fwdReq.ContentLength = contentLength
+		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+			fwdReq.Header.Del("Content-Encoding")
+		}
+	} else if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
+	}
+}
+
 // Forward forwards a request to Tigris and writes the response to the client.
 // Uses zero-copy streaming - the X-Amz-Content-Sha256 header is required (all AWS SDKs set this).
 // If the request uses AWS chunked transfer encoding (streaming SigV4), the body
@@ -149,19 +163,7 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 	if err != nil {
 		return err
 	}
-
-	// For chunked requests, always override Content-Length with decoded size
-	// (the original Content-Length reflects wire size including chunk framing).
-	// For non-chunked requests, set Content-Length if known.
-	if chunked {
-		fwdReq.ContentLength = contentLength
-		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-			fwdReq.Header.Del("Content-Encoding")
-		}
-	} else if contentLength > 0 {
-		fwdReq.ContentLength = contentLength
-	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
 
 	// Track bytes in from request body
 	if contentLength > 0 {
@@ -223,19 +225,7 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 	if err != nil {
 		return nil, err
 	}
-
-	// For chunked requests, always override Content-Length with decoded size
-	// (the original Content-Length reflects wire size including chunk framing).
-	// For non-chunked requests, set Content-Length if known.
-	if chunked {
-		fwdReq.ContentLength = contentLength
-		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-			fwdReq.Header.Del("Content-Encoding")
-		}
-	} else if contentLength > 0 {
-		fwdReq.ContentLength = contentLength
-	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
 
 	// Track bytes in from request body
 	if contentLength > 0 {
@@ -339,19 +329,7 @@ func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, acc
 	if err != nil {
 		return nil, err
 	}
-
-	// For chunked requests, always override Content-Length with decoded size
-	// (the original Content-Length reflects wire size including chunk framing).
-	// For non-chunked requests, set Content-Length if known.
-	if chunked {
-		fwdReq.ContentLength = contentLength
-		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-			fwdReq.Header.Del("Content-Encoding")
-		}
-	} else if contentLength > 0 {
-		fwdReq.ContentLength = contentLength
-	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
 
 	// Track bytes in from request body
 	if contentLength > 0 {

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -119,9 +119,11 @@ func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string
 
 // Forward forwards a request to Tigris and writes the response to the client.
 // Uses zero-copy streaming - the X-Amz-Content-Sha256 header is required (all AWS SDKs set this).
+// If the request uses AWS chunked transfer encoding (streaming SigV4), the body
+// is decoded on-the-fly and forwarded as UNSIGNED-PAYLOAD.
 func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	// Get body hash from request header (required for all AWS SDK clients)
-	bodyHash := r.Header.Get("X-Amz-Content-Sha256")
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
 
 	// Validate incoming request signature
 	accessKey, err := f.validator.ValidateRequest(r)
@@ -143,19 +145,25 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 	}
 
 	// Create signed request (passes body hash, streams body directly)
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, r.Body, bodyHash, accessKey, secretKey, r.Header)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
 	if err != nil {
 		return err
 	}
 
-	// Set content length if known (needed for streaming)
-	if r.ContentLength > 0 {
-		fwdReq.ContentLength = r.ContentLength
+	// Set content length for the forwarded request
+	if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
+	}
+
+	// Strip chunked-encoding headers that don't apply to the decoded body
+	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+		fwdReq.Header.Del("Content-Encoding")
 	}
 
 	// Track bytes in from request body
-	if r.ContentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	if contentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
 	}
 
 	// Forward to Tigris
@@ -184,9 +192,10 @@ func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.
 // ForwardWithCapture forwards request and captures response for caching.
 // Uses zero-copy streaming for the request body (X-Amz-Content-Sha256 header is required).
 // The response body is captured for caching while streaming to the client.
+// If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
 func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
-	// Get body hash from request header (required for all AWS SDK clients)
-	bodyHash := r.Header.Get("X-Amz-Content-Sha256")
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
 
 	// Validate incoming request signature
 	accessKey, err := f.validator.ValidateRequest(r)
@@ -208,19 +217,25 @@ func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWrite
 	}
 
 	// Create signed request (passes body hash, streams body directly)
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, r.Body, bodyHash, accessKey, secretKey, r.Header)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set content length if known
-	if r.ContentLength > 0 {
-		fwdReq.ContentLength = r.ContentLength
+	// Set content length for the forwarded request
+	if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
+	}
+
+	// Strip chunked-encoding headers that don't apply to the decoded body
+	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+		fwdReq.Header.Del("Content-Encoding")
 	}
 
 	// Track bytes in from request body
-	if r.ContentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	if contentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
 	}
 
 	// Forward to Tigris
@@ -306,26 +321,34 @@ func (f *Forwarder) ValidateAndGetCredentials(r *http.Request) (accessKey, secre
 
 // DoRequestWithCreds executes a request with pre-validated credentials.
 // Returns the raw response for streaming. Caller is responsible for closing the response body.
+// If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
 func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
-	bodyHash := r.Header.Get("X-Amz-Content-Sha256")
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength := decodeChunkedIfNeeded(r)
 
 	path := r.URL.Path
 	if r.URL.RawQuery != "" {
 		path = path + "?" + r.URL.RawQuery
 	}
 
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, r.Body, bodyHash, accessKey, secretKey, r.Header)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
 	if err != nil {
 		return nil, err
 	}
 
-	if r.ContentLength > 0 {
-		fwdReq.ContentLength = r.ContentLength
+	if contentLength > 0 {
+		fwdReq.ContentLength = contentLength
+	}
+
+	// Strip chunked-encoding headers that don't apply to the decoded body
+	fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
+	if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
+		fwdReq.Header.Del("Content-Encoding")
 	}
 
 	// Track bytes in from request body
-	if r.ContentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(r.ContentLength))
+	if contentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
 	}
 
 	upstreamStart := time.Now()

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -123,11 +123,32 @@ func prepareForwardedRequest(fwdReq *http.Request, contentLength int64, chunked 
 	if chunked {
 		fwdReq.ContentLength = contentLength
 		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
-		if fwdReq.Header.Get("Content-Encoding") == "aws-chunked" {
-			fwdReq.Header.Del("Content-Encoding")
-		}
+		stripAWSChunkedEncoding(fwdReq)
 	} else if contentLength > 0 {
 		fwdReq.ContentLength = contentLength
+	}
+}
+
+// stripAWSChunkedEncoding removes "aws-chunked" from the Content-Encoding header.
+// AWS S3 allows combined values like "aws-chunked,gzip". After decoding the chunked
+// layer, we strip only the aws-chunked token and preserve any remaining encodings.
+func stripAWSChunkedEncoding(req *http.Request) {
+	ce := req.Header.Get("Content-Encoding")
+	if ce == "" {
+		return
+	}
+
+	var remaining []string
+	for _, part := range strings.Split(ce, ",") {
+		if strings.TrimSpace(part) != "aws-chunked" {
+			remaining = append(remaining, strings.TrimSpace(part))
+		}
+	}
+
+	if len(remaining) == 0 {
+		req.Header.Del("Content-Encoding")
+	} else {
+		req.Header.Set("Content-Encoding", strings.Join(remaining, ","))
 	}
 }
 

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -124,6 +124,13 @@ func prepareForwardedRequest(fwdReq *http.Request, contentLength int64, chunked 
 		fwdReq.ContentLength = contentLength
 		fwdReq.Header.Del("X-Amz-Decoded-Content-Length")
 		stripAWSChunkedEncoding(fwdReq)
+		// When decoded content length is 0, set Body to http.NoBody so Go's
+		// HTTP transport sends "Content-Length: 0" instead of using
+		// "Transfer-Encoding: chunked" (which happens when ContentLength == 0
+		// but Body is a non-nil reader — Go's outgoingLength returns -1).
+		if contentLength == 0 {
+			fwdReq.Body = http.NoBody
+		}
 	} else if contentLength > 0 {
 		fwdReq.ContentLength = contentLength
 	}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -393,6 +393,10 @@ func (s *Service) receiveFromBroadcastListener(
 
 // writeChunksToResponse writes received chunks to the HTTP response.
 // xCache specifies the X-Cache header value (MISS, BYPASS, DISABLED).
+//
+// Header commitment is deferred until the first data chunk arrives. This prevents
+// committing a 200 OK with Content-Length when the upstream fetch may still fail.
+// If an error arrives before any data, the caller can write a proper error response.
 func (s *Service) writeChunksToResponse(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -405,12 +409,7 @@ func (s *Service) writeChunksToResponse(
 		return err
 	}
 
-	// Write headers to response
-	copyHeaders(w.Header(), headers)
-	w.Header().Set(XCacheHeader, xCache)
-	w.WriteHeader(status)
-
-	// Receive and write chunks
+	var headersWritten bool
 	var totalBytesOut int64
 	defer func() {
 		// Track bytes out to client, even on error
@@ -428,6 +427,12 @@ func (s *Service) writeChunksToResponse(
 		}
 
 		if len(chunk.Data) > 0 {
+			if !headersWritten {
+				copyHeaders(w.Header(), headers)
+				w.Header().Set(XCacheHeader, xCache)
+				w.WriteHeader(status)
+				headersWritten = true
+			}
 			n, writeErr := w.Write(chunk.Data)
 			totalBytesOut += int64(n)
 			if writeErr != nil {
@@ -438,6 +443,13 @@ func (s *Service) writeChunksToResponse(
 				flusher.Flush()
 			}
 		}
+	}
+
+	// Zero-byte response or all-empty chunks: commit headers now
+	if !headersWritten {
+		copyHeaders(w.Header(), headers)
+		w.Header().Set(XCacheHeader, xCache)
+		w.WriteHeader(status)
 	}
 
 	return nil

--- a/proxy/get_object_test.go
+++ b/proxy/get_object_test.go
@@ -1,0 +1,179 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tigrisdata/tag/proxy/broadcast"
+)
+
+func TestWriteChunksToResponse_ErrorBeforeData(t *testing.T) {
+	// When broadcast errors before sending any data, headers should NOT be
+	// committed so the caller can write a proper error response.
+	b := broadcast.NewBroadcaster(16)
+	listener := b.Subscribe()
+	b.SetHeaders(http.StatusOK, http.Header{
+		"Content-Length": []string{"3"},
+		"Content-Type":  []string{"application/octet-stream"},
+	})
+
+	// Complete with error before any data chunks
+	go func() {
+		b.Complete(errors.New("upstream fetch failed"))
+	}()
+
+	w := httptest.NewRecorder()
+	svc := &Service{}
+	err := svc.writeChunksToResponse(context.Background(), w, listener, "MISS")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "upstream fetch failed" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Headers should NOT be committed — status code should still be default (200)
+	// and no explicit WriteHeader call should have been made
+	if w.Code != http.StatusOK {
+		// httptest.ResponseRecorder defaults to 200 if WriteHeader was never called.
+		// We verify no body was written, which is the key behavior.
+		t.Errorf("unexpected status code: %d", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %d bytes", w.Body.Len())
+	}
+	// Content-Length should NOT have been set on the response
+	if w.Header().Get("Content-Length") != "" {
+		t.Error("Content-Length should not be set when error occurs before data")
+	}
+	if w.Header().Get("X-Cache") != "" {
+		t.Error("X-Cache should not be set when error occurs before data")
+	}
+}
+
+func TestWriteChunksToResponse_NormalDataFlow(t *testing.T) {
+	// Normal case: headers committed on first data chunk, body written correctly.
+	b := broadcast.NewBroadcaster(16)
+	listener := b.Subscribe()
+	b.SetHeaders(http.StatusOK, http.Header{
+		"Content-Length": []string{"6"},
+		"Content-Type":  []string{"text/plain"},
+	})
+
+	go func() {
+		b.Broadcast([]byte("foo"))
+		b.Broadcast([]byte("bar"))
+		b.Complete(nil)
+	}()
+
+	w := httptest.NewRecorder()
+	svc := &Service{}
+	err := svc.writeChunksToResponse(context.Background(), w, listener, "HIT")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Body.String(); got != "foobar" {
+		t.Errorf("body = %q, want %q", got, "foobar")
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Errorf("Content-Type = %q, want %q", got, "text/plain")
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache = %q, want %q", got, "HIT")
+	}
+}
+
+func TestWriteChunksToResponse_ZeroByteResponse(t *testing.T) {
+	// Zero-byte response: no data chunks, complete with nil error.
+	// Headers should still be committed after the loop.
+	b := broadcast.NewBroadcaster(16)
+	listener := b.Subscribe()
+	b.SetHeaders(http.StatusOK, http.Header{
+		"Content-Length": []string{"0"},
+		"Content-Type":  []string{"application/octet-stream"},
+	})
+
+	go func() {
+		b.Complete(nil)
+	}()
+
+	w := httptest.NewRecorder()
+	svc := &Service{}
+	err := svc.writeChunksToResponse(context.Background(), w, listener, "MISS")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %d bytes", w.Body.Len())
+	}
+	if got := w.Header().Get("X-Cache"); got != "MISS" {
+		t.Errorf("X-Cache = %q, want %q", got, "MISS")
+	}
+}
+
+func TestWriteChunksToResponse_ErrorAfterPartialData(t *testing.T) {
+	// Error after partial data: headers are committed (can't undo), error returned.
+	b := broadcast.NewBroadcaster(16)
+	listener := b.Subscribe()
+	b.SetHeaders(http.StatusOK, http.Header{
+		"Content-Length": []string{"6"},
+		"Content-Type":  []string{"text/plain"},
+	})
+
+	go func() {
+		b.Broadcast([]byte("foo"))
+		b.Complete(errors.New("upstream connection reset"))
+	}()
+
+	w := httptest.NewRecorder()
+	svc := &Service{}
+	err := svc.writeChunksToResponse(context.Background(), w, listener, "MISS")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "upstream connection reset" {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Headers should have been committed because data was written
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Errorf("Content-Type = %q, want %q", got, "text/plain")
+	}
+	// Partial body should have been written
+	if got := w.Body.String(); got != "foo" {
+		t.Errorf("body = %q, want %q", got, "foo")
+	}
+}
+
+func TestWriteChunksToResponse_WaitForHeadersTimeout(t *testing.T) {
+	// If context is canceled before headers arrive, should return context error.
+	b := broadcast.NewBroadcaster(16)
+	listener := b.Subscribe()
+	// Don't call SetHeaders — context will cancel first
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	w := httptest.NewRecorder()
+	svc := &Service{}
+	err := svc.writeChunksToResponse(ctx, w, listener, "MISS")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}

--- a/tests/integration/sdk_test.go
+++ b/tests/integration/sdk_test.go
@@ -1461,74 +1461,30 @@ func TestSDK_DeleteObjects_WithCache(t *testing.T) {
 	t.Logf("DeleteObjects with cache verified: %d objects deleted and cache invalidated", len(result.Deleted))
 }
 
-// buildAWSChunkedBody encodes raw data into AWS chunked transfer encoding format.
-// Each chunk is: <hex-size>;chunk-signature=<dummy>\r\n<data>\r\n
-// Terminal chunk: 0;chunk-signature=<dummy>\r\n\r\n
-func buildAWSChunkedBody(data []byte, chunkSize int) []byte {
-	var buf bytes.Buffer
-	for i := 0; i < len(data); i += chunkSize {
-		end := i + chunkSize
-		if end > len(data) {
-			end = len(data)
-		}
-		chunk := data[i:end]
-		fmt.Fprintf(&buf, "%x;chunk-signature=0000000000000000000000000000000000000000000000000000000000000000\r\n", len(chunk))
-		buf.Write(chunk)
-		buf.WriteString("\r\n")
-	}
-	// Terminal chunk
-	buf.WriteString("0;chunk-signature=0000000000000000000000000000000000000000000000000000000000000000\r\n\r\n")
-	return buf.Bytes()
-}
-
 // TestSDK_PutObject_ChunkedEncoding verifies that AWS chunked transfer encoding
-// (streaming SigV4) is correctly decoded by TAG. The request body uses the
-// <hex-size>;chunk-signature=<sig>\r\n<data>\r\n framing format.
+// is correctly decoded by TAG. Over TLS, the AWS Go SDK v2 automatically uses
+// aws-chunked encoding with trailing checksums (STREAMING-UNSIGNED-PAYLOAD-TRAILER).
 func TestSDK_PutObject_ChunkedEncoding(t *testing.T) {
-	env := NewTestEnvironment()
+	env := NewTestEnvironmentWithTLS()
 	defer env.Close()
 
 	env.CreateTestBucket("test-bucket")
 
+	client := env.GetS3ClientTLS()
+	ctx := context.Background()
+
 	objectData := []byte("hello from chunked encoding test!")
-	chunkedBody := buildAWSChunkedBody(objectData, 10) // 10-byte chunks
-
-	// Build request with chunked encoding headers.
-	// Sign first, then add X-Amz-Decoded-Content-Length after signing.
-	// The signer doesn't copy this header, but the validator only checks
-	// headers listed in SignedHeaders, so adding it post-sign is safe.
-	req, err := env.Signer.SignRequest(
-		context.Background(),
-		http.MethodPut,
-		"/test-bucket/chunked-key",
-		bytes.NewReader(chunkedBody),
-		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
-		TestAccessKey,
-		TestSecretKey,
-		http.Header{
-			"Content-Encoding": []string{"aws-chunked"},
-		},
-	)
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-key"),
+		Body:   bytes.NewReader(objectData),
+	})
 	if err != nil {
-		t.Fatalf("Failed to sign chunked request: %v", err)
-	}
-	req.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(objectData)))
-	req.ContentLength = int64(len(chunkedBody))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Chunked PUT request failed: %v", err)
-	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+		t.Fatalf("PutObject failed: %v", err)
 	}
 
-	// Verify object was stored correctly via standard SDK GET
-	client := env.GetS3Client()
-	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+	// Verify object was stored correctly via GET
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
 		Key:    aws.String("chunked-key"),
 	})
@@ -1544,50 +1500,31 @@ func TestSDK_PutObject_ChunkedEncoding(t *testing.T) {
 }
 
 // TestSDK_PutObject_ChunkedEncoding_LargeObject verifies chunked encoding with a
-// larger object that spans many chunks.
+// larger object that spans multiple 64KB chunks.
 func TestSDK_PutObject_ChunkedEncoding_LargeObject(t *testing.T) {
-	env := NewTestEnvironment()
+	env := NewTestEnvironmentWithTLS()
 	defer env.Close()
 
 	env.CreateTestBucket("test-bucket")
 
-	// 128KB object, split into 64KB chunks (matches DefaultChunkSize)
+	client := env.GetS3ClientTLS()
+	ctx := context.Background()
+
+	// 128KB object — the SDK will split this into multiple 64KB aws-chunked chunks
 	objectData := make([]byte, 128*1024)
 	rand.Read(objectData)
-	chunkedBody := buildAWSChunkedBody(objectData, 64*1024)
 
-	req, err := env.Signer.SignRequest(
-		context.Background(),
-		http.MethodPut,
-		"/test-bucket/chunked-large-key",
-		bytes.NewReader(chunkedBody),
-		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
-		TestAccessKey,
-		TestSecretKey,
-		http.Header{
-			"Content-Encoding": []string{"aws-chunked"},
-		},
-	)
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-large-key"),
+		Body:   bytes.NewReader(objectData),
+	})
 	if err != nil {
-		t.Fatalf("Failed to sign chunked request: %v", err)
-	}
-	req.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(objectData)))
-	req.ContentLength = int64(len(chunkedBody))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Chunked PUT request failed: %v", err)
-	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+		t.Fatalf("PutObject failed: %v", err)
 	}
 
 	// Verify via GET
-	client := env.GetS3Client()
-	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
 		Key:    aws.String("chunked-large-key"),
 	})
@@ -1601,55 +1538,33 @@ func TestSDK_PutObject_ChunkedEncoding_LargeObject(t *testing.T) {
 		t.Error("Large chunked PUT: downloaded content does not match original")
 	}
 
-	t.Logf("Chunked encoding verified: %d bytes uploaded in 64KB chunks, content matches", len(objectData))
+	t.Logf("Chunked encoding verified: %d bytes uploaded via SDK over TLS, content matches", len(objectData))
 }
 
-// TestSDK_PutObject_ChunkedEncoding_ZeroByte verifies chunked encoding with an
-// empty body (terminal chunk only).
+// TestSDK_PutObject_ChunkedEncoding_ZeroByte verifies that zero-byte PutObject
+// works correctly over TLS (where the SDK uses aws-chunked encoding).
 func TestSDK_PutObject_ChunkedEncoding_ZeroByte(t *testing.T) {
-	env := NewTestEnvironment()
+	env := NewTestEnvironmentWithTLS()
 	defer env.Close()
 
 	env.CreateTestBucket("test-bucket")
 
-	// Now test zero-byte via chunked encoding
-	objectData := []byte{}
-	chunkedBody := buildAWSChunkedBody(objectData, 64*1024) // Only terminal chunk
+	client := env.GetS3ClientTLS()
+	ctx := context.Background()
 
-	req, err := env.Signer.SignRequest(
-		context.Background(),
-		http.MethodPut,
-		"/test-bucket/chunked-empty-key2",
-		bytes.NewReader(chunkedBody),
-		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
-		TestAccessKey,
-		TestSecretKey,
-		http.Header{
-			"Content-Encoding": []string{"aws-chunked"},
-		},
-	)
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-empty-key"),
+		Body:   bytes.NewReader([]byte{}),
+	})
 	if err != nil {
-		t.Fatalf("Failed to sign chunked request: %v", err)
-	}
-	req.Header.Set("X-Amz-Decoded-Content-Length", "0")
-	req.ContentLength = int64(len(chunkedBody))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Chunked PUT request failed: %v", err)
-	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+		t.Fatalf("PutObject failed: %v", err)
 	}
 
 	// Verify via GET
-	client := env.GetS3Client()
-	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
-		Key:    aws.String("chunked-empty-key2"),
+		Key:    aws.String("chunked-empty-key"),
 	})
 	if err != nil {
 		t.Fatalf("GetObject verification failed: %v", err)

--- a/tests/integration/sdk_test.go
+++ b/tests/integration/sdk_test.go
@@ -1460,3 +1460,204 @@ func TestSDK_DeleteObjects_WithCache(t *testing.T) {
 
 	t.Logf("DeleteObjects with cache verified: %d objects deleted and cache invalidated", len(result.Deleted))
 }
+
+// buildAWSChunkedBody encodes raw data into AWS chunked transfer encoding format.
+// Each chunk is: <hex-size>;chunk-signature=<dummy>\r\n<data>\r\n
+// Terminal chunk: 0;chunk-signature=<dummy>\r\n\r\n
+func buildAWSChunkedBody(data []byte, chunkSize int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < len(data); i += chunkSize {
+		end := i + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[i:end]
+		fmt.Fprintf(&buf, "%x;chunk-signature=0000000000000000000000000000000000000000000000000000000000000000\r\n", len(chunk))
+		buf.Write(chunk)
+		buf.WriteString("\r\n")
+	}
+	// Terminal chunk
+	buf.WriteString("0;chunk-signature=0000000000000000000000000000000000000000000000000000000000000000\r\n\r\n")
+	return buf.Bytes()
+}
+
+// TestSDK_PutObject_ChunkedEncoding verifies that AWS chunked transfer encoding
+// (streaming SigV4) is correctly decoded by TAG. The request body uses the
+// <hex-size>;chunk-signature=<sig>\r\n<data>\r\n framing format.
+func TestSDK_PutObject_ChunkedEncoding(t *testing.T) {
+	env := NewTestEnvironment()
+	defer env.Close()
+
+	env.CreateTestBucket("test-bucket")
+
+	objectData := []byte("hello from chunked encoding test!")
+	chunkedBody := buildAWSChunkedBody(objectData, 10) // 10-byte chunks
+
+	// Build request with chunked encoding headers.
+	// Sign first, then add X-Amz-Decoded-Content-Length after signing.
+	// The signer doesn't copy this header, but the validator only checks
+	// headers listed in SignedHeaders, so adding it post-sign is safe.
+	req, err := env.Signer.SignRequest(
+		context.Background(),
+		http.MethodPut,
+		"/test-bucket/chunked-key",
+		bytes.NewReader(chunkedBody),
+		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+		TestAccessKey,
+		TestSecretKey,
+		http.Header{
+			"Content-Encoding": []string{"aws-chunked"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to sign chunked request: %v", err)
+	}
+	req.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(objectData)))
+	req.ContentLength = int64(len(chunkedBody))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Chunked PUT request failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+	}
+
+	// Verify object was stored correctly via standard SDK GET
+	client := env.GetS3Client()
+	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-key"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	if !bytes.Equal(body, objectData) {
+		t.Errorf("GET body = %q, want %q", body, objectData)
+	}
+}
+
+// TestSDK_PutObject_ChunkedEncoding_LargeObject verifies chunked encoding with a
+// larger object that spans many chunks.
+func TestSDK_PutObject_ChunkedEncoding_LargeObject(t *testing.T) {
+	env := NewTestEnvironment()
+	defer env.Close()
+
+	env.CreateTestBucket("test-bucket")
+
+	// 128KB object, split into 64KB chunks (matches DefaultChunkSize)
+	objectData := make([]byte, 128*1024)
+	rand.Read(objectData)
+	chunkedBody := buildAWSChunkedBody(objectData, 64*1024)
+
+	req, err := env.Signer.SignRequest(
+		context.Background(),
+		http.MethodPut,
+		"/test-bucket/chunked-large-key",
+		bytes.NewReader(chunkedBody),
+		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+		TestAccessKey,
+		TestSecretKey,
+		http.Header{
+			"Content-Encoding": []string{"aws-chunked"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to sign chunked request: %v", err)
+	}
+	req.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(objectData)))
+	req.ContentLength = int64(len(chunkedBody))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Chunked PUT request failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+	}
+
+	// Verify via GET
+	client := env.GetS3Client()
+	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-large-key"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	if !bytes.Equal(body, objectData) {
+		t.Error("Large chunked PUT: downloaded content does not match original")
+	}
+
+	t.Logf("Chunked encoding verified: %d bytes uploaded in 64KB chunks, content matches", len(objectData))
+}
+
+// TestSDK_PutObject_ChunkedEncoding_ZeroByte verifies chunked encoding with an
+// empty body (terminal chunk only).
+func TestSDK_PutObject_ChunkedEncoding_ZeroByte(t *testing.T) {
+	env := NewTestEnvironment()
+	defer env.Close()
+
+	env.CreateTestBucket("test-bucket")
+
+	// Now test zero-byte via chunked encoding
+	objectData := []byte{}
+	chunkedBody := buildAWSChunkedBody(objectData, 64*1024) // Only terminal chunk
+
+	req, err := env.Signer.SignRequest(
+		context.Background(),
+		http.MethodPut,
+		"/test-bucket/chunked-empty-key2",
+		bytes.NewReader(chunkedBody),
+		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+		TestAccessKey,
+		TestSecretKey,
+		http.Header{
+			"Content-Encoding": []string{"aws-chunked"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to sign chunked request: %v", err)
+	}
+	req.Header.Set("X-Amz-Decoded-Content-Length", "0")
+	req.ContentLength = int64(len(chunkedBody))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Chunked PUT request failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Chunked PUT returned status %d, want 200", resp.StatusCode)
+	}
+
+	// Verify via GET
+	client := env.GetS3Client()
+	result, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("chunked-empty-key2"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	if len(body) != 0 {
+		t.Errorf("Expected empty body, got %d bytes", len(body))
+	}
+}

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -225,7 +225,7 @@ func NewTestEnvironment() *TestEnvironment {
 	// Start fake S3 server
 	upstream := httptest.NewServer(faker.Server())
 
-	return newTestEnvironmentWithUpstream(upstream, backend)
+	return newTestEnvironmentWithUpstream(upstream, backend, false)
 }
 
 // NewTestEnvironmentWithMiddleware creates a test environment with middleware wrapping gofakes3.
@@ -239,14 +239,14 @@ func NewTestEnvironmentWithMiddleware(middleware func(http.Handler) http.Handler
 	handler := middleware(faker.Server())
 	upstream := httptest.NewServer(handler)
 
-	return newTestEnvironmentWithUpstream(upstream, backend)
+	return newTestEnvironmentWithUpstream(upstream, backend, false)
 }
 
 // NewTestEnvironmentWithHandler creates a test environment with a custom HTTP handler.
 // This is useful for auth tests that don't need a real S3 backend.
 func NewTestEnvironmentWithHandler(upstreamHandler http.HandlerFunc) *TestEnvironment {
 	upstream := httptest.NewServer(upstreamHandler)
-	return newTestEnvironmentWithUpstream(upstream, nil)
+	return newTestEnvironmentWithUpstream(upstream, nil, false)
 }
 
 // NewTestEnvironmentWithTLS creates a test environment with a TLS-enabled TAG server.
@@ -260,59 +260,7 @@ func NewTestEnvironmentWithTLS() *TestEnvironment {
 	// Start fake S3 server (plain HTTP is fine for upstream)
 	upstream := httptest.NewServer(faker.Server())
 
-	// Create credential store with test credentials
-	credStore := auth.NewCredentialStore()
-	credStore.AddCredential(TestAccessKey, TestSecretKey)
-
-	// Create config with cache disabled
-	cfg := &config.Config{
-		Server: config.ServerConfig{
-			HTTPPort: 8080,
-			BindIP:   "127.0.0.1",
-		},
-		Upstream: config.UpstreamConfig{
-			Endpoint: upstream.URL,
-			Region:   TestRegion,
-		},
-		Cache: config.CacheConfig{
-			TTL:           config.DefaultCacheTTL,
-			SizeThreshold: config.DefaultCacheSizeThreshold,
-		},
-	}
-	cfg.Cache.SetEnabled(false)
-
-	// Create disabled cache
-	testCache := cache.NewDisabledCache()
-
-	// Create forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
-
-	// Create service
-	service := proxy.NewService(forwarder, testCache, cfg)
-
-	// Create X-Cache tracker
-	xCacheTracker := NewXCacheTracker()
-
-	// Create TAG server with TLS
-	server := handlers.NewServer(service, "127.0.0.1", 0, true)
-	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
-	tagServer := httptest.NewTLSServer(wrappedRouter)
-
-	// Create signer for test requests (pointing to TAG server)
-	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
-
-	return &TestEnvironment{
-		UpstreamServer: upstream,
-		TAGServer:      tagServer,
-		CredStore:      credStore,
-		Cache:          testCache,
-		Config:         cfg,
-		Service:        service,
-		Signer:         signer,
-		S3Backend:      backend,
-		XCacheTracker:  xCacheTracker,
-		TLSHTTPClient:  tagServer.Client(),
-	}
+	return newTestEnvironmentWithUpstream(upstream, backend, true)
 }
 
 // NewTestEnvironmentWithCache creates a test environment with caching enabled using embedded RocksDB cache.
@@ -396,7 +344,8 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 }
 
 // newTestEnvironmentWithUpstream creates a test environment with the given upstream server.
-func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Backend) *TestEnvironment {
+// If useTLS is true, the TAG server uses HTTPS (required for SDK chunked encoding tests).
+func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Backend, useTLS bool) *TestEnvironment {
 	// Create credential store with test credentials
 	credStore := auth.NewCredentialStore()
 	credStore.AddCredential(TestAccessKey, TestSecretKey)
@@ -433,12 +382,18 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	// Create TAG server with X-Cache tracking middleware
 	server := handlers.NewServer(service, "127.0.0.1", 0, true)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
-	tagServer := httptest.NewServer(wrappedRouter)
+
+	var tagServer *httptest.Server
+	if useTLS {
+		tagServer = httptest.NewTLSServer(wrappedRouter)
+	} else {
+		tagServer = httptest.NewServer(wrappedRouter)
+	}
 
 	// Create signer for test requests (pointing to TAG server)
 	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
 
-	return &TestEnvironment{
+	env := &TestEnvironment{
 		UpstreamServer: upstream,
 		TAGServer:      tagServer,
 		CredStore:      credStore,
@@ -449,6 +404,12 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 		S3Backend:      backend,
 		XCacheTracker:  xCacheTracker,
 	}
+
+	if useTLS {
+		env.TLSHTTPClient = tagServer.Client()
+	}
+
+	return env
 }
 
 // Close cleans up the test environment.

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -211,6 +211,9 @@ type TestEnvironment struct {
 	UpstreamRequestCount *int32
 	// XCacheTracker tracks X-Cache headers from TAG server responses.
 	XCacheTracker *XCacheTracker
+	// TLSHTTPClient is the HTTP client configured to trust the TLS test server certificate.
+	// Non-nil only for TLS test environments.
+	TLSHTTPClient *http.Client
 }
 
 // NewTestEnvironment creates a new test environment with gofakes3 in-memory backend.
@@ -244,6 +247,72 @@ func NewTestEnvironmentWithMiddleware(middleware func(http.Handler) http.Handler
 func NewTestEnvironmentWithHandler(upstreamHandler http.HandlerFunc) *TestEnvironment {
 	upstream := httptest.NewServer(upstreamHandler)
 	return newTestEnvironmentWithUpstream(upstream, nil)
+}
+
+// NewTestEnvironmentWithTLS creates a test environment with a TLS-enabled TAG server.
+// Over HTTPS, the AWS Go SDK v2 uses aws-chunked encoding with trailing checksums,
+// which exercises TAG's chunked decoding path.
+func NewTestEnvironmentWithTLS() *TestEnvironment {
+	// Create in-memory S3 backend
+	backend := s3mem.New()
+	faker := gofakes3.New(backend)
+
+	// Start fake S3 server (plain HTTP is fine for upstream)
+	upstream := httptest.NewServer(faker.Server())
+
+	// Create credential store with test credentials
+	credStore := auth.NewCredentialStore()
+	credStore.AddCredential(TestAccessKey, TestSecretKey)
+
+	// Create config with cache disabled
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTPPort: 8080,
+			BindIP:   "127.0.0.1",
+		},
+		Upstream: config.UpstreamConfig{
+			Endpoint: upstream.URL,
+			Region:   TestRegion,
+		},
+		Cache: config.CacheConfig{
+			TTL:           config.DefaultCacheTTL,
+			SizeThreshold: config.DefaultCacheSizeThreshold,
+		},
+	}
+	cfg.Cache.SetEnabled(false)
+
+	// Create disabled cache
+	testCache := cache.NewDisabledCache()
+
+	// Create forwarder
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
+
+	// Create service
+	service := proxy.NewService(forwarder, testCache, cfg)
+
+	// Create X-Cache tracker
+	xCacheTracker := NewXCacheTracker()
+
+	// Create TAG server with TLS
+	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
+	tagServer := httptest.NewTLSServer(wrappedRouter)
+
+	// Create signer for test requests (pointing to TAG server)
+	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
+
+	return &TestEnvironment{
+		UpstreamServer: upstream,
+		TAGServer:      tagServer,
+		CredStore:      credStore,
+		Cache:          testCache,
+		Config:         cfg,
+		Service:        service,
+		Signer:         signer,
+		S3Backend:      backend,
+		XCacheTracker:  xCacheTracker,
+		TLSHTTPClient:  tagServer.Client(),
+	}
 }
 
 // NewTestEnvironmentWithCache creates a test environment with caching enabled using embedded RocksDB cache.
@@ -438,6 +507,22 @@ func (e *TestEnvironment) GetS3Client() *s3.Client {
 		o.BaseEndpoint = aws.String(e.TAGServer.URL)
 		o.Region = TestRegion
 		o.EndpointOptions.DisableHTTPS = true
+		o.UsePathStyle = true
+		o.Credentials = credentials.NewStaticCredentialsProvider(
+			TestAccessKey, TestSecretKey, "")
+	})
+}
+
+// GetS3ClientTLS returns an AWS SDK S3 client configured for a TLS TAG server.
+// The client uses the test server's HTTP client which trusts the test certificate.
+// Unlike GetS3Client, this does NOT disable HTTPS, allowing the SDK to use
+// aws-chunked encoding with trailing checksums.
+func (e *TestEnvironment) GetS3ClientTLS() *s3.Client {
+	return s3.NewFromConfig(aws.Config{
+		HTTPClient: e.TLSHTTPClient,
+	}, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(e.TAGServer.URL)
+		o.Region = TestRegion
 		o.UsePathStyle = true
 		o.Credentials = credentials.NewStaticCredentialsProvider(
 			TestAccessKey, TestSecretKey, "")


### PR DESCRIPTION
## Summary

Adds support for warp and other S3 clients that use AWS chunked transfer encoding (streaming SigV4) for PUT uploads. Implements on-the-fly chunked body decoding while preserving zero-copy streaming.

- Register bucket-level routes for both `/{bucket}` and `/{bucket}/` patterns to handle clients sending trailing slashes
- Add `awsChunkedReader` to decode `STREAMING-AWS4-HMAC-SHA256-PAYLOAD` bodies on-the-fly
- Forward decoded requests as `UNSIGNED-PAYLOAD` to avoid SigV4 signature chain conflicts when re-signing with a different Host header
- Update `validateContentLength()` to accept `X-Amz-Decoded-Content-Length` header for chunked requests

## Test plan

- All unit tests pass (including new tests for chunked reader and trailing slash routing)
- Race detector passes
- Verified with warp: 1000 PUT objects at 88.46 MiB/s, all succeeded
- Verified with warp: GET throughput at ~2986 MiB/s with 3-4ms median TTFB on cache hits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request forwarding and HTTP semantics (stream decoding, content length/encoding, header commit timing) which can affect correctness and interoperability across S3 clients, though changes are well-covered by new unit and integration tests.
> 
> **Overview**
> Adds support for AWS SigV4 streaming chunked uploads by decoding `aws-chunked` request bodies on the fly, forwarding them upstream as `UNSIGNED-PAYLOAD`, and fixing forwarded `Content-Length`/`Content-Encoding` handling (including zero-byte uploads).
> 
> Improves S3 client compatibility by registering bucket-level routes for both `/{bucket}` and `/{bucket}/` (preserving the exact path for SigV4), updating `validateContentLength` to accept `X-Amz-Decoded-Content-Length`, and deferring GET response header commitment until the first data chunk to allow clean error responses. Also tightens cache tombstone checks to skip all cache writes when invalidated mid-write and adds docs + unit/integration coverage for these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd23dcbe82169b1c913b2d89ffc8150f29144c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->