### PR TITLE
docs: add cluster testing and security config patterns

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -36,6 +36,18 @@ Cover these scenarios for transparent proxy:
 - Internal header stripping (even on errors or cache hits)
 - Multi-bucket auth enforcement (access to bucket A ≠ access to bucket B)
 
+## Local Cluster Testing
+
+New features involving cluster communication should have dedicated Makefile targets to spin up local multi-node clusters (e.g., `s3-test-local-cluster`) for running compatibility tests against a multi-node setup.
+
+## Configuration Override Tests
+
+Always add explicit tests for env var overrides (e.g., `TestHTTPPort_OverrideByEnv`, `TestGRPCAuth_UnrecognizedValueKeepsEnabled`) to validate configuration parsing logic.
+
+## Incremental Verification
+
+When updating complex dependencies or configuration logic, build and test after each change rather than batching all changes together.
+
 ## Cache Libraries
 
 Prefer `hashicorp/golang-lru/v2/expirable` for bounded TTL caches over custom map implementations with manual cleanup logic.

--- a/.claude/rules/transparent-proxy.md
+++ b/.claude/rules/transparent-proxy.md
@@ -51,6 +51,12 @@ TAG adds four proxy headers using HMAC-SHA256 over `forwarded_host\ntimestamp\nm
 - `auth/parser.go` provides `ExtractAccessKey()` and `ParseAuthInfo()` for SigV4 headers and query params
 - SigV4 date parsing must handle `time.RFC1123Z` in addition to `RFC1123` and `TimeFormat`
 
+## Security Configuration Parsing
+
+- **Fail-closed**: Boolean security env vars (e.g., `TAG_CACHE_GRPC_AUTH`) must only disable on explicit "false" or "0". Any unrecognized value (typos, "True", "yes") defaults to enabled.
+- **Unconditional auth**: If the gRPC server is exposed and authentication is enabled, apply auth unconditionally regardless of deployment mode (single-node vs cluster). Disabling must be explicit.
+- **Missing credentials**: Missing AWS credentials when gRPC auth is enabled → `log.Fatal()` at startup.
+
 ## In-Memory Caches
 
 - `AuthzCache`: Expirable LRU with TTL, per-bucket auth decisions


### PR DESCRIPTION
## Summary
Added guidance for local cluster testing with dedicated Makefile targets and configuration override tests. Added security configuration parsing guidelines ensuring fail-closed defaults and unconditional authentication when gRPC server is exposed.

## Changes
- **testing.md**: New sections on local cluster testing patterns, configuration override test requirements, and incremental verification practices
- **transparent-proxy.md**: New security configuration parsing section documenting fail-closed env var defaults, unconditional auth requirements, and fatal startup errors for missing credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime behavior impact; risk is limited to guidance being misapplied or misinterpreted.
> 
> **Overview**
> Adds new testing guidance to `.claude/rules/testing.md`, recommending dedicated Make targets for local multi-node cluster compatibility tests, explicit tests for env var config overrides, and incremental build/test verification.
> 
> Extends `.claude/rules/transparent-proxy.md` with **security configuration parsing** rules: fail-closed boolean env var handling, enforcing gRPC auth unconditionally when enabled/exposed, and requiring startup `log.Fatal()` when credentials are missing while gRPC auth is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b76f6e1271118ad2fa87ca60cf38a7be6f736f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->