### PR TITLE
fix: add error checking to test setup and use configurable port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,8 +365,8 @@ test-sdk: rocksdb-static
 		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
 		exit 1; \
 	fi
-	@if ! curl -s http://localhost:8080/health > /dev/null 2>&1; then \
-		echo "Error: TAG not running at localhost:8080"; \
+	@if ! curl -s http://localhost:$(TAG_LOCAL_HTTP_PORT)/health > /dev/null 2>&1; then \
+		echo "Error: TAG not running at localhost:$(TAG_LOCAL_HTTP_PORT)"; \
 		echo "  Start TAG with: make s3-test-local"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,6 @@ test-sdk: rocksdb-static
 		echo "  Start TAG with: make s3-test-local"; \
 		exit 1; \
 	fi
-	$(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
+	TAG_ENDPOINT=http://localhost:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
 
 .DEFAULT_GOAL := help

--- a/tests/integration/sdk/go_sdk_test.go
+++ b/tests/integration/sdk/go_sdk_test.go
@@ -197,9 +197,15 @@ func TestSDK_ListObjectsV2(t *testing.T) {
 	}
 
 	// Create test objects with prefix structure
-	globalEnv.PutTestObject(bucket, "test/object1.txt", []byte("content1"))
-	globalEnv.PutTestObject(bucket, "test/object2.txt", []byte("content2"))
-	globalEnv.PutTestObject(bucket, "other/object3.txt", []byte("content3"))
+	if err := globalEnv.PutTestObject(bucket, "test/object1.txt", []byte("content1")); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
+	if err := globalEnv.PutTestObject(bucket, "test/object2.txt", []byte("content2")); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
+	if err := globalEnv.PutTestObject(bucket, "other/object3.txt", []byte("content3")); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
 
 	client := globalEnv.GetS3Client()
 	ctx := context.Background()
@@ -239,7 +245,9 @@ func TestSDK_CopyObject(t *testing.T) {
 	}
 
 	sourceContent := []byte("source object content to copy")
-	globalEnv.PutTestObject(sourceBucket, "source-key", sourceContent)
+	if err := globalEnv.PutTestObject(sourceBucket, "source-key", sourceContent); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
 
 	client := globalEnv.GetS3Client()
 	ctx := context.Background()
@@ -277,7 +285,9 @@ func TestSDK_GetObjectRange(t *testing.T) {
 	}
 
 	fullContent := []byte("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij") // 46 bytes
-	globalEnv.PutTestObject(bucket, "range-key", fullContent)
+	if err := globalEnv.PutTestObject(bucket, "range-key", fullContent); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
 
 	client := globalEnv.GetS3Client()
 	ctx := context.Background()
@@ -484,7 +494,9 @@ func TestSDK_EmptyObject(t *testing.T) {
 		t.Fatalf("Failed to create test bucket: %v", err)
 	}
 
-	globalEnv.PutTestObject(bucket, "empty-key", []byte{})
+	if err := globalEnv.PutTestObject(bucket, "empty-key", []byte{}); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
 
 	client := globalEnv.GetS3Client()
 	ctx := context.Background()


### PR DESCRIPTION
Add error checking to PutTestObject calls in SDK integration tests to prevent test flakiness when object creation fails. Replace hardcoded health check port with TAG_LOCAL_HTTP_PORT variable to support configurable deployments.

Addresses PR review comments on test robustness and port configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes: adds missing error handling around test object creation and makes the SDK integration harness respect the configurable local TAG port, reducing flakiness with minimal behavioral risk.
> 
> **Overview**
> Improves Go SDK integration test reliability by **failing fast** when `globalEnv.PutTestObject` setup calls error (instead of silently continuing and producing misleading failures).
> 
> Updates the `make test-sdk` target to use `TAG_LOCAL_HTTP_PORT` for the health check and to export `TAG_ENDPOINT` based on that port, removing the hardcoded `localhost:8080` assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37911827f52dcdffddfbadaff36ba9408f4c3357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->