### PR TITLE
feat: add transparent proxy mode and refactor forwarder interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,6 @@ test-sdk: rocksdb-static
 		echo "  Start TAG with: make s3-test-local"; \
 		exit 1; \
 	fi
-	TAG_ENDPOINT=http://127-0-0-1.sslip.io:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
+	TAG_ENDPOINT=http://localhost:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TAG_CACHE_DATA_DIR := /tmp/tag-cache-data
 
 # Local test ports (avoid macOS conflicts: 7000 is used by AirPlay Receiver)
-TAG_LOCAL_HTTP_PORT := 8080
+TAG_LOCAL_HTTP_PORT := 80
 TAG_LOCAL_GRPC_PORT := 9090
 TAG_LOCAL_CLUSTER_PORT := 7070
 
@@ -370,6 +370,6 @@ test-sdk: rocksdb-static
 		echo "  Start TAG with: make s3-test-local"; \
 		exit 1; \
 	fi
-	TAG_ENDPOINT=http://localhost:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
+	TAG_ENDPOINT=http://127-0-0-1.sslip.io $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TAG_CACHE_DATA_DIR := /tmp/tag-cache-data
 
 # Local test ports (avoid macOS conflicts: 7000 is used by AirPlay Receiver)
-TAG_LOCAL_HTTP_PORT := 80
+TAG_LOCAL_HTTP_PORT := 8080
 TAG_LOCAL_GRPC_PORT := 9090
 TAG_LOCAL_CLUSTER_PORT := 7070
 
@@ -370,6 +370,6 @@ test-sdk: rocksdb-static
 		echo "  Start TAG with: make s3-test-local"; \
 		exit 1; \
 	fi
-	TAG_ENDPOINT=http://127-0-0-1.sslip.io $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
+	TAG_ENDPOINT=http://127-0-0-1.sslip.io:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test -v -timeout 300s $(TESTFLAGS) ./tests/integration/sdk/...
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigri
 ## Features
 
 - **S3-Compatible API**: Supports all S3 API endpoints supported by Tigris
+- **Transparent Proxy Mode**: Forwards client requests as-is with proxy headers, preserving original signatures (enabled by default)
 - **Embedded Cache**: High-performance RocksDB-based cache with automatic cluster discovery
 - **Request Coalescing**: Streaming broadcast pattern reduces duplicate upstream requests under concurrent load
 - **Range Request Caching**: Background fetch of full objects on range cache miss for optimal ML training workloads
@@ -87,7 +88,7 @@ See [docs/configuration.md](docs/configuration.md) for full configuration refere
 
 ## Architecture
 
-```
+```text
 ┌─────────────┐     ┌─────────────────────────────┐     ┌─────────────┐
 │   Client    │────▶│           TAG               │────▶│   Tigris    │
 │  (S3 SDK)   │◀────│  ┌─────────────────────┐    │◀────│   Storage   │

--- a/auth/proxy_signer.go
+++ b/auth/proxy_signer.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ProxySigner computes proxy headers for transparent proxy mode.
+// In this mode, TAG forwards the client's original signed request as-is
+// and adds proxy headers so Tigris validates the signature against the original host.
+type ProxySigner struct {
+	accessKey string
+	secretKey string
+}
+
+// NewProxySigner creates a new proxy signer with TAG's own Tigris credentials.
+func NewProxySigner(accessKey, secretKey string) *ProxySigner {
+	return &ProxySigner{
+		accessKey: accessKey,
+		secretKey: secretKey,
+	}
+}
+
+// ProxyHeaders holds the 4 proxy headers to add to the forwarded request.
+type ProxyHeaders struct {
+	ForwardedHost  string // X-Tigris-Forwarded-Host
+	ProxyAccessKey string // X-Tigris-Proxy-Access-Key
+	ProxyTimestamp string // X-Tigris-Proxy-Timestamp
+	ProxySignature string // X-Tigris-Proxy-Signature
+}
+
+// ComputeProxyHeaders computes the 4 proxy headers for a given request.
+// forwardedHost is the original Host header from the client request.
+// method is the HTTP method (GET, PUT, etc.).
+// path is the URL path (e.g., /bucket/object.jpg).
+func (s *ProxySigner) ComputeProxyHeaders(forwardedHost, method, path string) *ProxyHeaders {
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	// Build canonical string: forwarded_host\ntimestamp\nmethod\npath
+	canonicalString := fmt.Sprintf("%s\n%s\n%s\n%s", forwardedHost, timestamp, method, path)
+
+	// HMAC-SHA256 signature using TAG's secret key
+	signature := hex.EncodeToString(hmacSHA256([]byte(s.secretKey), []byte(canonicalString)))
+
+	return &ProxyHeaders{
+		ForwardedHost:  forwardedHost,
+		ProxyAccessKey: s.accessKey,
+		ProxyTimestamp: timestamp,
+		ProxySignature: signature,
+	}
+}
+
+// AccessKey returns the proxy access key.
+func (s *ProxySigner) AccessKey() string { return s.accessKey }
+
+// SecretKey returns the proxy secret key.
+func (s *ProxySigner) SecretKey() string { return s.secretKey }

--- a/auth/proxy_signer_test.go
+++ b/auth/proxy_signer_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestComputeProxyHeaders(t *testing.T) {
+	signer := NewProxySigner("test-access-key", "test-secret-key")
+
+	headers := signer.ComputeProxyHeaders("cache.customer.com", "GET", "/bucket/object.jpg")
+
+	if headers.ForwardedHost != "cache.customer.com" {
+		t.Errorf("ForwardedHost = %q, want %q", headers.ForwardedHost, "cache.customer.com")
+	}
+	if headers.ProxyAccessKey != "test-access-key" {
+		t.Errorf("ProxyAccessKey = %q, want %q", headers.ProxyAccessKey, "test-access-key")
+	}
+
+	// Verify timestamp is a valid Unix timestamp within 5 seconds of now
+	ts, err := strconv.ParseInt(headers.ProxyTimestamp, 10, 64)
+	if err != nil {
+		t.Fatalf("ProxyTimestamp %q is not a valid integer: %v", headers.ProxyTimestamp, err)
+	}
+	now := time.Now().Unix()
+	if ts < now-5 || ts > now+5 {
+		t.Errorf("ProxyTimestamp %d is not within 5 seconds of now (%d)", ts, now)
+	}
+
+	// Verify signature is a valid hex string
+	sigBytes, err := hex.DecodeString(headers.ProxySignature)
+	if err != nil {
+		t.Fatalf("ProxySignature %q is not valid hex: %v", headers.ProxySignature, err)
+	}
+	// HMAC-SHA256 produces 32 bytes
+	if len(sigBytes) != 32 {
+		t.Errorf("ProxySignature decoded to %d bytes, want 32", len(sigBytes))
+	}
+
+	// Verify the signature matches the expected HMAC computation
+	canonical := fmt.Sprintf("%s\n%s\n%s\n%s", "cache.customer.com", headers.ProxyTimestamp, "GET", "/bucket/object.jpg")
+	mac := hmac.New(sha256.New, []byte("test-secret-key"))
+	mac.Write([]byte(canonical))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if headers.ProxySignature != expected {
+		t.Errorf("ProxySignature = %q, want %q", headers.ProxySignature, expected)
+	}
+}
+
+func TestComputeProxyHeaders_DifferentMethods(t *testing.T) {
+	signer := NewProxySigner("ak", "sk")
+
+	methods := []string{"GET", "PUT", "DELETE", "HEAD", "POST"}
+	signatures := make(map[string]bool)
+
+	for _, method := range methods {
+		headers := signer.ComputeProxyHeaders("host.example.com", method, "/bucket/key")
+		if headers.ProxySignature == "" {
+			t.Errorf("Empty signature for method %s", method)
+		}
+		signatures[headers.ProxySignature] = true
+	}
+
+	// All methods should produce different signatures (since method is part of canonical string)
+	// Note: there's a tiny chance of collision, but practically impossible with SHA256
+	if len(signatures) != len(methods) {
+		t.Errorf("Expected %d unique signatures, got %d", len(methods), len(signatures))
+	}
+}
+
+func TestProxySignerAccessors(t *testing.T) {
+	signer := NewProxySigner("my-access-key", "my-secret-key")
+
+	if signer.AccessKey() != "my-access-key" {
+		t.Errorf("AccessKey() = %q, want %q", signer.AccessKey(), "my-access-key")
+	}
+	if signer.SecretKey() != "my-secret-key" {
+		t.Errorf("SecretKey() = %q, want %q", signer.SecretKey(), "my-secret-key")
+	}
+}

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -266,25 +266,16 @@ func shouldCopyHeader(key string) bool {
 	// Range requests
 	case "range":
 		return true
-	// S3-specific headers for operations
-	case "x-amz-copy-source", "x-amz-copy-source-range",
-		"x-amz-copy-source-if-match", "x-amz-copy-source-if-none-match",
-		"x-amz-copy-source-if-modified-since", "x-amz-copy-source-if-unmodified-since",
-		"x-amz-metadata-directive", "x-amz-tagging-directive",
-		"x-amz-storage-class", "x-amz-website-redirect-location",
-		"x-amz-server-side-encryption", "x-amz-server-side-encryption-customer-algorithm",
-		"x-amz-server-side-encryption-customer-key", "x-amz-server-side-encryption-customer-key-md5",
-		"x-amz-acl", "x-amz-grant-read", "x-amz-grant-write", "x-amz-grant-read-acp",
-		"x-amz-grant-write-acp", "x-amz-grant-full-control",
-		"x-amz-tagging", "x-amz-object-lock-mode", "x-amz-object-lock-retain-until-date",
-		"x-amz-object-lock-legal-hold", "x-amz-expected-bucket-owner":
-		return true
 	// Conditional request headers
 	case "if-match", "if-none-match", "if-modified-since", "if-unmodified-since":
 		return true
 	}
-	// Copy user metadata headers
-	if strings.HasPrefix(lower, "x-amz-meta-") {
+	// All x-amz-* headers (S3 operations, metadata, etc.)
+	if strings.HasPrefix(lower, "x-amz-") {
+		return true
+	}
+	// All Tigris-specific headers (tigris-* and x-tigris-*)
+	if strings.HasPrefix(lower, "tigris-") || strings.HasPrefix(lower, "x-tigris-") {
 		return true
 	}
 	return false

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -274,7 +274,12 @@ func shouldCopyHeader(key string) bool {
 	if strings.HasPrefix(lower, "x-amz-") {
 		return true
 	}
-	// All Tigris-specific headers (tigris-* and x-tigris-*)
+	// All Tigris-specific headers (tigris-* and x-tigris-*), except proxy headers
+	// which must not be forwarded in signing mode to prevent client injection.
+	// The transparent forwarder overwrites these with .Set() so it's unaffected.
+	if strings.HasPrefix(lower, "x-tigris-proxy-") || lower == "x-tigris-forwarded-host" {
+		return false
+	}
 	if strings.HasPrefix(lower, "tigris-") || strings.HasPrefix(lower, "x-tigris-") {
 		return true
 	}

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -21,8 +21,8 @@ const (
 	// unsignedPayload is used for streaming uploads or when payload hash is not computed.
 	unsignedPayload = "UNSIGNED-PAYLOAD"
 
-	// timeFormat is the format for X-Amz-Date header.
-	timeFormat = "20060102T150405Z"
+	// TimeFormat is the format for X-Amz-Date header.
+	TimeFormat = "20060102T150405Z"
 
 	// shortTimeFormat is the format for the date in the credential scope.
 	shortTimeFormat = "20060102"
@@ -36,6 +36,20 @@ const (
 	// terminationString is the termination string for AWS SigV4.
 	terminationString = "aws4_request"
 )
+
+// ParseHTTPDate parses a date string in common HTTP/AWS formats.
+func ParseHTTPDate(dateStr string) (time.Time, error) {
+	for _, layout := range []string{
+		TimeFormat,
+		time.RFC1123,
+		time.RFC1123Z,
+	} {
+		if t, err := time.Parse(layout, dateStr); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized date format: %s", dateStr)
+}
 
 // RequestSigner signs HTTP requests using AWS SigV4.
 type RequestSigner struct {
@@ -101,7 +115,7 @@ func (s *RequestSigner) SignRequest(ctx context.Context, method, path string,
 
 	// Set required headers for signing
 	now := time.Now().UTC()
-	req.Header.Set("X-Amz-Date", now.Format(timeFormat))
+	req.Header.Set("X-Amz-Date", now.Format(TimeFormat))
 	req.Header.Set("X-Amz-Content-Sha256", bodyHash)
 	req.Header.Set("Host", req.URL.Host)
 
@@ -239,7 +253,7 @@ func (s *RequestSigner) buildCanonicalHeaders(req *http.Request) (string, string
 func (s *RequestSigner) buildStringToSign(signingTime time.Time, credentialScope, canonicalRequest string) string {
 	return strings.Join([]string{
 		algorithm,
-		signingTime.Format(timeFormat),
+		signingTime.Format(TimeFormat),
 		credentialScope,
 		hashSHA256([]byte(canonicalRequest)),
 	}, "\n")

--- a/auth/signer_test.go
+++ b/auth/signer_test.go
@@ -202,6 +202,11 @@ func TestShouldCopyHeader(t *testing.T) {
 		// Tigris-specific headers (tigris-* and x-tigris-*)
 		{"Tigris-Force-Delete", true},
 		{"X-Tigris-Custom", true},
+		// Proxy headers are blocked to prevent client injection in signing mode
+		{"X-Tigris-Forwarded-Host", false},
+		{"X-Tigris-Proxy-Access-Key", false},
+		{"X-Tigris-Proxy-Timestamp", false},
+		{"X-Tigris-Proxy-Signature", false},
 		// Conditional request headers
 		{"If-None-Match", true},
 		{"If-Modified-Since", true},

--- a/auth/signer_test.go
+++ b/auth/signer_test.go
@@ -184,6 +184,7 @@ func TestShouldCopyHeader(t *testing.T) {
 		header   string
 		expected bool
 	}{
+		// Content headers
 		{"Content-Type", true},
 		{"Content-Length", true},
 		{"Content-Encoding", true},
@@ -191,10 +192,21 @@ func TestShouldCopyHeader(t *testing.T) {
 		{"Cache-Control", true},
 		{"Expires", true},
 		{"Content-MD5", true},
+		// All x-amz-* headers are allowed (signer overwrites X-Amz-Date etc.)
 		{"X-Amz-Meta-Custom", true},
 		{"X-Amz-Meta-Another-Header", true},
+		{"X-Amz-Date", true},
+		{"X-Amz-Content-Sha256", true},
+		{"X-Amz-Copy-Source", true},
+		{"X-Amz-Tagging", true},
+		// Tigris-specific headers (tigris-* and x-tigris-*)
+		{"Tigris-Force-Delete", true},
+		{"X-Tigris-Custom", true},
+		// Conditional request headers
+		{"If-None-Match", true},
+		{"If-Modified-Since", true},
+		// Not copied
 		{"Authorization", false},
-		{"X-Amz-Date", false},
 		{"Host", false},
 		{"Random-Header", false},
 	}

--- a/auth/signer_test.go
+++ b/auth/signer_test.go
@@ -251,6 +251,38 @@ func TestHashSHA256(t *testing.T) {
 	}
 }
 
+func TestParseHTTPDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "ISO 8601", input: "20260211T055514Z", wantErr: false},
+		{name: "RFC 1123", input: "Wed, 11 Feb 2026 05:55:14 GMT", wantErr: false},
+		{name: "RFC 1123Z", input: "Wed, 11 Feb 2026 05:55:14 -0000", wantErr: false},
+		{name: "invalid format", input: "not-a-date", wantErr: true},
+		{name: "empty string", input: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHTTPDate(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseHTTPDate(%q) error = nil, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseHTTPDate(%q) error = %v, want nil", tt.input, err)
+			}
+			if got.IsZero() {
+				t.Errorf("ParseHTTPDate(%q) returned zero time", tt.input)
+			}
+		})
+	}
+}
+
 func TestAwsURIEncode(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -86,7 +86,7 @@ func (v *RequestValidator) validateSigned(r *http.Request, authInfo *AuthInfo, s
 	}
 
 	// Parse and validate the date
-	requestTime, err := time.Parse(timeFormat, dateStr)
+	requestTime, err := time.Parse(TimeFormat, dateStr)
 	if err != nil {
 		// Try HTTP date format
 		requestTime, err = time.Parse(time.RFC1123, dateStr)
@@ -122,7 +122,7 @@ func (v *RequestValidator) validatePresigned(r *http.Request, authInfo *AuthInfo
 		return ErrInvalidDate
 	}
 
-	requestTime, err := time.Parse(timeFormat, dateStr)
+	requestTime, err := time.Parse(TimeFormat, dateStr)
 	if err != nil {
 		return ErrInvalidDate
 	}
@@ -162,7 +162,7 @@ func (v *RequestValidator) computeSignature(r *http.Request, authInfo *AuthInfo,
 	// Build string to sign
 	stringToSign := strings.Join([]string{
 		algorithm,
-		signingTime.Format(timeFormat),
+		signingTime.Format(TimeFormat),
 		credentialScope,
 		hashSHA256([]byte(canonicalRequest)),
 	}, "\n")
@@ -185,7 +185,7 @@ func (v *RequestValidator) computePresignedSignature(r *http.Request, authInfo *
 	// Build string to sign
 	stringToSign := strings.Join([]string{
 		algorithm,
-		signingTime.Format(timeFormat),
+		signingTime.Format(TimeFormat),
 		credentialScope,
 		hashSHA256([]byte(canonicalRequest)),
 	}, "\n")

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -92,6 +92,7 @@ func main() {
 		Int("http_port", cfg.Server.HTTPPort).
 		Str("upstream", cfg.Upstream.Endpoint).
 		Bool("cache_enabled", cfg.Cache.IsEnabled()).
+		Bool("transparent_proxy", cfg.Upstream.TransparentProxy).
 		Str("node_id", cfg.Cache.NodeID).
 		Msg("Starting TAG (Tigris Access Gateway)")
 
@@ -107,7 +108,19 @@ func main() {
 		log.Warn().Err(err).Msg("Failed to load credentials from environment")
 	}
 
-	if credStore.Count() == 0 {
+	// Initialize proxy signer if transparent proxy is enabled
+	var proxySigner *auth.ProxySigner
+	if cfg.Upstream.TransparentProxy {
+		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+		if accessKey == "" || secretKey == "" {
+			log.Fatal().Msg("Transparent proxy requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
+		}
+		proxySigner = auth.NewProxySigner(accessKey, secretKey)
+		log.Info().Msg("Transparent proxy mode enabled")
+	}
+
+	if credStore.Count() == 0 && !cfg.Upstream.TransparentProxy {
 		log.Warn().Msg("No credentials loaded - TAG will reject all requests")
 	}
 
@@ -162,7 +175,7 @@ func main() {
 	}
 
 	// 3. Initialize forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost, proxySigner)
 
 	// 4. Initialize proxy service
 	service := proxy.NewService(forwarder, objectCache, cfg)

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -92,7 +92,7 @@ func main() {
 		Int("http_port", cfg.Server.HTTPPort).
 		Str("upstream", cfg.Upstream.Endpoint).
 		Bool("cache_enabled", cfg.Cache.IsEnabled()).
-		Bool("transparent_proxy", cfg.Upstream.TransparentProxy).
+		Bool("transparent_proxy", cfg.Upstream.IsTransparentProxy()).
 		Str("node_id", cfg.Cache.NodeID).
 		Msg("Starting TAG (Tigris Access Gateway)")
 
@@ -110,7 +110,7 @@ func main() {
 
 	// Initialize proxy signer if transparent proxy is enabled
 	var proxySigner *auth.ProxySigner
-	if cfg.Upstream.TransparentProxy {
+	if cfg.Upstream.IsTransparentProxy() {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 		if accessKey == "" || secretKey == "" {
@@ -120,7 +120,7 @@ func main() {
 		log.Info().Msg("Transparent proxy mode enabled")
 	}
 
-	if credStore.Count() == 0 && !cfg.Upstream.TransparentProxy {
+	if credStore.Count() == 0 && !cfg.Upstream.IsTransparentProxy() {
 		log.Warn().Msg("No credentials loaded - TAG will reject all requests")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 // Default configuration values.
 const (
 	// DefaultHTTPPort is the default S3 API port.
-	DefaultHTTPPort = 80
+	DefaultHTTPPort = 8080
 
 	// DefaultBindIP is the default bind address.
 	DefaultBindIP = "0.0.0.0"

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 // Default configuration values.
 const (
 	// DefaultHTTPPort is the default S3 API port.
-	DefaultHTTPPort = 8080
+	DefaultHTTPPort = 80
 
 	// DefaultBindIP is the default bind address.
 	DefaultBindIP = "0.0.0.0"
@@ -79,6 +79,7 @@ type UpstreamConfig struct {
 	Endpoint            string `yaml:"endpoint"`                // Tigris S3 endpoint (e.g., https://fly.storage.tigris.dev)
 	Region              string `yaml:"region"`                  // AWS region for signing (default: auto)
 	MaxIdleConnsPerHost int    `yaml:"max_idle_conns_per_host"` // HTTP connection pool size per host (default: 100)
+	TransparentProxy    bool   `yaml:"transparent_proxy"`       // Forward client requests as-is with proxy headers (default: false)
 }
 
 // CredentialsConfig holds credential store configuration.
@@ -278,6 +279,11 @@ func applyEnvOverrides(cfg *Config) {
 	// Enable pprof from environment (disabled by default for security)
 	if enabled := os.Getenv("TAG_PPROF_ENABLED"); enabled == "true" || enabled == "1" {
 		cfg.Server.PprofEnabled = true
+	}
+
+	// Enable transparent proxy from environment (disabled by default)
+	if enabled := os.Getenv("TAG_TRANSPARENT_PROXY"); enabled == "true" || enabled == "1" {
+		cfg.Upstream.TransparentProxy = true
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -79,7 +81,21 @@ type UpstreamConfig struct {
 	Endpoint            string `yaml:"endpoint"`                // Tigris S3 endpoint (e.g., https://fly.storage.tigris.dev)
 	Region              string `yaml:"region"`                  // AWS region for signing (default: auto)
 	MaxIdleConnsPerHost int    `yaml:"max_idle_conns_per_host"` // HTTP connection pool size per host (default: 100)
-	TransparentProxy    bool   `yaml:"transparent_proxy"`       // Forward client requests as-is with proxy headers (default: false)
+	TransparentProxy    *bool  `yaml:"transparent_proxy"`       // Forward client requests as-is with proxy headers (default: true when nil)
+}
+
+// IsTransparentProxy returns whether transparent proxy mode is enabled.
+// Returns true by default if not explicitly set.
+func (u *UpstreamConfig) IsTransparentProxy() bool {
+	if u.TransparentProxy == nil {
+		return true // Default to enabled
+	}
+	return *u.TransparentProxy
+}
+
+// SetTransparentProxy sets the TransparentProxy field to the given value.
+func (u *UpstreamConfig) SetTransparentProxy(enabled bool) {
+	u.TransparentProxy = &enabled
 }
 
 // CredentialsConfig holds credential store configuration.
@@ -149,14 +165,23 @@ func Load(path string) (*Config, error) {
 	// Override from environment variables
 	applyEnvOverrides(&cfg)
 
+	// Validate configuration
+	if err := validate(&cfg); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
 }
 
 // NewDefault creates a Config with default values.
+// Panics if the resulting configuration is invalid (e.g., disallowed upstream endpoint).
 func NewDefault() *Config {
 	cfg := &Config{}
 	applyDefaults(cfg)
 	applyEnvOverrides(cfg)
+	if err := validate(cfg); err != nil {
+		panic(fmt.Sprintf("invalid default configuration: %v", err))
+	}
 	return cfg
 }
 
@@ -281,10 +306,37 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Server.PprofEnabled = true
 	}
 
-	// Enable transparent proxy from environment (disabled by default)
-	if enabled := os.Getenv("TAG_TRANSPARENT_PROXY"); enabled == "true" || enabled == "1" {
-		cfg.Upstream.TransparentProxy = true
+	// Override transparent proxy from environment (enabled by default)
+	if val := os.Getenv("TAG_TRANSPARENT_PROXY"); val != "" {
+		enabled := val == "true" || val == "1"
+		cfg.Upstream.SetTransparentProxy(enabled)
 	}
+}
+
+// validate checks that the final configuration is valid.
+func validate(cfg *Config) error {
+	if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateUpstreamEndpoint ensures the upstream endpoint is an allowed Tigris domain or localhost.
+func validateUpstreamEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid upstream endpoint %q: %w", endpoint, err)
+	}
+
+	host := u.Hostname() // strips port if present
+	if host == "localhost" {
+		return nil
+	}
+	if strings.HasSuffix(host, ".tigris.dev") || strings.HasSuffix(host, ".storage.dev") {
+		return nil
+	}
+
+	return fmt.Errorf("upstream endpoint %q is not allowed: host must be localhost, *.tigris.dev, or *.storage.dev", endpoint)
 }
 
 // splitEndpoints splits a comma-separated string into a slice of endpoints.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,7 @@ server:
   http_port: 9000
   bind_ip: "127.0.0.1"
 upstream:
-  endpoint: "https://custom.endpoint.com"
+  endpoint: "https://fly.storage.tigris.dev"
   region: "us-west-2"
 cache:
   enabled: true
@@ -48,8 +48,8 @@ log:
 	}
 
 	// Verify upstream config
-	if cfg.Upstream.Endpoint != "https://custom.endpoint.com" {
-		t.Errorf("Upstream.Endpoint = %q, want https://custom.endpoint.com", cfg.Upstream.Endpoint)
+	if cfg.Upstream.Endpoint != "https://fly.storage.tigris.dev" {
+		t.Errorf("Upstream.Endpoint = %q, want https://fly.storage.tigris.dev", cfg.Upstream.Endpoint)
 	}
 	if cfg.Upstream.Region != "us-west-2" {
 		t.Errorf("Upstream.Region = %q, want us-west-2", cfg.Upstream.Region)
@@ -123,7 +123,7 @@ func TestLoad_EnvOverrides(t *testing.T) {
 server:
   http_port: 8080
 upstream:
-  endpoint: "https://default.endpoint.com"
+  endpoint: "https://fly.storage.tigris.dev"
 log:
   level: "info"
 `
@@ -134,7 +134,7 @@ log:
 	}
 
 	// Set environment variables
-	t.Setenv("TAG_UPSTREAM_ENDPOINT", "https://env.endpoint.com")
+	t.Setenv("TAG_UPSTREAM_ENDPOINT", "https://t3.storage.dev")
 	t.Setenv("TAG_CACHE_NODE_ID", "env-node-1")
 	t.Setenv("TAG_CACHE_DISK_PATH", "/env/cache/path")
 	t.Setenv("TAG_CACHE_SEED_NODES", "env-node-0:7000,env-node-1:7000")
@@ -146,8 +146,8 @@ log:
 	}
 
 	// Verify env overrides
-	if cfg.Upstream.Endpoint != "https://env.endpoint.com" {
-		t.Errorf("Upstream.Endpoint = %q, want https://env.endpoint.com", cfg.Upstream.Endpoint)
+	if cfg.Upstream.Endpoint != "https://t3.storage.dev" {
+		t.Errorf("Upstream.Endpoint = %q, want https://t3.storage.dev", cfg.Upstream.Endpoint)
 	}
 	if cfg.Cache.NodeID != "env-node-1" {
 		t.Errorf("Cache.NodeID = %q, want env-node-1", cfg.Cache.NodeID)
@@ -322,17 +322,17 @@ cache:
 	}
 }
 
-func TestTransparentProxy_DisabledByDefault(t *testing.T) {
+func TestTransparentProxy_EnabledByDefault(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Upstream.TransparentProxy {
-		t.Error("TransparentProxy = true, want false (disabled by default)")
+	if !cfg.Upstream.IsTransparentProxy() {
+		t.Error("IsTransparentProxy() = false, want true (enabled by default)")
 	}
 }
 
-func TestTransparentProxy_EnabledByYAML(t *testing.T) {
+func TestTransparentProxy_DisabledByYAML(t *testing.T) {
 	content := `
 upstream:
-  transparent_proxy: true
+  transparent_proxy: false
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
@@ -344,26 +344,67 @@ upstream:
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if !cfg.Upstream.TransparentProxy {
-		t.Error("TransparentProxy = false, want true")
+	if cfg.Upstream.IsTransparentProxy() {
+		t.Error("IsTransparentProxy() = true, want false")
 	}
 }
 
-func TestTransparentProxy_EnabledByEnv(t *testing.T) {
-	t.Setenv("TAG_TRANSPARENT_PROXY", "true")
+func TestTransparentProxy_DisabledByEnv(t *testing.T) {
+	t.Setenv("TAG_TRANSPARENT_PROXY", "false")
 
 	cfg := NewDefault()
-	if !cfg.Upstream.TransparentProxy {
-		t.Error("TransparentProxy = false, want true (enabled by env)")
+	if cfg.Upstream.IsTransparentProxy() {
+		t.Error("IsTransparentProxy() = true, want false (disabled by env)")
 	}
 }
 
-func TestTransparentProxy_EnabledByEnv_NumericOne(t *testing.T) {
-	t.Setenv("TAG_TRANSPARENT_PROXY", "1")
+func TestTransparentProxy_DisabledByEnv_NumericZero(t *testing.T) {
+	t.Setenv("TAG_TRANSPARENT_PROXY", "0")
 
 	cfg := NewDefault()
-	if !cfg.Upstream.TransparentProxy {
-		t.Error("TransparentProxy = false, want true (enabled by env with '1')")
+	if cfg.Upstream.IsTransparentProxy() {
+		t.Error("IsTransparentProxy() = true, want false (disabled by env with '0')")
+	}
+}
+
+func TestValidateUpstreamEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+	}{
+		{"tigris.dev domain", "https://fly.storage.tigris.dev", false},
+		{"storage.dev domain", "https://t3.storage.dev", false},
+		{"localhost", "http://localhost:8080", false},
+		{"localhost no port", "http://localhost", false},
+		{"disallowed domain", "https://evil.example.com", true},
+		{"subdomain of tigris.dev", "https://sub.tigris.dev", false},
+		{"not a suffix match", "https://nottrigris.dev", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUpstreamEndpoint(tt.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateUpstreamEndpoint(%q) error = %v, wantErr %v", tt.endpoint, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoad_InvalidUpstreamEndpoint(t *testing.T) {
+	content := `
+upstream:
+  endpoint: "https://evil.example.com"
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	_, err := Load(tmpFile)
+	if err == nil {
+		t.Error("Load() should return error for disallowed upstream endpoint")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,6 +322,51 @@ cache:
 	}
 }
 
+func TestTransparentProxy_DisabledByDefault(t *testing.T) {
+	cfg := NewDefault()
+	if cfg.Upstream.TransparentProxy {
+		t.Error("TransparentProxy = true, want false (disabled by default)")
+	}
+}
+
+func TestTransparentProxy_EnabledByYAML(t *testing.T) {
+	content := `
+upstream:
+  transparent_proxy: true
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if !cfg.Upstream.TransparentProxy {
+		t.Error("TransparentProxy = false, want true")
+	}
+}
+
+func TestTransparentProxy_EnabledByEnv(t *testing.T) {
+	t.Setenv("TAG_TRANSPARENT_PROXY", "true")
+
+	cfg := NewDefault()
+	if !cfg.Upstream.TransparentProxy {
+		t.Error("TransparentProxy = false, want true (enabled by env)")
+	}
+}
+
+func TestTransparentProxy_EnabledByEnv_NumericOne(t *testing.T) {
+	t.Setenv("TAG_TRANSPARENT_PROXY", "1")
+
+	cfg := NewDefault()
+	if !cfg.Upstream.TransparentProxy {
+		t.Error("TransparentProxy = false, want true (enabled by env with '1')")
+	}
+}
+
 func TestCacheDefaultValues(t *testing.T) {
 	cfg := NewDefault()
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,11 @@ This document describes the architecture of TAG (Tigris Access Gateway), a high-
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                              TAG Proxy                                   │
-│  ┌─────────┐  ┌──────────┐  ┌─────────┐  ┌─────────┐  ┌─────────────┐  │
-│  │ Handler │──│   Auth   │──│  Proxy  │──│  Cache  │──│  Forwarder  │  │
-│  │ Server  │  │ Validator│  │ Service │  │ Client  │  │   (Signer)  │  │
-│  └────┬────┘  └──────────┘  └────┬────┘  └────┬────┘  └──────┬──────┘  │
+│                              TAG Proxy                                  │
+│  ┌─────────┐  ┌──────────┐  ┌─────────┐  ┌─────────┐  ┌─────────────┐   │
+│  │ Handler │──│   Auth   │──│  Proxy  │──│  Cache  │──│  Forwarder  │   │
+│  │ Server  │  │ Validator│  │ Service │  │ Client  │  │   (Signer)  │   │
+│  └────┬────┘  └──────────┘  └────┬────┘  └────┬────┘  └──────┬──────┘   │
 │       │                          │            │               │         │
 │       │                          │     ┌──────┴──────┐        │         │
 │       │                          │     │  Embedded   │        │         │
@@ -41,6 +41,7 @@ The HTTP server that receives incoming S3 requests.
 - **errors.go**: S3-compatible error responses
 
 Routes requests to appropriate handlers based on HTTP method and path:
+
 - `GET /{bucket}/{key}` → GetObject
 - `PUT /{bucket}/{key}` → PutObject
 - `DELETE /{bucket}/{key}` → DeleteObject
@@ -58,6 +59,7 @@ AWS Signature Version 4 authentication and request signing.
 - **parser.go**: Parses Authorization headers and presigned URLs
 
 **Authentication Flow:**
+
 ```
 1. Extract access key from Authorization header or query params
 2. Look up secret key from credential store
@@ -82,12 +84,14 @@ Interface to the embedded OCache module with RocksDB storage.
 - **object.go**: Cached object metadata structure
 
 TAG embeds OCache directly, providing:
+
 - High-performance RocksDB-based storage
 - Optional clustering via gossip protocol (memberlist)
 - gRPC-based cache routing between nodes
 - Consistent hashing for key distribution
 
 **Two-Key Storage Pattern:**
+
 ```
 Object "bucket/key" is stored as:
   - Metadata key: "meta:bucket/key" → JSON with headers, size, etag, etc.
@@ -95,6 +99,7 @@ Object "bucket/key" is stored as:
 ```
 
 This pattern enables:
+
 - Efficient HEAD requests (metadata only)
 - Conditional request support (If-None-Match, If-Modified-Since)
 - Range requests from cached full objects
@@ -116,28 +121,28 @@ For multi-node deployments, TAG nodes form a distributed cache cluster:
                     └─────────────────────────────────────────┘
                               ▲           ▲           ▲
                               │           │           │
-                    ┌─────────┴───┐ ┌─────┴─────┐ ┌───┴─────────┐
-                    │   TAG-1     │ │   TAG-2   │ │   TAG-3     │
-                    │ ┌─────────┐ │ │ ┌───────┐ │ │ ┌─────────┐ │
-                    │ │ Embedded│ │ │ │Embedded│ │ │ │ Embedded│ │
-                    │ │ Cache   │ │ │ │ Cache  │ │ │ │ Cache   │ │
+                    ┌─────────┴───┐ ┌─────┴───────┐ ┌───┴─────────┐
+                    │   TAG-1     │ │   TAG-2     │ │   TAG-3     │
+                    │ ┌─────────┐ │ │ ┌─────────┐ │ │ ┌─────────┐ │
+                    │ │ Embedded│ │ │ │ Embedded│ │ │ │ Embedded│ │
+                    │ │ Cache   │ │ │ │ Cache   │ │ │ │ Cache   │ │
                     │ │(RocksDB)│ │ │ │(RocksDB)│ │ │ │(RocksDB)│ │
-                    │ └─────────┘ │ │ └───────┘ │ │ └─────────┘ │
-                    └──────┬──────┘ └─────┬─────┘ └──────┬──────┘
-                           │              │              │
-                    ┌──────┴──────────────┴──────────────┴──────┐
-                    │              gRPC Routing                  │
-                    │         (Cache Key Distribution)           │
-                    └───────────────────────────────────────────┘
+                    │ └─────────┘ │ │ └─────────┘ │ │ └─────────┘ │
+                    └──────┬──────┘ └─────┬───────┘ └──────┬──────┘
+                           │              │                │
+                    ┌──────┴──────────────┴────────────────┴──────┐
+                    │              gRPC Routing                   │
+                    │         (Cache Key Distribution)            │
+                    └─────────────────────────────────────────────┘
 ```
 
 **Cluster Components:**
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 8080 | HTTP | S3 API requests |
-| 7000 | TCP | Memberlist gossip (cluster discovery) |
-| 9000 | gRPC | Cache routing between nodes |
+| Port | Protocol | Purpose                               |
+| ---- | -------- | ------------------------------------- |
+| 8080 | HTTP     | S3 API requests                       |
+| 7000 | TCP      | Memberlist gossip (cluster discovery) |
+| 9000 | gRPC     | Cache routing between nodes           |
 
 **How Clustering Works:**
 
@@ -243,6 +248,7 @@ Client3                 │                                  │
 ```
 
 **Key Points:**
+
 - First request becomes the "fetcher" and initiates upstream request
 - Subsequent requests before streaming starts join as "listeners"
 - All clients receive data simultaneously as chunks arrive
@@ -278,6 +284,7 @@ Client                 TAG                    Embedded Cache         Tigris
 ```
 
 **Benefits:**
+
 - Low latency: Client gets range immediately
 - Future ranges served from cache
 - Background fetches are coalesced (multiple range requests = single fetch)
@@ -310,11 +317,13 @@ Body key:               "body|bucket|key"
 ### Cacheability Rules
 
 Objects are cached when:
+
 - Response status is 200 OK
 - Size is within `size_threshold` (default 1GB)
 - No `Cache-Control: no-store` or `private` headers
 
 Objects are NOT cached when:
+
 - Response is not 200 (errors, redirects)
 - Size exceeds threshold
 - Cache-Control prevents caching
@@ -344,6 +353,7 @@ type Listener struct {
 ```
 
 **Policies:**
+
 - **No Late Joiners**: Once streaming starts, new requests start their own broadcast
 - **Slow Consumer Handling**: Listeners with full channels are disconnected
 - **Memory Bounded**: `chunkSize × channelBuffer × numListeners` per broadcast
@@ -365,10 +375,10 @@ TAG returns S3-compatible XML error responses:
 
 ### Error Mapping
 
-| Internal Error | S3 Error Code | HTTP Status |
-|----------------|---------------|-------------|
-| Invalid signature | SignatureDoesNotMatch | 403 |
-| Unknown access key | InvalidAccessKeyId | 403 |
-| Request expired | RequestTimeTooSkewed | 403 |
-| Slow consumer | InternalError | 500 |
-| Upstream error | InternalError | 502 |
+| Internal Error     | S3 Error Code         | HTTP Status |
+| ------------------ | --------------------- | ----------- |
+| Invalid signature  | SignatureDoesNotMatch | 403         |
+| Unknown access key | InvalidAccessKeyId    | 403         |
+| Request expired    | RequestTimeTooSkewed  | 403         |
+| Slow consumer      | InternalError         | 500         |
+| Upstream error     | InternalError         | 502         |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,12 +4,12 @@ This document describes the architecture of TAG (Tigris Access Gateway), a high-
 
 ## System Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                              TAG Proxy                                  │
 │  ┌─────────┐  ┌──────────┐  ┌─────────┐  ┌─────────┐  ┌─────────────┐   │
 │  │ Handler │──│   Auth   │──│  Proxy  │──│  Cache  │──│  Forwarder  │   │
-│  │ Server  │  │ Validator│  │ Service │  │ Client  │  │   (Signer)  │   │
+│  │ Server  │  │ Validator│  │ Service │  │ Client  │  │             │   │
 │  └────┬────┘  └──────────┘  └────┬────┘  └────┬────┘  └──────┬──────┘   │
 │       │                          │            │               │         │
 │       │                          │     ┌──────┴──────┐        │         │
@@ -54,13 +54,14 @@ Routes requests to appropriate handlers based on HTTP method and path:
 AWS Signature Version 4 authentication and request signing.
 
 - **credentials.go**: Credential store for access/secret key pairs
-- **validator.go**: Validates incoming request signatures
+- **validator.go**: Validates incoming request signatures (signing mode only)
 - **signer.go**: Re-signs requests for upstream Tigris
+- **proxy_signer.go**: Computes proxy headers for transparent proxy mode
 - **parser.go**: Parses Authorization headers and presigned URLs
 
-**Authentication Flow:**
+**Authentication Flow (signing mode):**
 
-```
+```text
 1. Extract access key from Authorization header or query params
 2. Look up secret key from credential store
 3. Compute expected signature using AWS SigV4 algorithm
@@ -68,12 +69,16 @@ AWS Signature Version 4 authentication and request signing.
 5. If valid, re-sign request for upstream with same credentials
 ```
 
+In transparent proxy mode (default), steps 1-4 are skipped. The client's original Authorization header is forwarded as-is, and proxy headers are added so Tigris validates the signature against the original host.
+
 ### Proxy Service (`proxy/`)
 
 Core proxy logic including caching and request coalescing.
 
 - **service.go**: Main request handling, cache logic, broadcast coordination
-- **forwarder.go**: Forwards requests to upstream Tigris
+- **forwarder.go**: `RequestForwarder` interface and shared `baseForwarder` logic
+- **forwarder_transparent.go**: Transparent proxy forwarding (preserves client signatures)
+- **forwarder_signing.go**: Signing mode forwarding (validates and re-signs requests)
 - **broadcast/**: Streaming broadcast pattern for request coalescing
 
 ### Cache Client (`cache/`)
@@ -92,7 +97,7 @@ TAG embeds OCache directly, providing:
 
 **Two-Key Storage Pattern:**
 
-```
+```text
 Object "bucket/key" is stored as:
   - Metadata key: "meta:bucket/key" → JSON with headers, size, etag, etc.
   - Body key: "body:bucket/key" → Raw object bytes
@@ -110,11 +115,36 @@ Prometheus metrics for monitoring and alerting.
 
 - **metrics.go**: Metric definitions and recording functions
 
+## Request Forwarding Modes
+
+TAG supports two request forwarding modes, controlled by the `transparent_proxy` config setting:
+
+### Transparent Proxy (default)
+
+Forwards client requests to Tigris as-is, preserving the original Authorization header. TAG adds four proxy headers so Tigris can validate the client's signature against the original host:
+
+- `X-Tigris-Forwarded-Host` - The original Host header from the client
+- `X-Tigris-Proxy-Access-Key` - TAG's own access key for proxy authentication
+- `X-Tigris-Proxy-Timestamp` - Timestamp for proxy signature
+- `X-Tigris-Proxy-Signature` - HMAC signature proving TAG's identity
+
+No local credential store is needed in this mode. URL encoding (including `RawPath`) is preserved exactly as received from the client.
+
+### Signing Mode
+
+Validates incoming request signatures against a local credential store, then re-signs requests for the upstream Tigris endpoint. This mode is used when TAG needs to perform credential translation (e.g., clients use different credentials than the upstream Tigris account).
+
+In signing mode, proxy headers (`X-Tigris-Proxy-*` and `X-Tigris-Forwarded-Host`) are stripped from client requests to prevent injection of unsigned headers.
+
+### Shared Infrastructure
+
+Both modes share the same `baseForwarder` for HTTP execution, response streaming, and cache interactions. Both use SigV4 signing for background cache operations (e.g., fetching full objects for range request caching).
+
 ## Cluster Architecture
 
 For multi-node deployments, TAG nodes form a distributed cache cluster:
 
-```
+```text
                     ┌─────────────────────────────────────────┐
                     │            Gossip Protocol              │
                     │         (Cluster Discovery)             │
@@ -155,7 +185,7 @@ For multi-node deployments, TAG nodes form a distributed cache cluster:
 
 ### GET Object (Cache Hit)
 
-```
+```text
 Client                 TAG                    Embedded Cache
   │                     │                       │
   │ GET /bucket/key     │                       │
@@ -173,7 +203,7 @@ Client                 TAG                    Embedded Cache
 
 ### GET Object (Cache Miss)
 
-```
+```text
 Client                 TAG                    Embedded Cache         Tigris
   │                     │                       │                    │
   │ GET /bucket/key     │                       │                    │
@@ -196,7 +226,7 @@ Client                 TAG                    Embedded Cache         Tigris
 
 ### GET Object (Cluster Mode - Remote Key)
 
-```
+```text
 Client                 TAG-1                   TAG-2 (owns key)       Tigris
   │                     │                       │                       │
   │ GET /bucket/key     │                       │                       │
@@ -217,7 +247,7 @@ Client                 TAG-1                   TAG-2 (owns key)       Tigris
 
 When multiple clients request the same uncached object simultaneously:
 
-```
+```text
 Client1                TAG                              Tigris
 Client2                 │                                  │
 Client3                 │                                  │
@@ -259,7 +289,7 @@ Client3                 │                                  │
 
 Range requests use a background fetch pattern for optimal ML training workloads:
 
-```
+```text
 Client                 TAG                    Embedded Cache         Tigris
   │                     │                       │                    │
   │ GET /bucket/key     │                       │                    │
@@ -309,7 +339,7 @@ type CachedObjectMeta struct {
 
 ### Cache Keys
 
-```
+```text
 Metadata key:           "meta|bucket|key"
 Body key:               "body|bucket|key"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `AWS_ACCESS_KEY_ID` | S3 access key for authentication | (required) |
+| `AWS_ACCESS_KEY_ID` | S3 access key (must have read-only access for all buckets accessed through TAG) | (required) |
 | `AWS_SECRET_ACCESS_KEY` | S3 secret key for authentication | (required) |
 | `TAG_UPSTREAM_ENDPOINT` | Tigris S3 endpoint URL | `https://t3.storage.dev` |
 | `TAG_MAX_IDLE_CONNS_PER_HOST` | HTTP connection pool size per upstream host | `100` |
@@ -20,6 +20,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_SEED_NODES` | Comma-separated seed nodes for cluster discovery | (none) |
 | `TAG_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 | `TAG_LOG_FORMAT` | Log format: `json` or `console` | `json` |
+| `TAG_TRANSPARENT_PROXY` | Disable transparent proxy mode (`false` or `0`) | `true` |
 | `TAG_PPROF_ENABLED` | Enable pprof endpoints (`true` or `1`) | `false` |
 
 ## Configuration File
@@ -61,6 +62,12 @@ upstream:
   # Higher values improve throughput for cache miss scenarios
   # Default: 100
   max_idle_conns_per_host: 100
+
+  # Enable transparent proxy mode
+  # When true (default), client requests are forwarded as-is with proxy headers.
+  # When false, TAG validates and re-signs requests (signing mode).
+  # Default: true
+  transparent_proxy: true
 
 # Cache configuration (embedded OCache)
 cache:
@@ -151,9 +158,22 @@ Configures the connection to upstream Tigris storage.
 | `endpoint` | string | `"https://t3.storage.dev"` | Tigris S3 endpoint URL |
 | `region` | string | `"auto"` | AWS region for request signing |
 | `max_idle_conns_per_host` | int | `100` | HTTP connection pool size per host |
+| `transparent_proxy` | bool | `true` | Forward client requests as-is with proxy headers |
 
-**Endpoint Options:**
-- `https://t3.storage.dev` - Default Tigris endpoint
+**Endpoint Validation:**
+
+The upstream endpoint must be one of the following allowed hosts:
+- `localhost` (for local development)
+- `*.tigris.dev` (e.g., `fly.storage.tigris.dev`)
+- `*.storage.dev` (e.g., `t3.storage.dev`)
+
+TAG will refuse to start if the endpoint host does not match one of these patterns.
+
+**Transparent Proxy Mode:**
+
+When `transparent_proxy` is `true` (default), TAG forwards client requests to Tigris as-is, preserving the original Authorization header and adding proxy headers so Tigris validates the signature against the original host. No local credential store is needed.
+
+When `transparent_proxy` is `false`, TAG validates incoming request signatures against its local credential store and re-signs requests for the upstream endpoint (signing mode). This is useful when TAG needs to perform credential translation.
 
 ### Cache
 

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -1,6 +1,6 @@
 # S3 API Compatibility
 
-TAG implements all the commonly used bucket and object APIs from the Amazon S3 REST API, acting as a caching proxy between S3 clients and Tigris object storage. All requests are authenticated using AWS Signature Version 4, re-signed, and forwarded to the Tigris upstream endpoint.
+TAG implements all the commonly used bucket and object APIs from the Amazon S3 REST API, acting as a caching proxy between S3 clients and Tigris object storage. By default, TAG operates in transparent proxy mode where client requests are forwarded as-is with proxy headers. In signing mode, requests are validated, re-signed, and forwarded to the Tigris upstream endpoint.
 
 ## Supported Operations
 
@@ -61,9 +61,9 @@ All bucket operations support both `/{bucket}` and `/{bucket}/` path forms for c
 
 TAG supports AWS chunked transfer encoding (streaming SigV4), used by tools like [warp](https://github.com/minio/warp) and many AWS SDKs for large uploads.
 
-When a client sends a PUT with `X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD`, the body is wrapped in an AWS-proprietary chunked format where each chunk includes a signature chained from the request-level seed signature. Because TAG re-signs requests with the upstream Tigris hostname (changing the `Host` header), these per-chunk signatures become invalid.
+In **transparent proxy mode** (default), chunked uploads are forwarded as-is since the original signatures remain valid (the Host header is not changed).
 
-TAG handles this by decoding the chunked body on-the-fly — stripping the chunk framing and signatures — and forwarding the raw payload as `UNSIGNED-PAYLOAD`. The decoded content length is read from the `X-Amz-Decoded-Content-Length` header. This is a streaming operation with no buffering of the full object.
+In **signing mode**, when a client sends a PUT with `X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD`, the body is wrapped in an AWS-proprietary chunked format where each chunk includes a signature chained from the request-level seed signature. Because TAG re-signs requests with the upstream Tigris hostname (changing the `Host` header), these per-chunk signatures become invalid. TAG handles this by decoding the chunked body on-the-fly — stripping the chunk framing and signatures — and forwarding the raw payload as `UNSIGNED-PAYLOAD`. The decoded content length is read from the `X-Amz-Decoded-Content-Length` header. This is a streaming operation with no buffering of the full object.
 
 ## Caching Behavior
 
@@ -90,7 +90,11 @@ TAG uses **path-style** addressing only (`http://host:port/bucket/key`). Virtual
 
 ## Authentication
 
-All requests must be signed with AWS Signature Version 4 (header-based). TAG validates the incoming signature against its credential store, then re-signs the request with the same credentials for the Tigris upstream endpoint.
+All requests must be signed with AWS Signature Version 4 (header-based).
+
+In **transparent proxy mode** (default), TAG forwards the client's original Authorization header as-is and adds proxy headers (`X-Tigris-Forwarded-Host`, etc.) so Tigris validates the signature against the original host. No local credential store is needed.
+
+In **signing mode**, TAG validates the incoming signature against its credential store, then re-signs the request with the same credentials for the Tigris upstream endpoint.
 
 Presigned URL authentication (`X-Amz-Algorithm` query parameter) is supported for request validation.
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1
+	github.com/aws/smithy-go v1.24.0
 	github.com/goccy/go-json v0.10.5
 	github.com/gorilla/mux v1.8.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20250916175020-ebf3e50324d3
@@ -28,7 +29,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/handlers/validate_content_length_test.go
+++ b/handlers/validate_content_length_test.go
@@ -37,10 +37,10 @@ func TestValidateContentLength_Regular(t *testing.T) {
 
 func TestValidateContentLength_Chunked(t *testing.T) {
 	tests := []struct {
-		name         string
-		bodyHash     string // X-Amz-Content-Sha256 value
-		decodedLen   string // X-Amz-Decoded-Content-Length value; empty = omit header
-		wantValid    bool
+		name       string
+		bodyHash   string // X-Amz-Content-Sha256 value
+		decodedLen string // X-Amz-Decoded-Content-Length value; empty = omit header
+		wantValid  bool
 	}{
 		{name: "valid length", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "1048576", wantValid: true},
 		{name: "zero byte upload", bodyHash: "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", decodedLen: "0", wantValid: true},

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -14,6 +14,29 @@ import (
 	"github.com/tigrisdata/tag/metrics"
 )
 
+// RequestForwarder is the interface for forwarding requests to the upstream Tigris server.
+// Two implementations exist: signingForwarder (validate + re-sign) and
+// transparentForwarder (clone headers + proxy headers).
+type RequestForwarder interface {
+	// Forward forwards a request to Tigris and writes the response to the client.
+	Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+
+	// ForwardWithCapture forwards request and captures response for caching.
+	ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error)
+
+	// ValidateAndGetCredentials validates the request signature and returns credentials.
+	ValidateAndGetCredentials(r *http.Request) (accessKey, secretKey string, err error)
+
+	// DoRequestWithCreds executes a request with pre-validated credentials.
+	// Returns the raw response for streaming. Caller is responsible for closing the response body.
+	DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error)
+
+	// DoFullObjectRequest executes a full object GET request (no Range header).
+	// Used for background cache population after a Range request cache miss.
+	// Caller is responsible for closing the response body.
+	DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error)
+}
+
 // AuthErrorCode represents the type of authentication error.
 type AuthErrorCode int
 
@@ -88,24 +111,27 @@ func IsAuthError(err error) (*AuthError, bool) {
 	return nil, false
 }
 
-// Forwarder handles forwarding requests to the upstream Tigris server.
-type Forwarder struct {
-	credStore  *auth.CredentialStore
-	validator  *auth.RequestValidator
-	signer     *auth.RequestSigner
+// Compile-time interface satisfaction checks.
+var (
+	_ RequestForwarder = (*signingForwarder)(nil)
+	_ RequestForwarder = (*transparentForwarder)(nil)
+)
+
+// baseForwarder contains shared HTTP execution logic used by both
+// signingForwarder and transparentForwarder.
+type baseForwarder struct {
+	signer     *auth.RequestSigner // Both modes need this for DoFullObjectRequest
 	httpClient *http.Client
 }
 
-// NewForwarder creates a new forwarder with configurable HTTP connection pool.
-func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string, maxIdleConnsPerHost int) *Forwarder {
+// newBaseForwarder creates the shared base with HTTP client and signer.
+func newBaseForwarder(tigrisEndpoint, region string, maxIdleConnsPerHost int) baseForwarder {
 	if maxIdleConnsPerHost <= 0 {
 		maxIdleConnsPerHost = 100 // Default
 	}
 
-	return &Forwarder{
-		credStore: credStore,
-		validator: auth.NewRequestValidator(credStore),
-		signer:    auth.NewRequestSigner(tigrisEndpoint, region),
+	return baseForwarder{
+		signer: auth.NewRequestSigner(tigrisEndpoint, region),
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				MaxIdleConns:        maxIdleConnsPerHost,
@@ -114,6 +140,140 @@ func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string
 			},
 			Timeout: 5 * time.Minute,
 		},
+	}
+}
+
+// executeAndStream executes the request and streams the response to the client.
+func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64) error {
+	if inContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(inContentLength))
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(fwdReq.Method, time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("method", fwdReq.Method).Str("path", fwdReq.URL.Path).Msg("Failed to forward request")
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Stream response back to client
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	n, copyErr := io.Copy(w, resp.Body)
+	if copyErr != nil {
+		log.Warn().Err(copyErr).Msg("Failed to copy response body to client")
+	}
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+
+	return nil
+}
+
+// executeAndCapture executes the request, streams to client, and captures the response.
+func (b *baseForwarder) executeAndCapture(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64) (*ResponseCapture, error) {
+	if inContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(inContentLength))
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(fwdReq.Method, time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("method", fwdReq.Method).Str("path", fwdReq.URL.Path).Msg("Failed to forward request")
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Capture response
+	capture := &ResponseCapture{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header.Clone(),
+	}
+
+	// Copy headers to response writer
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+
+	// Capture body while streaming to client
+	var readErr error
+	capture.Body, readErr = io.ReadAll(io.TeeReader(resp.Body, w))
+	if readErr != nil {
+		log.Warn().Err(readErr).Msg("Failed to fully capture response body")
+		capture.Complete = false
+	} else {
+		capture.Complete = true
+	}
+
+	// Track bytes out from response body
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(len(capture.Body)))
+
+	return capture, nil
+}
+
+// executeRequest executes the request and returns the raw response.
+// Caller is responsible for closing the response body.
+func (b *baseForwarder) executeRequest(fwdReq *http.Request, inContentLength int64) (*http.Response, error) {
+	if inContentLength > 0 {
+		metrics.BytesTransferred.WithLabelValues("in").Add(float64(inContentLength))
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(fwdReq.Method, time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("method", fwdReq.Method).Str("path", fwdReq.URL.Path).Msg("Failed to forward request")
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// DoFullObjectRequest executes a full object GET request (no Range header).
+// Used for background cache population after a Range request cache miss.
+// Caller is responsible for closing the response body.
+//
+// This always uses standard SigV4 signing because it is a synthetic request
+// initiated by TAG itself, not a forwarded client request. TAG's credentials
+// (from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY) are valid Tigris credentials
+// that can sign requests directly.
+func (b *baseForwarder) DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+	path := "/" + bucket + "/" + key
+
+	// Create request without Range header - just a simple GET for the full object
+	fwdReq, err := b.signer.SignRequest(ctx, "GET", path, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest("GET", time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background fetch failed")
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// NewForwarder creates a new forwarder with configurable HTTP connection pool.
+// If proxySigner is non-nil, transparent proxy mode is enabled.
+func NewForwarder(credStore *auth.CredentialStore, tigrisEndpoint, region string, maxIdleConnsPerHost int, proxySigner *auth.ProxySigner) RequestForwarder {
+	base := newBaseForwarder(tigrisEndpoint, region, maxIdleConnsPerHost)
+
+	if proxySigner != nil {
+		return &transparentForwarder{
+			baseForwarder:    base,
+			proxySigner:      proxySigner,
+			upstreamEndpoint: strings.TrimSuffix(tigrisEndpoint, "/"),
+		}
+	}
+
+	return &signingForwarder{
+		baseForwarder: base,
+		credStore:     credStore,
+		validator:     auth.NewRequestValidator(credStore),
 	}
 }
 
@@ -159,143 +319,6 @@ func stripAWSChunkedEncoding(req *http.Request) {
 	}
 }
 
-// Forward forwards a request to Tigris and writes the response to the client.
-// Uses zero-copy streaming - the X-Amz-Content-Sha256 header is required (all AWS SDKs set this).
-// If the request uses AWS chunked transfer encoding (streaming SigV4), the body
-// is decoded on-the-fly and forwarded as UNSIGNED-PAYLOAD.
-func (f *Forwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
-
-	// Validate incoming request signature
-	accessKey, err := f.validator.ValidateRequest(r)
-	if err != nil {
-		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
-		return mapAuthError(err)
-	}
-
-	// Look up secret key from credential store
-	secretKey, err := f.credStore.GetSecretKey(accessKey)
-	if err != nil {
-		return mapAuthError(err)
-	}
-
-	// Build the path with query string
-	path := r.URL.Path
-	if r.URL.RawQuery != "" {
-		path = path + "?" + r.URL.RawQuery
-	}
-
-	// Create signed request (passes body hash, streams body directly)
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
-	if err != nil {
-		return err
-	}
-	prepareForwardedRequest(fwdReq, contentLength, chunked)
-
-	// Track bytes in from request body
-	if contentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
-	}
-
-	// Forward to Tigris
-	upstreamStart := time.Now()
-	resp, err := f.httpClient.Do(fwdReq)
-	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
-	if err != nil {
-		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Stream response back to client
-	copyHeaders(w.Header(), resp.Header)
-	w.WriteHeader(resp.StatusCode)
-	n, copyErr := io.Copy(w, resp.Body)
-	if copyErr != nil {
-		log.Warn().Err(copyErr).Msg("Failed to copy response body to client")
-	}
-	// Track bytes out from response body
-	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
-
-	return nil
-}
-
-// ForwardWithCapture forwards request and captures response for caching.
-// Uses zero-copy streaming for the request body (X-Amz-Content-Sha256 header is required).
-// The response body is captured for caching while streaming to the client.
-// If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
-func (f *Forwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
-	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
-
-	// Validate incoming request signature
-	accessKey, err := f.validator.ValidateRequest(r)
-	if err != nil {
-		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
-		return nil, mapAuthError(err)
-	}
-
-	// Look up secret key
-	secretKey, err := f.credStore.GetSecretKey(accessKey)
-	if err != nil {
-		return nil, mapAuthError(err)
-	}
-
-	// Build the path with query string
-	path := r.URL.Path
-	if r.URL.RawQuery != "" {
-		path = path + "?" + r.URL.RawQuery
-	}
-
-	// Create signed request (passes body hash, streams body directly)
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
-	if err != nil {
-		return nil, err
-	}
-	prepareForwardedRequest(fwdReq, contentLength, chunked)
-
-	// Track bytes in from request body
-	if contentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
-	}
-
-	// Forward to Tigris
-	upstreamStart := time.Now()
-	resp, err := f.httpClient.Do(fwdReq)
-	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
-	if err != nil {
-		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Capture response
-	capture := &ResponseCapture{
-		StatusCode: resp.StatusCode,
-		Headers:    resp.Header.Clone(),
-	}
-
-	// Copy headers to response writer
-	copyHeaders(w.Header(), resp.Header)
-	w.WriteHeader(resp.StatusCode)
-
-	// Capture body while streaming to client
-	var readErr error
-	capture.Body, readErr = io.ReadAll(io.TeeReader(resp.Body, w))
-	if readErr != nil {
-		log.Warn().Err(readErr).Msg("Failed to fully capture response body")
-		capture.Complete = false
-	} else {
-		capture.Complete = true
-	}
-
-	// Track bytes out from response body
-	metrics.BytesTransferred.WithLabelValues("out").Add(float64(len(capture.Body)))
-
-	return capture, nil
-}
-
 // ResponseCapture holds captured response data.
 type ResponseCapture struct {
 	StatusCode int
@@ -322,78 +345,4 @@ func copyHeaders(dst, src http.Header) {
 			dst[k] = v
 		}
 	}
-}
-
-// ValidateAndGetCredentials validates the request signature and returns credentials.
-// This is used to validate credentials before joining a broadcast.
-func (f *Forwarder) ValidateAndGetCredentials(r *http.Request) (accessKey, secretKey string, err error) {
-	accessKey, err = f.validator.ValidateRequest(r)
-	if err != nil {
-		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
-		return "", "", mapAuthError(err)
-	}
-
-	secretKey, err = f.credStore.GetSecretKey(accessKey)
-	if err != nil {
-		return "", "", mapAuthError(err)
-	}
-
-	return accessKey, secretKey, nil
-}
-
-// DoRequestWithCreds executes a request with pre-validated credentials.
-// Returns the raw response for streaming. Caller is responsible for closing the response body.
-// If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
-func (f *Forwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
-	// Decode AWS chunked encoding if present, otherwise pass through unchanged
-	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
-
-	path := r.URL.Path
-	if r.URL.RawQuery != "" {
-		path = path + "?" + r.URL.RawQuery
-	}
-
-	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
-	if err != nil {
-		return nil, err
-	}
-	prepareForwardedRequest(fwdReq, contentLength, chunked)
-
-	// Track bytes in from request body
-	if contentLength > 0 {
-		metrics.BytesTransferred.WithLabelValues("in").Add(float64(contentLength))
-	}
-
-	upstreamStart := time.Now()
-	resp, err := f.httpClient.Do(fwdReq)
-	metrics.RecordUpstreamRequest(r.Method, time.Since(upstreamStart).Seconds(), err)
-	if err != nil {
-		log.Error().Err(err).Str("method", r.Method).Str("path", path).Msg("Failed to forward request")
-		return nil, err
-	}
-
-	return resp, nil
-}
-
-// DoFullObjectRequest executes a full object GET request (no Range header).
-// Used for background cache population after a Range request cache miss.
-// Caller is responsible for closing the response body.
-func (f *Forwarder) DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
-	path := "/" + bucket + "/" + key
-
-	// Create request without Range header - just a simple GET for the full object
-	fwdReq, err := f.signer.SignRequest(ctx, "GET", path, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	upstreamStart := time.Now()
-	resp, err := f.httpClient.Do(fwdReq)
-	metrics.RecordUpstreamRequest("GET", time.Since(upstreamStart).Seconds(), err)
-	if err != nil {
-		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background fetch failed")
-		return nil, err
-	}
-
-	return resp, nil
 }

--- a/proxy/forwarder_signing.go
+++ b/proxy/forwarder_signing.go
@@ -1,0 +1,131 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/auth"
+)
+
+// signingForwarder validates incoming request signatures and re-signs requests
+// before forwarding to upstream Tigris. This is the default mode where TAG
+// acts as a credential-translating proxy.
+//
+// DoFullObjectRequest is inherited from baseForwarder (always uses SigV4 signing).
+type signingForwarder struct {
+	baseForwarder
+	credStore *auth.CredentialStore
+	validator *auth.RequestValidator
+}
+
+// Forward forwards a request to Tigris and writes the response to the client.
+// Validates the incoming request signature, re-signs with upstream credentials,
+// and streams the response back. If the request uses AWS chunked transfer encoding
+// (streaming SigV4), the body is decoded on-the-fly and forwarded as UNSIGNED-PAYLOAD.
+func (f *signingForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
+
+	// Validate incoming request signature
+	accessKey, err := f.validator.ValidateRequest(r)
+	if err != nil {
+		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
+		return mapAuthError(err)
+	}
+
+	// Look up secret key from credential store
+	secretKey, err := f.credStore.GetSecretKey(accessKey)
+	if err != nil {
+		return mapAuthError(err)
+	}
+
+	// Build the path with query string
+	path := r.URL.Path
+	if r.URL.RawQuery != "" {
+		path = path + "?" + r.URL.RawQuery
+	}
+
+	// Create signed request (passes body hash, streams body directly)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
+	if err != nil {
+		return err
+	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
+
+	return f.executeAndStream(w, fwdReq, contentLength)
+}
+
+// ForwardWithCapture forwards request and captures response for caching.
+// Validates and re-signs like Forward, but also captures the response body
+// for caching while streaming to the client.
+func (f *signingForwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
+
+	// Validate incoming request signature
+	accessKey, err := f.validator.ValidateRequest(r)
+	if err != nil {
+		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
+		return nil, mapAuthError(err)
+	}
+
+	// Look up secret key
+	secretKey, err := f.credStore.GetSecretKey(accessKey)
+	if err != nil {
+		return nil, mapAuthError(err)
+	}
+
+	// Build the path with query string
+	path := r.URL.Path
+	if r.URL.RawQuery != "" {
+		path = path + "?" + r.URL.RawQuery
+	}
+
+	// Create signed request (passes body hash, streams body directly)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
+	if err != nil {
+		return nil, err
+	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
+
+	return f.executeAndCapture(w, fwdReq, contentLength)
+}
+
+// ValidateAndGetCredentials validates the request signature and returns credentials.
+// This is used to validate credentials before joining a broadcast.
+func (f *signingForwarder) ValidateAndGetCredentials(r *http.Request) (accessKey, secretKey string, err error) {
+	accessKey, err = f.validator.ValidateRequest(r)
+	if err != nil {
+		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
+		return "", "", mapAuthError(err)
+	}
+
+	secretKey, err = f.credStore.GetSecretKey(accessKey)
+	if err != nil {
+		return "", "", mapAuthError(err)
+	}
+
+	return accessKey, secretKey, nil
+}
+
+// DoRequestWithCreds executes a request with pre-validated credentials.
+// Returns the raw response for streaming. Caller is responsible for closing the response body.
+// If the request uses AWS chunked transfer encoding, the body is decoded on-the-fly.
+func (f *signingForwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
+	// Decode AWS chunked encoding if present, otherwise pass through unchanged
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
+
+	path := r.URL.Path
+	if r.URL.RawQuery != "" {
+		path = path + "?" + r.URL.RawQuery
+	}
+
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, body, bodyHash, accessKey, secretKey, r.Header)
+	if err != nil {
+		return nil, err
+	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
+
+	return f.executeRequest(fwdReq, contentLength)
+}

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -1,0 +1,100 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/tigrisdata/tag/auth"
+)
+
+// transparentForwarder forwards client requests as-is (preserving their
+// Authorization header) and adds proxy headers so Tigris validates the
+// signature against the original host. Used when TAG acts as a transparent proxy.
+//
+// DoFullObjectRequest is inherited from baseForwarder (always uses SigV4 signing).
+type transparentForwarder struct {
+	baseForwarder
+	proxySigner      *auth.ProxySigner
+	upstreamEndpoint string
+}
+
+// buildTransparentRequest creates a forwarded request for transparent proxy mode.
+// Copies ALL headers from the original request (including Authorization, X-Amz-Date, etc.)
+// and adds the 4 proxy headers. The body is streamed as-is without decoding.
+func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *http.Request) (*http.Request, error) {
+	baseURL, err := url.Parse(f.upstreamEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
+	}
+
+	baseURL.Path = r.URL.Path
+	baseURL.RawQuery = r.URL.RawQuery
+
+	fwdReq, err := http.NewRequestWithContext(ctx, r.Method, baseURL.String(), r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Clone ALL headers from the original request (preserving Authorization, X-Amz-Date, etc.)
+	// Clone avoids mutating the original request headers when adding proxy headers below.
+	fwdReq.Header = r.Header.Clone()
+
+	// Preserve Content-Length from original request
+	fwdReq.ContentLength = r.ContentLength
+
+	// Capture original Host before it gets overwritten by the upstream URL
+	forwardedHost := r.Host
+
+	// Compute and set the 4 proxy headers
+	proxyHeaders := f.proxySigner.ComputeProxyHeaders(forwardedHost, r.Method, r.URL.Path)
+	fwdReq.Header.Set("X-Tigris-Forwarded-Host", proxyHeaders.ForwardedHost)
+	fwdReq.Header.Set("X-Tigris-Proxy-Access-Key", proxyHeaders.ProxyAccessKey)
+	fwdReq.Header.Set("X-Tigris-Proxy-Timestamp", proxyHeaders.ProxyTimestamp)
+	fwdReq.Header.Set("X-Tigris-Proxy-Signature", proxyHeaders.ProxySignature)
+
+	return fwdReq, nil
+}
+
+// Forward forwards a request to Tigris in transparent proxy mode.
+// The client's original signed request is forwarded as-is with proxy headers added.
+func (f *transparentForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	fwdReq, err := f.buildTransparentRequest(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	return f.executeAndStream(w, fwdReq, r.ContentLength)
+}
+
+// ForwardWithCapture forwards request in transparent proxy mode and captures the response.
+func (f *transparentForwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+	fwdReq, err := f.buildTransparentRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.executeAndCapture(w, fwdReq, r.ContentLength)
+}
+
+// ValidateAndGetCredentials returns proxy credentials for background operations.
+// In transparent mode, there is no client signature validation - the proxy credentials
+// (TAG's own Tigris credentials) are returned for use by DoFullObjectRequest.
+func (f *transparentForwarder) ValidateAndGetCredentials(r *http.Request) (accessKey, secretKey string, err error) {
+	return f.proxySigner.AccessKey(), f.proxySigner.SecretKey(), nil
+}
+
+// DoRequestWithCreds executes a request with transparent proxy headers.
+// Returns the raw response for streaming. Caller is responsible for closing the response body.
+// accessKey and secretKey are unused in transparent mode (the client's original
+// Authorization header is preserved as-is), but are accepted to satisfy the
+// RequestForwarder interface.
+func (f *transparentForwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
+	fwdReq, err := f.buildTransparentRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.executeRequest(fwdReq, r.ContentLength)
+}

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -30,6 +30,7 @@ func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *h
 	}
 
 	baseURL.Path = r.URL.Path
+	baseURL.RawPath = r.URL.RawPath
 	baseURL.RawQuery = r.URL.RawQuery
 
 	fwdReq, err := http.NewRequestWithContext(ctx, r.Method, baseURL.String(), r.Body)

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -42,6 +42,20 @@ func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *h
 	// Clone avoids mutating the original request headers when adding proxy headers below.
 	fwdReq.Header = r.Header.Clone()
 
+	// Ensure X-Amz-Date is present for Tigris's proxy validation path.
+	// Some SDK versions (botocore 1.42+) sign with "date" in SignedHeaders
+	// and don't set X-Amz-Date at all. Tigris's proxy code path requires
+	// X-Amz-Date, so synthesize it from Date when missing.
+	// We never remove Date — it may be in SignedHeaders and required for
+	// signature verification.
+	if fwdReq.Header.Get("X-Amz-Date") == "" {
+		if dateStr := fwdReq.Header.Get("Date"); dateStr != "" {
+			if t, err := auth.ParseHTTPDate(dateStr); err == nil {
+				fwdReq.Header.Set("X-Amz-Date", t.UTC().Format(auth.TimeFormat))
+			}
+		}
+	}
+
 	// Preserve Content-Length from original request
 	fwdReq.ContentLength = r.ContentLength
 

--- a/proxy/forwarder_transparent_test.go
+++ b/proxy/forwarder_transparent_test.go
@@ -1,0 +1,98 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/tigrisdata/tag/auth"
+)
+
+func TestBuildTransparentRequest_DateHandling(t *testing.T) {
+	ps := auth.NewProxySigner("test-access-key", "test-secret-key")
+	fwd := &transparentForwarder{
+		baseForwarder:    newBaseForwarder("https://upstream.example.com", "us-east-1", 10),
+		proxySigner:      ps,
+		upstreamEndpoint: "https://upstream.example.com",
+	}
+
+	tests := []struct {
+		name          string
+		dateHeader    string
+		amzDateHeader string
+		wantDate      string // expected Date header ("" means absent)
+		wantAmzDate   bool   // whether X-Amz-Date should be present
+	}{
+		{
+			name:          "both Date and X-Amz-Date present",
+			dateHeader:    "Wed, 11 Feb 2026 05:55:14 GMT",
+			amzDateHeader: "20260211T055514Z",
+			wantDate:      "Wed, 11 Feb 2026 05:55:14 GMT",
+			wantAmzDate:   true,
+		},
+		{
+			name:          "only Date present - synthesize X-Amz-Date",
+			dateHeader:    "Wed, 11 Feb 2026 05:55:14 -0000",
+			amzDateHeader: "",
+			wantDate:      "Wed, 11 Feb 2026 05:55:14 -0000",
+			wantAmzDate:   true,
+		},
+		{
+			name:          "only X-Amz-Date present",
+			dateHeader:    "",
+			amzDateHeader: "20260211T055514Z",
+			wantDate:      "",
+			wantAmzDate:   true,
+		},
+		{
+			name:          "neither present",
+			dateHeader:    "",
+			amzDateHeader: "",
+			wantDate:      "",
+			wantAmzDate:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", nil)
+			if tt.dateHeader != "" {
+				req.Header.Set("Date", tt.dateHeader)
+			}
+			if tt.amzDateHeader != "" {
+				req.Header.Set("X-Amz-Date", tt.amzDateHeader)
+			}
+
+			fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+			if err != nil {
+				t.Fatalf("buildTransparentRequest() error = %v", err)
+			}
+
+			// Check Date header preserved
+			gotDate := fwdReq.Header.Get("Date")
+			if gotDate != tt.wantDate {
+				t.Errorf("Date header = %q, want %q", gotDate, tt.wantDate)
+			}
+
+			// Check X-Amz-Date header
+			gotAmzDate := fwdReq.Header.Get("X-Amz-Date")
+			if tt.wantAmzDate && gotAmzDate == "" {
+				t.Error("X-Amz-Date header is missing, want present")
+			}
+			if !tt.wantAmzDate && gotAmzDate != "" {
+				t.Errorf("X-Amz-Date header = %q, want absent", gotAmzDate)
+			}
+
+			// When X-Amz-Date was explicitly set, it should be preserved as-is
+			if tt.amzDateHeader != "" && gotAmzDate != tt.amzDateHeader {
+				t.Errorf("X-Amz-Date header = %q, want %q (should be preserved)", gotAmzDate, tt.amzDateHeader)
+			}
+
+			// When synthesized from Date, verify ISO 8601 format
+			if tt.amzDateHeader == "" && tt.dateHeader != "" && gotAmzDate != "" {
+				if len(gotAmzDate) != 16 || gotAmzDate[8] != 'T' || gotAmzDate[15] != 'Z' {
+					t.Errorf("Synthesized X-Amz-Date = %q, want ISO 8601 format (20060102T150405Z)", gotAmzDate)
+				}
+			}
+		})
+	}
+}

--- a/proxy/get_object_test.go
+++ b/proxy/get_object_test.go
@@ -17,7 +17,7 @@ func TestWriteChunksToResponse_ErrorBeforeData(t *testing.T) {
 	listener := b.Subscribe()
 	b.SetHeaders(http.StatusOK, http.Header{
 		"Content-Length": []string{"3"},
-		"Content-Type":  []string{"application/octet-stream"},
+		"Content-Type":   []string{"application/octet-stream"},
 	})
 
 	// Complete with error before any data chunks
@@ -61,7 +61,7 @@ func TestWriteChunksToResponse_NormalDataFlow(t *testing.T) {
 	listener := b.Subscribe()
 	b.SetHeaders(http.StatusOK, http.Header{
 		"Content-Length": []string{"6"},
-		"Content-Type":  []string{"text/plain"},
+		"Content-Type":   []string{"text/plain"},
 	})
 
 	go func() {
@@ -98,7 +98,7 @@ func TestWriteChunksToResponse_ZeroByteResponse(t *testing.T) {
 	listener := b.Subscribe()
 	b.SetHeaders(http.StatusOK, http.Header{
 		"Content-Length": []string{"0"},
-		"Content-Type":  []string{"application/octet-stream"},
+		"Content-Type":   []string{"application/octet-stream"},
 	})
 
 	go func() {
@@ -129,7 +129,7 @@ func TestWriteChunksToResponse_ErrorAfterPartialData(t *testing.T) {
 	listener := b.Subscribe()
 	b.SetHeaders(http.StatusOK, http.Header{
 		"Content-Length": []string{"6"},
-		"Content-Type":  []string{"text/plain"},
+		"Content-Type":   []string{"text/plain"},
 	})
 
 	go func() {

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -28,7 +28,7 @@ const (
 
 // Service provides the core caching proxy logic.
 type Service struct {
-	forwarder              *Forwarder
+	forwarder              RequestForwarder
 	cache                  *cache.Cache
 	config                 *config.Config
 	cacheSemaphore         chan struct{}      // Limits concurrent cache writes
@@ -37,7 +37,7 @@ type Service struct {
 }
 
 // NewService creates a new proxy service.
-func NewService(forwarder *Forwarder, cache *cache.Cache, cfg *config.Config) *Service {
+func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Config) *Service {
 	channelBuf := cfg.Broadcast.ChannelBuffer
 	if channelBuf <= 0 {
 		channelBuf = broadcast.DefaultChannelBuffer

--- a/tests/integration/sdk/go_sdk_test.go
+++ b/tests/integration/sdk/go_sdk_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -1235,10 +1234,3 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 	t.Logf("User metadata caching verified")
 }
 
-// ============================================================================
-// Helper function for generating test bucket names (used by individual tests)
-// ============================================================================
-
-func uniqueKey(prefix string) string {
-	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
-}

--- a/tests/integration/sdk/testutil.go
+++ b/tests/integration/sdk/testutil.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultTAGEndpoint is the default TAG endpoint when running via make s3-test-local.
-	DefaultTAGEndpoint = "http://127-0-0-1.sslip.io:8080"
+	DefaultTAGEndpoint = "http://localhost:8080"
 	// DefaultRegion is the default AWS region for signing.
 	DefaultRegion = "auto"
 	// BucketPrefixBase is the base prefix for test buckets.

--- a/tests/integration/sdk/testutil.go
+++ b/tests/integration/sdk/testutil.go
@@ -14,12 +14,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 const (
 	// DefaultTAGEndpoint is the default TAG endpoint when running via make s3-test-local.
-	DefaultTAGEndpoint = "http://localhost:8080"
+	DefaultTAGEndpoint = "http://127-0-0-1.sslip.io"
 	// DefaultRegion is the default AWS region for signing.
 	DefaultRegion = "auto"
 	// BucketPrefixBase is the base prefix for test buckets.
@@ -174,51 +174,12 @@ func (e *TestEnvironment) DeleteTestObject(bucket, key string) error {
 	return err
 }
 
-// deleteAllObjects deletes all objects in a bucket.
-func (e *TestEnvironment) deleteAllObjects(bucket string) error {
-	ctx := context.Background()
-
-	// List all objects
-	paginator := s3.NewListObjectsV2Paginator(e.S3Client, &s3.ListObjectsV2Input{
-		Bucket: aws.String(bucket),
-	})
-
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list objects in %s: %w", bucket, err)
-		}
-
-		if len(page.Contents) == 0 {
-			continue
-		}
-
-		// Build delete request
-		objects := make([]types.ObjectIdentifier, len(page.Contents))
-		for i, obj := range page.Contents {
-			objects[i] = types.ObjectIdentifier{Key: obj.Key}
-		}
-
-		// Delete objects
-		_, err = e.S3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-			Bucket: aws.String(bucket),
-			Delete: &types.Delete{
-				Objects: objects,
-				Quiet:   aws.Bool(true),
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to delete objects in %s: %w", bucket, err)
-		}
-	}
-
-	return nil
-}
-
-// deleteBucket deletes a bucket (must be empty).
+// deleteBucket force-deletes a bucket and all its objects using Tigris-Force-Delete header.
 func (e *TestEnvironment) deleteBucket(bucket string) error {
 	_, err := e.S3Client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
 		Bucket: aws.String(bucket),
+	}, func(o *s3.Options) {
+		o.APIOptions = append(o.APIOptions, smithyhttp.AddHeaderValue("Tigris-Force-Delete", "true"))
 	})
 	return err
 }
@@ -232,13 +193,6 @@ func (e *TestEnvironment) Cleanup() error {
 
 	var errs []error
 	for _, bucket := range buckets {
-		// Delete all objects first
-		if err := e.deleteAllObjects(bucket); err != nil {
-			errs = append(errs, fmt.Errorf("failed to empty bucket %s: %w", bucket, err))
-			continue
-		}
-
-		// Delete bucket
 		if err := e.deleteBucket(bucket); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete bucket %s: %w", bucket, err))
 		}

--- a/tests/integration/sdk/testutil.go
+++ b/tests/integration/sdk/testutil.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultTAGEndpoint is the default TAG endpoint when running via make s3-test-local.
-	DefaultTAGEndpoint = "http://127-0-0-1.sslip.io"
+	DefaultTAGEndpoint = "http://127-0-0-1.sslip.io:8080"
 	// DefaultRegion is the default AWS region for signing.
 	DefaultRegion = "auto"
 	// BucketPrefixBase is the base prefix for test buckets.

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -312,7 +312,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	testCache := cache.NewCacheWithClient(sharedEmbeddedCache, &cfg.Cache)
 
 	// Create forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost, nil)
 
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)
@@ -371,7 +371,7 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	testCache := cache.NewDisabledCache()
 
 	// Create forwarder
-	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost)
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost, nil)
 
 	// Create service
 	service := proxy.NewService(forwarder, testCache, cfg)

--- a/tests/s3compat/run-tests.sh
+++ b/tests/s3compat/run-tests.sh
@@ -242,6 +242,9 @@ test_objects=(
     "test_object_copy_16m"
     # Special prefix handling
     "test_bucket_list_special_prefix"
+    # Chunked encoding tests
+    # "test_object_write_with_chunked_transfer_encoding"  # Requires HTTP Transfer-Encoding: chunked (Ceph RGW-specific, not supported by S3/Tigris)
+    # "test_object_content_encoding_aws_chunked"  # Tigris stores aws-chunked in Content-Encoding as-is; stripping it in TAG breaks signatures in transparent mode
 )
 
 # Bucket operations tests


### PR DESCRIPTION
## Summary

Implement transparent proxy support with two forwarder modes: signing (validate + re-sign) and transparent (preserve client auth + proxy headers). Refactor shared HTTP logic into baseForwarder to eliminate code duplication.

- Add ProxySigner to compute X-Tigris-* proxy headers for transparent mode
- Split Forwarder into RequestForwarder interface with signingForwarder and transparentForwarder implementations
- Extract shared HTTP execution (stream, capture, request) into baseForwarder helpers
- Liberalize header forwarding to support all x-amz-*, tigris-*, and x-tigris-* prefixes
- Add Tigris-Force-Delete header support for SDK test cleanup
- Change default HTTP port from 8080 to 80 for proper Host header format in transparent mode

## Test plan

- Unit tests pass (auth, config, proxy packages)
- Integration tests use 127-0-0-1.sslip.io for transparent proxy compatibility
- Compile-time interface satisfaction checks verify RequestForwarder implementations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core request forwarding and authentication behavior (default mode switch + new proxy-header signing), so regressions could break SigV4 validation or inadvertently forward/strip security-sensitive headers; endpoint allowlisting also risks unexpected startup failures in existing deployments.
> 
> **Overview**
> Adds **transparent proxy mode (default)** that forwards the client’s original SigV4 request *as-is* (including `Authorization`, `RawPath`, and most headers) and appends `X-Tigris-Forwarded-Host` / `X-Tigris-Proxy-*` headers computed by a new `auth.ProxySigner`; when clients omit `X-Amz-Date`, it is synthesized from `Date` for upstream validation.
> 
> Refactors request forwarding by introducing a `RequestForwarder` interface, splitting the old forwarder into `signingForwarder` (validate + re-sign) and `transparentForwarder`, and extracting shared HTTP execution/capture logic into `baseForwarder`; `Service` now depends on the interface and `cmd/tag` wires the mode based on `upstream.transparent_proxy`/`TAG_TRANSPARENT_PROXY`.
> 
> Hardens and broadens request/header handling: `shouldCopyHeader` now allows all `x-amz-*` plus `tigris-*`/`x-tigris-*` headers while explicitly blocking proxy-header injection in signing mode, adds upstream endpoint allowlist validation (`localhost`, `*.tigris.dev`, `*.storage.dev`), and updates tests/docs plus integration cleanup to use `Tigris-Force-Delete` (via smithy HTTP header injection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a644ddbc17bc2f979be42e79c8f6e37c8877754d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->