### PR TITLE
fix: add Content-Encoding header for streaming SigV4 uploads

### DIFF
--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -378,6 +378,28 @@ func stripAWSChunkedEncoding(req *http.Request) {
 	}
 }
 
+// ensureAWSChunkedEncoding adds "aws-chunked" to the Content-Encoding header
+// if not already present. Some S3 clients (e.g., minio-go) use streaming SigV4
+// (X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD) but omit the
+// required Content-Encoding: aws-chunked header. This ensures the upstream
+// server can correctly identify and process the chunked body.
+func ensureAWSChunkedEncoding(req *http.Request) {
+	ce := req.Header.Get("Content-Encoding")
+	if ce == "" {
+		req.Header.Set("Content-Encoding", "aws-chunked")
+		return
+	}
+
+	for _, part := range strings.Split(ce, ",") {
+		if strings.TrimSpace(part) == "aws-chunked" {
+			return // Already present
+		}
+	}
+
+	// Prepend aws-chunked (it's the outermost encoding layer)
+	req.Header.Set("Content-Encoding", "aws-chunked,"+ce)
+}
+
 // ResponseCapture holds captured response data.
 type ResponseCapture struct {
 	StatusCode int

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -391,7 +391,7 @@ func ensureAWSChunkedEncoding(req *http.Request) {
 	}
 
 	for _, part := range strings.Split(ce, ",") {
-		if strings.TrimSpace(part) == "aws-chunked" {
+		if strings.EqualFold(strings.TrimSpace(part), "aws-chunked") {
 			return // Already present
 		}
 	}

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -50,6 +50,10 @@ func (f *transparentForwarder) interceptResponse(resp *http.Response, originalRe
 // buildTransparentRequest creates a forwarded request for transparent proxy mode.
 // Copies ALL headers from the original request (including Authorization, X-Amz-Date, etc.)
 // and adds the 4 proxy headers. The body is streamed as-is without decoding.
+//
+// For AWS chunked transfer encoding (streaming SigV4), ensures the required
+// Content-Encoding: aws-chunked header is present per the S3 spec. Some clients
+// (e.g., minio-go) omit this header despite using chunked encoding on the wire.
 func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *http.Request) (*http.Request, error) {
 	baseURL, err := url.Parse(f.upstreamEndpoint)
 	if err != nil {
@@ -85,6 +89,15 @@ func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *h
 
 	// Preserve Content-Length from original request
 	fwdReq.ContentLength = r.ContentLength
+
+	// AWS S3 spec requires Content-Encoding: aws-chunked for streaming SigV4
+	// uploads. Some clients (e.g., minio-go) send STREAMING-AWS4-HMAC-SHA256-PAYLOAD
+	// in X-Amz-Content-Sha256 but omit the Content-Encoding header. Ensure it's
+	// present so upstream Tigris can correctly process the chunked body.
+	// Content-Encoding is not in the client's SignedHeaders so adding it is safe.
+	if IsStreamingPayload(fwdReq.Header.Get("X-Amz-Content-Sha256")) {
+		ensureAWSChunkedEncoding(fwdReq)
+	}
 
 	// Capture original Host before it gets overwritten by the upstream URL
 	forwardedHost := r.Host

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tag/auth"
@@ -94,8 +95,9 @@ func (f *transparentForwarder) buildTransparentRequest(ctx context.Context, r *h
 	// uploads. Some clients (e.g., minio-go) send STREAMING-AWS4-HMAC-SHA256-PAYLOAD
 	// in X-Amz-Content-Sha256 but omit the Content-Encoding header. Ensure it's
 	// present so upstream Tigris can correctly process the chunked body.
-	// Content-Encoding is not in the client's SignedHeaders so adding it is safe.
-	if IsStreamingPayload(fwdReq.Header.Get("X-Amz-Content-Sha256")) {
+	// Only add the header if content-encoding is NOT in the client's SignedHeaders,
+	// since mutating a signed header would invalidate the Authorization signature.
+	if IsStreamingPayload(fwdReq.Header.Get("X-Amz-Content-Sha256")) && !isContentEncodingSigned(r) {
 		ensureAWSChunkedEncoding(fwdReq)
 	}
 
@@ -197,6 +199,24 @@ func (f *transparentForwarder) validateLocally(r *http.Request) (AuthResult, err
 
 	metrics.RecordLocalAuthValidation("success")
 	return AuthValidated, nil
+}
+
+// isContentEncodingSigned returns true if "content-encoding" is listed in the
+// request's SigV4 SignedHeaders. When it is signed, we must not modify the
+// Content-Encoding header because doing so would invalidate the Authorization
+// signature. Returns false if the auth header can't be parsed (anonymous or
+// malformed requests will be forwarded to Tigris for authoritative handling).
+func isContentEncodingSigned(r *http.Request) bool {
+	authInfo, err := auth.ParseAuthInfo(r)
+	if err != nil {
+		return false
+	}
+	for _, h := range authInfo.SignedHeaders {
+		if strings.EqualFold(h, "content-encoding") {
+			return true
+		}
+	}
+	return false
 }
 
 // DoRequestWithCreds executes a request with transparent proxy headers.

--- a/proxy/forwarder_transparent_test.go
+++ b/proxy/forwarder_transparent_test.go
@@ -2,10 +2,161 @@ package proxy
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/tigrisdata/tag/auth"
 )
+
+func TestBuildTransparentRequest_StreamingPayload(t *testing.T) {
+	ps := auth.NewProxySigner("test-access-key", "test-secret-key")
+	fwd := &transparentForwarder{
+		baseForwarder:    newBaseForwarder("https://upstream.example.com", "us-east-1", 10),
+		proxySigner:      ps,
+		upstreamEndpoint: "https://upstream.example.com",
+	}
+
+	t.Run("adds Content-Encoding aws-chunked when missing", func(t *testing.T) {
+		// minio-go sends STREAMING-AWS4-HMAC-SHA256-PAYLOAD but omits Content-Encoding
+		chunkedBody := "4;chunk-signature=abc123\r\ntest\r\n0;chunk-signature=def456\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "aws-chunked" {
+			t.Errorf("Content-Encoding = %q, want %q", ce, "aws-chunked")
+		}
+
+		// Body and ContentLength should be preserved (wire size, not decoded)
+		if fwdReq.ContentLength != int64(len(chunkedBody)) {
+			t.Errorf("ContentLength = %d, want %d", fwdReq.ContentLength, len(chunkedBody))
+		}
+	})
+
+	t.Run("adds Content-Encoding for unsigned streaming payload", func(t *testing.T) {
+		chunkedBody := "5\r\nhello\r\n0\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingUnsignedTrailerHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "5")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "aws-chunked" {
+			t.Errorf("Content-Encoding = %q, want %q", ce, "aws-chunked")
+		}
+	})
+
+	t.Run("preserves existing Content-Encoding aws-chunked", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=sig\r\ntest\r\n0;chunk-signature=sig\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Content-Encoding", "aws-chunked")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		// Should not duplicate aws-chunked
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "aws-chunked" {
+			t.Errorf("Content-Encoding = %q, want %q", ce, "aws-chunked")
+		}
+	})
+
+	t.Run("preserves combined Content-Encoding with aws-chunked", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=sig\r\ntest\r\n0;chunk-signature=sig\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Content-Encoding", "aws-chunked,gzip")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		// Should not modify when aws-chunked already present
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "aws-chunked,gzip" {
+			t.Errorf("Content-Encoding = %q, want %q", ce, "aws-chunked,gzip")
+		}
+	})
+
+	t.Run("prepends aws-chunked to existing Content-Encoding", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=sig\r\ntest\r\n0;chunk-signature=sig\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Content-Encoding", "gzip")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "aws-chunked,gzip" {
+			t.Errorf("Content-Encoding = %q, want %q", ce, "aws-chunked,gzip")
+		}
+	})
+
+	t.Run("signed headers preserved", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=abc\r\ntest\r\n0;chunk-signature=def\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=key/date/region/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length,Signature=sig")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		if got := fwdReq.Header.Get("X-Amz-Content-Sha256"); got != StreamingPayloadHash {
+			t.Errorf("X-Amz-Content-Sha256 = %q, want %q", got, StreamingPayloadHash)
+		}
+		if got := fwdReq.Header.Get("X-Amz-Decoded-Content-Length"); got != "4" {
+			t.Errorf("X-Amz-Decoded-Content-Length = %q, want %q", got, "4")
+		}
+		if got := fwdReq.Header.Get("Authorization"); got == "" {
+			t.Error("Authorization header missing")
+		}
+	})
+
+	t.Run("non-streaming payload no Content-Encoding added", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader("data"))
+		req.ContentLength = 4
+		req.Header.Set("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "" {
+			t.Errorf("Content-Encoding = %q, want empty for non-streaming", ce)
+		}
+	})
+}
 
 func TestBuildTransparentRequest_DateHandling(t *testing.T) {
 	ps := auth.NewProxySigner("test-access-key", "test-secret-key")

--- a/proxy/forwarder_transparent_test.go
+++ b/proxy/forwarder_transparent_test.go
@@ -156,6 +156,48 @@ func TestBuildTransparentRequest_StreamingPayload(t *testing.T) {
 			t.Errorf("Content-Encoding = %q, want empty for non-streaming", ce)
 		}
 	})
+
+	t.Run("skips mutation when content-encoding is in SignedHeaders", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=sig\r\ntest\r\n0;chunk-signature=sig\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Content-Encoding", "gzip")
+		// content-encoding IS in SignedHeaders — must not be mutated
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=key/20260214/us-east-1/s3/aws4_request,SignedHeaders=content-encoding;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length,Signature=sig")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		// Content-Encoding should be preserved as-is (no aws-chunked prepended)
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "gzip" {
+			t.Errorf("Content-Encoding = %q, want %q (should not be mutated when signed)", ce, "gzip")
+		}
+	})
+
+	t.Run("case-insensitive aws-chunked detection", func(t *testing.T) {
+		chunkedBody := "4;chunk-signature=sig\r\ntest\r\n0;chunk-signature=sig\r\n\r\n"
+
+		req, _ := http.NewRequest(http.MethodPut, "http://localhost:8080/bucket/key", strings.NewReader(chunkedBody))
+		req.ContentLength = int64(len(chunkedBody))
+		req.Header.Set("X-Amz-Content-Sha256", StreamingPayloadHash)
+		req.Header.Set("X-Amz-Decoded-Content-Length", "4")
+		req.Header.Set("Content-Encoding", "AWS-CHUNKED")
+
+		fwdReq, err := fwd.buildTransparentRequest(t.Context(), req)
+		if err != nil {
+			t.Fatalf("buildTransparentRequest() error = %v", err)
+		}
+
+		// Should not duplicate — case-insensitive match should detect AWS-CHUNKED
+		if ce := fwdReq.Header.Get("Content-Encoding"); ce != "AWS-CHUNKED" {
+			t.Errorf("Content-Encoding = %q, want %q (should not duplicate)", ce, "AWS-CHUNKED")
+		}
+	})
 }
 
 func TestBuildTransparentRequest_DateHandling(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes streaming SigV4 upload failures in transparent proxy mode. When minio-go sends streaming uploads, it omits the required `Content-Encoding: aws-chunked` header per the AWS S3 spec. TAG now ensures this header is present when forwarding to Tigris, allowing proper validation of the chunked body and chunk signatures.

## Changes

- Add `ensureAWSChunkedEncoding()` function that prepends `aws-chunked` to Content-Encoding when needed
- Call `ensureAWSChunkedEncoding()` in `buildTransparentRequest()` for streaming SigV4 payloads
- Add comprehensive unit tests covering streaming payload header handling

## Test plan

- [x] Unit tests: `make test-proxy` passes all proxy package tests
- [x] Full test suite: `make test` passes all packages
- [x] Race detector: `make test-race` passes
- [x] Integration: Verified with warp (minio benchmark) streaming SigV4 uploads now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request header mutation in the transparent proxy path; incorrect conditions could invalidate SigV4 signatures or alter upstream request interpretation. Risk is mitigated by explicit SignedHeaders checks and comprehensive unit tests.
> 
> **Overview**
> Fixes transparent proxy mode for streaming SigV4 S3 uploads by ensuring the forwarded request includes `Content-Encoding: aws-chunked` when the payload hash indicates AWS chunked streaming.
> 
> Adds `ensureAWSChunkedEncoding()` to prepend or set the header without duplicating it (case-insensitive), and guards the mutation by skipping it when `content-encoding` is part of SigV4 `SignedHeaders` to avoid breaking signatures. Adds unit tests covering missing/present/combined encodings, signed-header skip behavior, and non-streaming no-op.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ffdd7c8ed46744116276d70f3158451a705c280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->