### PR TITLE
Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ rocksdb-static/
 
 # Environment variables
 .env
+
+# IDE files
+.vscode/

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -113,9 +113,11 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 }
 
 // PutWithMetaStreamTombstoneAware is like PutWithMetaStream but checks for
-// tombstones before writing metadata. If a tombstone exists that's newer than
-// writeStartTime, the metadata write is skipped (preventing stale cache).
-// This is used by async cache writers to avoid caching stale data after invalidation.
+// tombstones after body streaming and before writing metadata. If a tombstone
+// exists that's newer than writeStartTime, the metadata write is skipped and
+// the orphaned body is cleaned up. Checking after body stream (rather than
+// before) closes the TOCTOU window where an invalidation during streaming
+// could be missed, causing resurrected metadata without a body.
 func (c *Cache) PutWithMetaStreamTombstoneAware(
 	ctx context.Context,
 	bucket, key string,
@@ -142,22 +144,25 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		return err
 	}
 
-	// CHECK TOMBSTONE BEFORE writing anything to cache
-	// If a tombstone exists with timestamp >= writeStartTime, the key was invalidated
-	// after this write started, so we should NOT write at all (prevents orphaned bodies)
+	// Stream body to cache
+	if err := c.client.PutStream(ctx, bodyKey, body, int64(ttl)); err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body put error")
+		return err
+	}
+
+	// Check tombstone AFTER body stream, right before meta write.
+	// This closes the TOCTOU window: if the key was invalidated during body streaming
+	// (e.g., a PUT/DELETE arrived while we were writing), we skip the meta write.
+	// Without this, a slow body stream could allow meta to be written after a
+	// concurrent invalidation deletes meta+body, resurrecting stale metadata.
 	tombTs := c.GetTombstoneTimestamp(ctx, bucket, key)
 	if tombTs >= writeStartTime {
 		log.Debug().Str("bucket", bucket).Str("key", key).
 			Int64("tombstone_ts", tombTs).
 			Int64("write_start", writeStartTime).
-			Msg("Skipping cache write - tombstone detected (key was invalidated)")
+			Msg("Skipping meta write - tombstone detected after body stream")
+		_ = c.client.Delete(ctx, bodyKey) // Clean up orphaned body
 		return nil
-	}
-
-	// Stream body to cache
-	if err := c.client.PutStream(ctx, bodyKey, body, int64(ttl)); err != nil {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body put error")
-		return err
 	}
 
 	// Write metadata AFTER body (makes entry visible)

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -203,6 +203,48 @@ func (s *Server) Stop(ctx context.Context) error {
 	return s.httpServer.Shutdown(ctx)
 }
 
+// responseTracker wraps http.ResponseWriter to track whether headers have been
+// committed. This prevents handleError from writing error XML after a handler
+// has already started writing a response (which would corrupt the HTTP stream
+// and break keep-alive connections).
+type responseTracker struct {
+	http.ResponseWriter
+	committed bool
+}
+
+func (rt *responseTracker) WriteHeader(code int) {
+	rt.committed = true
+	rt.ResponseWriter.WriteHeader(code)
+}
+
+func (rt *responseTracker) Write(b []byte) (int, error) {
+	rt.committed = true // implicit 200 if WriteHeader not called
+	return rt.ResponseWriter.Write(b)
+}
+
+func (rt *responseTracker) Flush() {
+	if f, ok := rt.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// handleWithError calls a handler function and handles any returned error.
+// If headers have already been committed (e.g., the handler started streaming
+// a response before encountering an error), the error is logged but no error
+// response is written to avoid corrupting the HTTP stream.
+func handleWithError(w http.ResponseWriter, r *http.Request, handler func(http.ResponseWriter, *http.Request) error) {
+	rt := &responseTracker{ResponseWriter: w}
+	err := handler(rt, r)
+	if err != nil {
+		if rt.committed {
+			log.Warn().Err(err).Str("path", r.URL.Path).
+				Msg("Error after response headers committed, cannot send error response")
+		} else {
+			handleError(w, r, err)
+		}
+	}
+}
+
 // handleHealth handles health check requests.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
@@ -334,9 +376,7 @@ func (s *Server) handleObject(w http.ResponseWriter, r *http.Request) {
 
 	// Check for copy operation (PUT with X-Amz-Copy-Source header)
 	if r.Method == http.MethodPut && r.Header.Get("X-Amz-Copy-Source") != "" {
-		if err := s.service.HandleCopyObject(w, r); err != nil {
-			handleError(w, r, err)
-		}
+		handleWithError(w, r, s.service.HandleCopyObject)
 		return
 	}
 
@@ -347,24 +387,22 @@ func (s *Server) handleObject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var err error
+	var handler func(http.ResponseWriter, *http.Request) error
 	switch r.Method {
 	case http.MethodGet:
-		err = s.service.HandleGetObject(w, r)
+		handler = s.service.HandleGetObject
 	case http.MethodHead:
-		err = s.service.HandleHeadObject(w, r)
+		handler = s.service.HandleHeadObject
 	case http.MethodPut:
-		err = s.service.HandlePutObject(w, r)
+		handler = s.service.HandlePutObject
 	case http.MethodDelete:
-		err = s.service.HandleDeleteObject(w, r)
+		handler = s.service.HandleDeleteObject
 	default:
 		WriteError(w, r, ErrMethodNotAllowed)
 		return
 	}
 
-	if err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, handler)
 }
 
 // handleBucket handles basic bucket operations.
@@ -373,35 +411,17 @@ func (s *Server) handleBucket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var err error
 	switch r.Method {
-	case http.MethodGet:
-		// ListObjects V1
-		err = s.service.HandlePassthrough(w, r)
-	case http.MethodHead:
-		// HeadBucket
-		err = s.service.HandlePassthrough(w, r)
-	case http.MethodPut:
-		// CreateBucket
-		err = s.service.HandlePassthrough(w, r)
-	case http.MethodDelete:
-		// DeleteBucket
-		err = s.service.HandlePassthrough(w, r)
+	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete:
+		handleWithError(w, r, s.service.HandlePassthrough)
 	default:
 		WriteError(w, r, ErrMethodNotAllowed)
-		return
-	}
-
-	if err != nil {
-		handleError(w, r, err)
 	}
 }
 
 // handleListBuckets handles ListBuckets operation.
 func (s *Server) handleListBuckets(w http.ResponseWriter, r *http.Request) {
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleListObjectsV2 handles ListObjectsV2 operation.
@@ -409,9 +429,7 @@ func (s *Server) handleListObjectsV2(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleCompleteMultipartUpload handles CompleteMultipartUpload with idempotency caching.
@@ -421,9 +439,7 @@ func (s *Server) handleCompleteMultipartUpload(w http.ResponseWriter, r *http.Re
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandleCompleteMultipartUpload(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandleCompleteMultipartUpload)
 }
 
 // handleObjectWithQuery handles object operations with query parameters (multipart).
@@ -431,9 +447,7 @@ func (s *Server) handleObjectWithQuery(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleInitiateMultipart handles InitiateMultipartUpload.
@@ -441,9 +455,7 @@ func (s *Server) handleInitiateMultipart(w http.ResponseWriter, r *http.Request)
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketMultipartUploads handles ListMultipartUploads.
@@ -451,9 +463,7 @@ func (s *Server) handleBucketMultipartUploads(w http.ResponseWriter, r *http.Req
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleObjectTagging handles object tagging operations.
@@ -461,9 +471,7 @@ func (s *Server) handleObjectTagging(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleObjectACL handles object ACL operations.
@@ -471,9 +479,7 @@ func (s *Server) handleObjectACL(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketVersioning handles bucket versioning operations.
@@ -481,9 +487,7 @@ func (s *Server) handleBucketVersioning(w http.ResponseWriter, r *http.Request) 
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketACL handles bucket ACL operations.
@@ -491,9 +495,7 @@ func (s *Server) handleBucketACL(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketLifecycle handles bucket lifecycle operations.
@@ -501,9 +503,7 @@ func (s *Server) handleBucketLifecycle(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketPolicy handles bucket policy operations.
@@ -511,9 +511,7 @@ func (s *Server) handleBucketPolicy(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketCORS handles bucket CORS operations.
@@ -521,9 +519,7 @@ func (s *Server) handleBucketCORS(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketTagging handles bucket tagging operations.
@@ -531,9 +527,7 @@ func (s *Server) handleBucketTagging(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandlePassthrough(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandlePassthrough)
 }
 
 // handleBucketLocation handles GetBucketLocation operation.
@@ -555,7 +549,5 @@ func (s *Server) handleDeleteObjects(w http.ResponseWriter, r *http.Request) {
 	if !validateBucketName(w, r) {
 		return
 	}
-	if err := s.service.HandleDeleteObjects(w, r); err != nil {
-		handleError(w, r, err)
-	}
+	handleWithError(w, r, s.service.HandleDeleteObjects)
 }

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -240,7 +240,7 @@ func handleWithError(w http.ResponseWriter, r *http.Request, handler func(http.R
 			log.Warn().Err(err).Str("path", r.URL.Path).
 				Msg("Error after response headers committed, cannot send error response")
 		} else {
-			handleError(w, r, err)
+			handleError(rt, r, err)
 		}
 	}
 }

--- a/proxy/broadcast/broadcaster.go
+++ b/proxy/broadcast/broadcaster.go
@@ -12,6 +12,40 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// chunkPool provides reusable byte buffers for broadcast chunk data.
+// Eliminates per-chunk allocations (make+copy) that cause GC pressure
+// with large objects (e.g., 4MB object = 64 chunks × 64KB = 192+ allocs).
+var chunkPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, DefaultChunkSize)
+		return &b
+	},
+}
+
+// GetChunkBuf returns a byte slice of exactly the given size from the pool.
+// If size exceeds DefaultChunkSize, a fresh allocation is returned (not pooled).
+// Returns nil for zero or negative sizes.
+func GetChunkBuf(size int) []byte {
+	if size <= 0 {
+		return nil
+	}
+	if size > DefaultChunkSize {
+		return make([]byte, size)
+	}
+	bp := chunkPool.Get().(*[]byte)
+	return (*bp)[:size]
+}
+
+// PutChunkBuf returns a byte slice to the pool for reuse.
+// Only slices with cap == DefaultChunkSize are pooled; others are left for GC.
+func PutChunkBuf(b []byte) {
+	if cap(b) != DefaultChunkSize {
+		return
+	}
+	b = b[:cap(b)]
+	chunkPool.Put(&b)
+}
+
 const (
 	// DefaultChunkSize is the default size of chunks for streaming (64 KB).
 	DefaultChunkSize = 64 * 1024
@@ -29,9 +63,26 @@ const (
 var ErrSlowConsumer = errors.New("slow consumer")
 
 // Chunk represents a piece of streamed data.
+// Consumers should call Release() after processing Data to return the
+// underlying buffer to the pool. If Release() is not called, the buffer
+// is garbage collected normally (safe, but less efficient).
 type Chunk struct {
 	Data []byte
 	Err  error // Non-nil on final chunk if error occurred
+}
+
+// Release returns the chunk's data buffer to the pool for reuse.
+// Safe to call multiple times or on chunks with nil Data.
+//
+// Thread safety: Release is not synchronized with a mutex because chunks flow
+// through channels, which guarantee exclusive ownership — only one goroutine
+// holds a given Chunk value at any time. DrainAndRelease only processes chunks
+// still in the channel, never ones already received by a consumer.
+func (c *Chunk) Release() {
+	if c.Data != nil {
+		PutChunkBuf(c.Data)
+		c.Data = nil
+	}
 }
 
 // Listener receives chunks from a broadcast.
@@ -56,6 +107,19 @@ func (l *Listener) WaitForHeaders(ctx context.Context) (int, http.Header, error)
 // Chunks returns the channel to receive chunks.
 func (l *Listener) Chunks() <-chan Chunk {
 	return l.ch
+}
+
+// DrainAndRelease drains remaining chunks from the listener channel,
+// returning pooled buffers. Runs in a background goroutine since the
+// channel may not yet be closed (broadcaster still streaming).
+// Call this after breaking out of a Chunks() range loop early.
+// Safe to call on normal completion (no-op if channel is already drained/closed).
+func (l *Listener) DrainAndRelease() {
+	go func() {
+		for chunk := range l.ch {
+			chunk.Release()
+		}
+	}()
 }
 
 // Broadcaster streams data to multiple listeners simultaneously.
@@ -143,6 +207,10 @@ func (b *Broadcaster) SetHeaders(status int, headers http.Header) {
 // Broadcast sends a chunk to all listeners.
 // Slow consumers (buffer full) are disconnected immediately.
 func (b *Broadcaster) Broadcast(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -158,7 +226,7 @@ func (b *Broadcaster) Broadcast(data []byte) {
 			continue
 		}
 
-		chunk := Chunk{Data: make([]byte, len(data))}
+		chunk := Chunk{Data: GetChunkBuf(len(data))}
 		copy(chunk.Data, data)
 
 		// Non-blocking send - disconnect immediately if buffer is full
@@ -166,7 +234,9 @@ func (b *Broadcaster) Broadcast(data []byte) {
 		case l.ch <- chunk:
 			activeListeners = append(activeListeners, l)
 		default:
-			// Buffer full - disconnect slow consumer
+			// Buffer full - disconnect slow consumer.
+			// Return pooled buffer since this chunk won't be consumed.
+			chunk.Release()
 			l.disconnected = true
 			select {
 			case l.ch <- Chunk{Err: ErrSlowConsumer}:

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -91,6 +91,7 @@ func (s *Service) setupCacheListener(
 		statusCode, headers, err := listener.WaitForHeaders(ctx)
 		if err != nil {
 			pipeWriter.CloseWithError(err)
+			listener.DrainAndRelease() // Return any buffered pooled chunks
 			errCh <- err
 			return
 		}
@@ -101,6 +102,7 @@ func (s *Service) setupCacheListener(
 		// Check if still cacheable based on metadata
 		if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
 			pipeWriter.CloseWithError(nil)
+			listener.DrainAndRelease() // Return any buffered pooled chunks
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache - not cacheable")
 			return
 		}
@@ -115,9 +117,13 @@ func (s *Service) setupCacheListener(
 		sigReader := newSignalingReader(pipeReader)
 
 		// Intermediate buffer absorbs chunks while cache writer initializes.
-		// 1024 chunks × 64KB = 64MB headroom, matching listener buffer size.
-		// This provides ~128ms at 1GB/s for cache initialization before slow consumer.
-		const cacheQueueSize = 1024
+		// Sized as 1/4 of the broadcaster's channel buffer to balance memory savings
+		// with sufficient headroom. Total buffering (listener channel + queue) stays
+		// well above typical object sizes while reducing per-listener memory.
+		cacheQueueSize := s.config.Broadcast.ChannelBuffer / 4
+		if cacheQueueSize < 64 {
+			cacheQueueSize = 64
+		}
 		chunkQueue := make(chan []byte, cacheQueueSize)
 
 		// Start cache writer goroutine - will call Read() when ready
@@ -139,22 +145,27 @@ func (s *Service) setupCacheListener(
 				// Reader is ready, safe to write
 			case <-cacheCtx.Done():
 				pipeErrCh <- cacheCtx.Err()
-				// Drain queue to unblock producer
-				for range chunkQueue {
+				// Drain queue to unblock producer, returning pooled buffers
+				for chunk := range chunkQueue {
+					broadcast.PutChunkBuf(chunk)
 				}
 				return
 			}
 
-			// Drain queue to pipe - blocks on writes, which is fine since reader is ready
+			// Drain queue to pipe - blocks on writes, which is fine since reader is ready.
+			// Returns pooled buffers after each write.
 			var writeErr error
 			for chunk := range chunkQueue {
 				if _, err := pipeWriter.Write(chunk); err != nil {
 					writeErr = err
-					// Drain remaining to unblock producer
-					for range chunkQueue {
+					broadcast.PutChunkBuf(chunk) // Return current buffer
+					// Drain remaining to unblock producer, returning buffers
+					for remaining := range chunkQueue {
+						broadcast.PutChunkBuf(remaining)
 					}
 					break
 				}
+				broadcast.PutChunkBuf(chunk) // Return buffer after successful write
 			}
 			pipeErrCh <- writeErr
 		}()
@@ -163,24 +174,36 @@ func (s *Service) setupCacheListener(
 		// This runs in parallel with cache writer initialization,
 		// with the intermediate buffer absorbing chunks during the startup window.
 		var chunkErr error
+		var earlyExit bool
 	chunkLoop:
 		for chunk := range listener.Chunks() {
 			if chunk.Err != nil {
 				chunkErr = chunk.Err
+				earlyExit = true
 				break
 			}
 			if len(chunk.Data) > 0 {
-				// Copy chunk data since broadcaster may reuse the slice
-				data := make([]byte, len(chunk.Data))
-				copy(data, chunk.Data)
-
+				// Transfer ownership of pooled buffer directly to queue.
+				// No copy needed - broadcaster gives each listener its own buffer.
+				// The pipe writer goroutine returns buffers to the pool after writing.
 				select {
-				case chunkQueue <- data:
+				case chunkQueue <- chunk.Data:
+					// Ownership transferred - don't Release()
 				case <-cacheCtx.Done():
+					broadcast.PutChunkBuf(chunk.Data) // Return unused buffer
 					chunkErr = cacheCtx.Err()
+					earlyExit = true
 					break chunkLoop
 				}
+			} else {
+				chunk.Release() // Return zero-length pooled buffers
 			}
+		}
+
+		// Drain remaining listener chunks to return pooled buffers on early exit.
+		// Runs async since the broadcaster may still be streaming (channel not closed yet).
+		if earlyExit {
+			listener.DrainAndRelease()
 		}
 
 		// Close queue to signal pipe writer to finish

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -141,7 +141,9 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				bodyBuf.Reset()
 
 				bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
-				if bodyErr == nil {
+				// Verify body was actually retrieved: ocache GetStream returns nil
+				// for not-found keys (by design), so we must check bytes written.
+				if bodyErr == nil && bodyBuf.Len() > 0 {
 					metrics.RecordCacheHit()
 					log.Debug().Str("bucket", bucket).Str("key", key).Int64("size", meta.ContentLength).Msg("Serving small object from cache (fast path)")
 					meta.WriteHeaders(w)
@@ -153,9 +155,13 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 					putBuffer(bodyBuf) // Return buffer to pool
 					return nil
 				}
-				putBuffer(bodyBuf) // Return buffer to pool even on error
+				putBuffer(bodyBuf) // Return buffer to pool even on error/miss
 				// Fall through to upstream (cache miss handling below)
-				log.Debug().Err(bodyErr).Str("bucket", bucket).Str("key", key).Msg("GetBodyStream failed for small object, falling back to upstream")
+				if bodyErr != nil {
+					log.Debug().Err(bodyErr).Str("bucket", bucket).Str("key", key).Msg("GetBodyStream failed for small object, falling back to upstream")
+				} else {
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache body empty despite meta hit, falling back to upstream")
+				}
 			} else {
 				// Large objects: use io.Pipe for streaming (avoids buffering entire object)
 				pr, pw := io.Pipe()
@@ -406,15 +412,21 @@ func (s *Service) writeChunksToResponse(
 	// Wait for headers first
 	status, headers, err := listener.WaitForHeaders(ctx)
 	if err != nil {
+		listener.DrainAndRelease() // Return any buffered pooled chunks
 		return err
 	}
 
 	var headersWritten bool
 	var totalBytesOut int64
+	var earlyExit bool
 	defer func() {
 		// Track bytes out to client, even on error
 		if totalBytesOut > 0 {
 			metrics.BytesTransferred.WithLabelValues("out").Add(float64(totalBytesOut))
+		}
+		// Drain remaining pooled chunks on early exit (error, slow consumer, write failure)
+		if earlyExit {
+			listener.DrainAndRelease()
 		}
 	}()
 
@@ -423,6 +435,7 @@ func (s *Service) writeChunksToResponse(
 			if chunk.Err == broadcast.ErrSlowConsumer {
 				metrics.RecordBroadcastSlowConsumer()
 			}
+			earlyExit = true
 			return chunk.Err
 		}
 
@@ -435,13 +448,17 @@ func (s *Service) writeChunksToResponse(
 			}
 			n, writeErr := w.Write(chunk.Data)
 			totalBytesOut += int64(n)
+			chunk.Release() // Return pooled buffer after write copies data
 			if writeErr != nil {
+				earlyExit = true
 				return writeErr
 			}
 			// Flush if ResponseWriter supports it
 			if flusher, ok := w.(http.Flusher); ok {
 				flusher.Flush()
 			}
+		} else {
+			chunk.Release() // Return zero-length pooled buffers
 		}
 	}
 

--- a/tests/s3compat/run-tests.sh
+++ b/tests/s3compat/run-tests.sh
@@ -70,7 +70,7 @@ if ! sed -e "s|__AWS_ACCESS_KEY_ID__|${AWS_ACCESS_KEY_ID}|g" \
 fi
 export S3TEST_CONF
 
-cd s3-tests
+cd s3-tests || exit
 
 # Create tox.ini for running tests
 cat <<EOF >tox.ini


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core streaming, caching, and HTTP error-handling paths; behavior changes under concurrent invalidation and mid-stream errors could impact correctness/performance and should be validated with load and S3 compat tests.
> 
> **Overview**
> Improves streaming correctness and efficiency across the S3 proxy, primarily around broadcasted GET responses and cache writes.
> 
> Cache writes are made more race-safe by moving the tombstone check in `PutWithMetaStreamTombstoneAware` to *after* body streaming and cleaning up the body on late invalidation, reducing chances of stale/partial cache visibility. Broadcast streaming now reuses chunk buffers via a pool and adds explicit buffer release/drain paths in listeners and response writers, cutting per-chunk allocations and preventing buffer leaks when consumers exit early or are disconnected.
> 
> HTTP handlers now wrap service calls with `handleWithError` to avoid emitting an S3 XML error after response headers/body have already started streaming (logs instead), preventing corrupted responses/keep-alive issues. Minor housekeeping includes ignoring `.vscode/`, fixing `.env` newline, and making the s3compat test script exit on failed `cd`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b77c0c7b130f92d101bfcdcf05e4c385f27522b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->