### PR TITLE
fix: pass response tracker to handleError instead of raw ResponseWriter

### DIFF
--- a/handlers/server.go
+++ b/handlers/server.go
@@ -240,7 +240,7 @@ func handleWithError(w http.ResponseWriter, r *http.Request, handler func(http.R
 			log.Warn().Err(err).Str("path", r.URL.Path).
 				Msg("Error after response headers committed, cannot send error response")
 		} else {
-			handleError(w, r, err)
+			handleError(rt, r, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Pass the response tracker (`rt`) instead of the original `ResponseWriter` (`w`) to `handleError()` to ensure proper response tracking. This prevents bypassing response tracking which could cause duplicate header writes and stream corruption when error responses are sent after partial writes.

## Test Plan

- All existing unit tests pass
- No new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling wiring; behavior change is limited to how error responses are written and tracked.
> 
> **Overview**
> `handleWithError` now calls `handleError` with the wrapped `responseTracker` (`rt`) instead of the raw `ResponseWriter`, so any error response writes are tracked consistently.
> 
> This avoids scenarios where `handleError` could write headers/body without updating `rt.committed`, reducing the risk of duplicate header writes or corrupted HTTP streams when handlers partially write responses before failing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f365d4e98e02903cec21e735919e70edb65ceba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->