### PR TITLE
docs: add security.md and rule files for auth patterns

### DIFF
--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -24,3 +24,7 @@ Avoid explicit batching delays:
 - Explicit batching (waiting for timeout or N items) adds latency
 - Prefer implicit pipelining via HTTP/2 layer
 - Let the transport handle batching naturally
+
+## Prefer Standard Cache Libraries
+
+Use `hashicorp/golang-lru/v2/expirable` for bounded, TTL-based caches. Avoid custom map implementations with manual O(N) cleanup loops. The library handles LRU eviction and TTL expiration efficiently.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,41 @@
+# Testing Patterns & Best Practices
+
+## Test Environment Factories
+
+Use dedicated `TestEnvironment` factories for different modes:
+- `NewTestEnvironmentWithTransparentAuth`: Sets up `ProxySigner`, `DerivedKeyStore`, `RequestValidator`, `KeyUnwrapper`, `AuthzCache`
+
+## Mocking Upstream
+
+Use `httptest.NewServer` with custom `http.HandlerFunc` to simulate Tigris responses:
+- e.g., `newSigningKeysUpstreamHandler` to inject `X-Tigris-Proxy-Signing-Keys`
+
+## Header Inspection
+
+Use raw `http.NewRequest` / `http.Client.Do` for verifying proxy behavior with specific HTTP headers (like `X-Cache` or internal headers). AWS SDK clients abstract these details.
+
+## Synchronization
+
+Never use `time.Sleep` for synchronization in concurrent tests. Use:
+- `sync.WaitGroup`
+- Channels
+- `time.After` with polling
+
+## Test Organization
+
+Related S3 compatibility tests grouped under `tests/s3compat/`:
+- `tests/s3compat/python/` — Python s3-tests (ceph)
+- `tests/s3compat/sdk/` — Go SDK tests
+
+## Integration Test Coverage Checklist
+
+Cover these scenarios for transparent proxy:
+- Happy path: key learning, local validation, cache hit
+- Auth failures: unknown key, unauthenticated request → correct forwarding/rejection
+- AuthZ revocation (Tigris 403 → cache entry removed)
+- Internal header stripping (even on errors or cache hits)
+- Multi-bucket auth enforcement (access to bucket A ≠ access to bucket B)
+
+## Cache Libraries
+
+Prefer `hashicorp/golang-lru/v2/expirable` for bounded TTL caches over custom map implementations with manual cleanup logic.

--- a/.claude/rules/transparent-proxy.md
+++ b/.claude/rules/transparent-proxy.md
@@ -1,0 +1,57 @@
+# Transparent Proxy Architecture & Auth Patterns
+
+## Forwarder Strategy Pattern
+
+`RequestForwarder` interface with three implementations:
+- `baseForwarder`: Shared HTTP execution, response streaming, cache interactions
+- `signingForwarder`: Validates client sigs, re-signs for upstream
+- `transparentForwarder`: Preserves client signatures, adds proxy headers
+
+`NewForwarder()` factory selects based on config. Compile-time interface satisfaction checks.
+
+## Configuration
+
+- Transparent mode is default (`TAG_TRANSPARENT_PROXY` / `upstream.transparent_proxy`)
+- `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials with read-only access for all buckets (background cache fetches). Missing in transparent mode = fatal startup error.
+- Local auth enabled implicitly when transparent proxy is active
+- Endpoint validation: only `localhost`, `*.tigris.dev`, `*.storage.dev` allowed. Startup fatal on mismatch.
+
+## Proxy Headers
+
+TAG adds four proxy headers using HMAC-SHA256 over `forwarded_host\ntimestamp\nmethod\npath`:
+- `X-Tigris-Forwarded-Host`: Original Host header from client
+- `X-Tigris-Proxy-Access-Key`: TAG's access key
+- `X-Tigris-Proxy-Timestamp`: Unix timestamp
+- `X-Tigris-Proxy-Signature`: HMAC signature proving TAG's identity
+
+## Header Security
+
+- `r.Header.Clone()` to prevent mutation of original request headers
+- `Header.Set()` to overwrite any client-injected proxy header values
+- In signing mode, strip `X-Tigris-Proxy-*` and `X-Tigris-Forwarded-Host` from client requests
+- `X-Tigris-Proxy-Signing-Keys` stripped from responses before reaching client — always, regardless of mode or error state
+
+## Authentication Flow
+
+- `AuthResult` enum: `AuthValidated`/`AuthNotValidated` + error (`nil` = forward to Tigris, non-nil = reject)
+- Missing auth (anonymous) → `ErrMissingAuth` → forward to upstream (may be public bucket)
+- Malformed auth → reject with error
+- Unknown key / invalid sig → forward to Tigris (learns keys on response)
+- Valid sig + valid authz → `AuthValidated` → serve from cache
+
+## Per-Bucket Authorization
+
+- `AuthzCache` keyed on `(accessKey, bucket)`. Auth for one bucket does not grant access to others.
+- Granted when Tigris returns 2xx with signing keys
+- Revoked when Tigris returns 403
+- TTL: 10 minutes (configurable via `TAG_AUTHZ_CACHE_TTL`)
+
+## Auth Parsing
+
+- `auth/parser.go` provides `ExtractAccessKey()` and `ParseAuthInfo()` for SigV4 headers and query params
+- SigV4 date parsing must handle `time.RFC1123Z` in addition to `RFC1123` and `TimeFormat`
+
+## In-Memory Caches
+
+- `AuthzCache`: Expirable LRU with TTL, per-bucket auth decisions
+- `DerivedKeyStore`: Expirable LRU with TTL, pre-derived SigV4 signing keys indexed by `accessKey|date|region`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [docs/s3-compatibility-testing.md](docs/s3-compatibility-testing.md) for det
 
 TAG can be configured via YAML file or environment variables. Key settings:
 
-- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` - Tigris credentials (required)
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` - TAG's own Tigris credentials with read-only access (required). In transparent proxy mode (default), clients use their own credentials directly.
 - `TAG_CACHE_NODE_ID` - Unique node identifier for cluster mode
 - `TAG_CACHE_DISK_PATH` - Path to cache data directory
 - `TAG_LOG_LEVEL` - Log level: debug, info, warn, error
@@ -120,6 +120,12 @@ See [docs/architecture.md](docs/architecture.md) for detailed architecture docum
 TAG exposes Prometheus metrics at `/metrics` including request counts, latencies, cache hit/miss rates, and broadcast statistics.
 
 See [docs/metrics.md](docs/metrics.md) for complete metrics reference.
+
+## Security
+
+TAG supports transparent proxy mode (default) with local SigV4 validation and per-bucket authorization caching, as well as signing mode with local credential stores.
+
+See [docs/security.md](docs/security.md) for authentication, access control, and security architecture.
 
 ## Deployment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,10 +54,13 @@ Routes requests to appropriate handlers based on HTTP method and path:
 AWS Signature Version 4 authentication and request signing.
 
 - **credentials.go**: Credential store for access/secret key pairs
-- **validator.go**: Validates incoming request signatures (signing mode only)
+- **validator.go**: Validates incoming request signatures using stored signing keys
 - **signer.go**: Re-signs requests for upstream Tigris
 - **proxy_signer.go**: Computes proxy headers for transparent proxy mode
 - **parser.go**: Parses Authorization headers and presigned URLs
+- **key_unwrapper.go**: Decrypts derived signing keys from upstream responses (AES-256-GCM)
+- **derived_key_store.go**: LRU cache of pre-derived SigV4 signing keys for local validation
+- **authz_cache.go**: Per-bucket authorization cache tracking `(accessKey, bucket)` decisions
 
 **Authentication Flow (signing mode):**
 
@@ -69,7 +72,9 @@ AWS Signature Version 4 authentication and request signing.
 5. If valid, re-sign request for upstream with same credentials
 ```
 
-In transparent proxy mode (default), steps 1-4 are skipped. The client's original Authorization header is forwarded as-is, and proxy headers are added so Tigris validates the signature against the original host.
+In transparent proxy mode (default), TAG forwards the client's original Authorization header as-is and adds proxy headers so Tigris validates the signature against the original host. TAG also performs local SigV4 validation using pre-derived signing keys learned from Tigris responses, enabling cache hits to be served without an upstream round-trip. Anonymous requests (missing auth) are forwarded to Tigris for authoritative handling (e.g., public bucket access), while malformed auth headers are rejected at TAG.
+
+See [security.md](security.md) for the full access control flow, local authentication mechanism, and authorization lifecycle.
 
 ### Proxy Service (`proxy/`)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,193 @@
+# Security & Access Control
+
+This document describes TAG's authentication, authorization, and security architecture.
+
+## Authentication Modes
+
+TAG supports two authentication modes, controlled by the `transparent_proxy` configuration setting.
+
+### Transparent Proxy (Default)
+
+Clients sign requests with their own Tigris credentials. TAG forwards the request as-is, preserving the original `Authorization` header, and adds four proxy headers so Tigris can validate the client's signature against the original host:
+
+- `X-Tigris-Forwarded-Host` - The original Host header from the client
+- `X-Tigris-Proxy-Access-Key` - TAG's own access key
+- `X-Tigris-Proxy-Timestamp` - Unix timestamp for the proxy signature
+- `X-Tigris-Proxy-Signature` - HMAC-SHA256 signature proving TAG's identity
+
+Tigris independently validates both the client's SigV4 signature and TAG's proxy signature. TAG's access key must belong to the same Tigris organization as the client's access key.
+
+### Signing Mode
+
+TAG validates incoming request signatures against a local credential store, then re-signs requests for the upstream Tigris endpoint. This mode is used when TAG needs to perform credential translation (e.g., clients use different credentials than the upstream Tigris account).
+
+Set `TAG_TRANSPARENT_PROXY=false` or `upstream.transparent_proxy: false` in YAML to enable signing mode.
+
+## Local Authentication
+
+In transparent proxy mode, TAG implements local SigV4 validation to serve cache hits without contacting Tigris on every request. This is enabled automatically when transparent proxy mode is active.
+
+### How It Works
+
+**First request (key learning):**
+
+```text
+Client                     TAG                          Tigris
+  │                         │                             │
+  │  GET /bucket/key        │                             │
+  │  Authorization: ...     │                             │
+  │────────────────────────▶│                             │
+  │                         │  Forward + proxy headers    │
+  │                         │────────────────────────────▶│
+  │                         │◀────────────────────────────│
+  │                         │  200 OK                     │
+  │                         │  X-Tigris-Proxy-Signing-Keys│
+  │                         │                             │
+  │                         │  (unwrap & store keys)      │
+  │                         │  (grant authz cache entry)  │
+  │◀────────────────────────│                             │
+  │  200 OK (key header     │                             │
+  │  stripped from response)│                             │
+```
+
+**Subsequent requests (local validation):**
+
+```text
+Client                     TAG                          Tigris
+  │                         │                             │
+  │  GET /bucket/key        │                             │
+  │  Authorization: ...     │                             │
+  │────────────────────────▶│                             │
+  │                         │  Validate SigV4 locally     │
+  │                         │  Check authz cache          │
+  │                         │  → AuthValidated            │
+  │                         │                             │
+  │                         │  Serve from cache           │
+  │◀────────────────────────│                             │
+  │  200 OK                 │                             │
+  │  X-Cache: HIT           │                             │
+```
+
+### Components
+
+| Component          | Purpose                                      | Capacity     | TTL                   |
+| ------------------ | -------------------------------------------- | ------------ | --------------------- |
+| `DerivedKeyStore`  | Pre-derived SigV4 signing keys               | 100K entries | 48 hours              |
+| `AuthzCache`       | Per-bucket authorization decisions           | 1M entries   | 10 min (configurable) |
+| `KeyUnwrapper`     | Decrypts signing keys from Tigris responses  | N/A          | N/A                   |
+| `RequestValidator` | Validates SigV4 signatures using stored keys | N/A          | N/A                   |
+
+**DerivedKeyStore** stores pre-derived SigV4 signing keys received from Tigris, indexed by `accessKey|date|region`. The 48-hour TTL covers today and yesterday to handle SigV4 clock skew tolerance.
+
+**AuthzCache** tracks per-bucket authorization decisions, indexed by `accessKey|bucket`. Authorization for one bucket does not grant access to others. Configurable via `TAG_AUTHZ_CACHE_TTL` (default: 10 minutes).
+
+**KeyUnwrapper** decrypts the `X-Tigris-Proxy-Signing-Keys` response header using AES-256-GCM with `SHA256(proxy_secret_key)` as the encryption key. The client's access key is used as Additional Authenticated Data (AAD) to prevent ciphertext transplant attacks between access keys.
+
+**RequestValidator** performs cryptographic SigV4 validation using stored signing keys. Uses constant-time comparison (HMAC-Equal) to prevent timing attacks. Enforces a 15-minute clock skew tolerance.
+
+## Access Control Flow
+
+```text
+Request arrives at TAG
+    │
+    ├─ No Authorization header (anonymous)
+    │   └─ Forward to Tigris → Tigris decides (e.g., public bucket access)
+    │
+    ├─ Malformed Authorization header
+    │   └─ Reject with 4xx error
+    │
+    ├─ Access key not in DerivedKeyStore (unknown key)
+    │   └─ Forward to Tigris → learn keys on successful response
+    │
+    ├─ SigV4 signature mismatch
+    │   └─ Forward to Tigris → re-learn keys if signature was stale
+    │
+    ├─ AuthzCache miss or expired
+    │   └─ Forward to Tigris → re-authorize on successful response
+    │
+    └─ Valid signature + valid authz cache entry
+        └─ AuthValidated → serve from cache if available
+```
+
+## Authorization Lifecycle
+
+Authorization decisions are cached per `(accessKey, bucket)` pair:
+
+| Event                                | Action                                    |
+| ------------------------------------ | ----------------------------------------- |
+| Tigris returns 2xx with signing keys | `AuthzCache.Grant(accessKey, bucket)`     |
+| Tigris returns 403                   | `AuthzCache.Revoke(accessKey, bucket)`    |
+| TTL expires (10 min default)         | Entry removed, next request re-authorizes |
+
+Authorization is strictly per-bucket. A client may have access to some buckets but not others, and TAG enforces this at the cache level.
+
+## Proxy Header Security
+
+### Preventing Client Injection
+
+Clients cannot forge proxy headers because TAG always overwrites them:
+
+**Transparent mode**: TAG uses `Header.Set()` to overwrite any client-supplied proxy header values with TAG's own computed values. Even if a client sends `X-Tigris-Proxy-Signature`, it is replaced.
+
+**Signing mode**: TAG strips all `X-Tigris-Proxy-*` and `X-Tigris-Forwarded-Host` headers from client requests entirely before forwarding.
+
+### Proxy Signature Computation
+
+TAG computes the proxy signature using its own secret key:
+
+```text
+canonical_string = forwarded_host + "\n" + timestamp + "\n" + method + "\n" + path
+signature = HMAC-SHA256(TAG_secret_key, canonical_string)
+```
+
+Only TAG (and Tigris, which knows TAG's key) can produce a valid proxy signature.
+
+## Internal Header Stripping
+
+The `X-Tigris-Proxy-Signing-Keys` response header contains encrypted signing keys intended only for TAG. This header is **always stripped** from responses before they reach the client:
+
+- Stripped in `ResponseInterceptor` before headers are written to the client
+- Stripped regardless of whether local auth is enabled or disabled
+- Stripped regardless of response status (success or error)
+- Stripped regardless of forwarding mode (transparent or signing)
+
+## Endpoint Validation
+
+TAG validates the upstream endpoint at startup to prevent misconfiguration and SSRF attacks.
+
+**Allowed hosts:**
+
+| Pattern         | Example                          | Use Case                  |
+| --------------- | -------------------------------- | ------------------------- |
+| `localhost`     | `http://localhost:8080`          | Development and testing   |
+| `*.tigris.dev`  | `https://fly.storage.tigris.dev` | Tigris production domains |
+| `*.storage.dev` | `https://t3.storage.dev`         | Tigris storage domains    |
+
+Any other endpoint causes a fatal startup error. This prevents TAG from being used as an open proxy to arbitrary services.
+
+## Credential Requirements
+
+TAG requires its own Tigris credentials via environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID=<TAG's access key>
+export AWS_SECRET_ACCESS_KEY=<TAG's secret key>
+```
+
+These credentials must have **read-only access** to all buckets accessed through TAG. This is required for:
+
+- Signing proxy headers (transparent mode)
+- Background cache fetches (e.g., fetching full objects after a range request cache miss)
+- Re-signing requests for upstream (signing mode)
+
+In transparent proxy mode, TAG's access key must belong to the same Tigris organization as client access keys. Clients use their own credentials directly — TAG does not need or store client secret keys.
+
+## Error Mapping
+
+| Auth Error         | S3 Error Code         | HTTP Status | Action            |
+| ------------------ | --------------------- | ----------- | ----------------- |
+| Signature mismatch | SignatureDoesNotMatch | 403         | Forward to Tigris |
+| Unknown access key | InvalidAccessKeyId    | 403         | Forward to Tigris |
+| Expired request    | RequestTimeTooSkewed  | 403         | Forward to Tigris |
+| Malformed auth     | MalformedAuth         | 400         | Reject at TAG     |
+| Missing auth       | (none)                | (none)      | Forward to Tigris |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,9 @@ TAG is fully compatible with standard S3 tools and SDKs. This guide shows how to
 ## Prerequisites
 
 - TAG running locally or accessible via network
-- Valid AWS credentials configured for TAG
+- TAG's own Tigris credentials configured via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (see [configuration.md](configuration.md))
+- **Transparent proxy mode** (default): Clients use their own Tigris credentials directly when making S3 requests
+- **Signing mode**: Clients must use credentials known to TAG's credential store
 
 ## AWS CLI
 
@@ -45,7 +47,7 @@ Then use the profile:
 aws s3 ls --profile tag
 ```
 
-### Common Operations
+### Common CLI Operations
 
 ```bash
 # List buckets


### PR DESCRIPTION
## Summary

- Add comprehensive security.md documenting transparent proxy authentication, local SigV4 validation, per-bucket authorization caching
- Create .claude/rules/ files for transparent proxy architecture, testing patterns, and cache library guidance
- Update architecture.md, README.md, and usage.md to clarify credential semantics and reference security documentation

## Changes

**New files:**
- `docs/security.md` (193 lines) — authentication modes, local auth mechanism, access control flow, authorization lifecycle, proxy header security, endpoint validation, credential requirements
- `.claude/rules/transparent-proxy.md` (57 lines) — proxy architecture patterns, auth flows, header safety
- `.claude/rules/testing.md` (41 lines) — test environment factories, mocking patterns, coverage checklist

**Updated files:**
- `docs/architecture.md` — add local auth components (key_unwrapper, derived_key_store, authz_cache) and link to security.md
- `README.md` — add Security section, clarify credential note for transparent proxy mode
- `docs/usage.md` — clarify prerequisites by mode
- `.claude/rules/performance.md` — add cache library guidance section

## Testing

- Manual review of documentation for accuracy and clarity
- Verification of cross-references between security.md, architecture.md, and README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (no runtime behavior changes), with low risk beyond potentially incorrect guidance if the docs are inaccurate.
> 
> **Overview**
> Adds a new `docs/security.md` describing transparent proxy vs signing mode, local SigV4 validation/key-learning, per-bucket authz caching, proxy-header hardening, endpoint allowlisting, and credential requirements.
> 
> Updates `README.md`, `docs/architecture.md`, and `docs/usage.md` to clarify that `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are TAG’s own read-only Tigris credentials (while clients use their own creds in transparent mode), and to link to the new security documentation. Adds new `.claude/rules/*` guidance for transparent-proxy auth patterns, testing practices, and preferring `hashicorp/golang-lru/v2/expirable` over custom TTL maps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea0dc8bfdaf2eb368e53d2608a9d0fd0d0158a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->