### PR TITLE
docs: add learnings from TLS testing and code review patterns

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -51,3 +51,18 @@ When updating complex dependencies or configuration logic, build and test after 
 ## Cache Libraries
 
 Prefer `hashicorp/golang-lru/v2/expirable` for bounded TTL caches over custom map implementations with manual cleanup logic.
+
+## TLS Testing
+
+- Self-signed certificates generated via `openssl` for local testing
+- Health checks use `curl -sk` (silent, insecure) for HTTPS with self-signed certs
+- S3 test config: `is_secure = True` and `ssl_verify = False` for self-signed cert environments
+- Use `S3TEST_CONF_TEMPLATE` env var to select config templates (e.g., `s3tests.conf` vs `s3tests-tls.conf`)
+
+## Idempotent Makefile Targets
+
+Targets that generate artifacts (like certificates) should check for file existence before regenerating, making them safe to run repeatedly.
+
+## Process Management in Test Targets
+
+Use `pkill -f` and `lsof -ti:<port> | xargs kill` to ensure clean state (no stale processes, no port conflicts) before starting local services in Makefile targets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ TESTRUN="TestBroadcast" make test-proxy
 
 ## Commit & PR Conventions
 
-PR titles and commit messages must use [Conventional Commits](https://www.conventionalcommits.org/) format with one of these prefixes: `feat`, `fix`, `perf`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert`. Example: `feat: add chunked transfer encoding support`.
+PR titles and commit messages must use [Conventional Commits](https://www.conventionalcommits.org/) format with one of these prefixes: `feat`, `fix`, `perf`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert`. Example: `feat: add chunked transfer encoding support`. PR title format is enforced by CI (`amannn/action-semantic-pull-request@v5`) — always verify PR titles match before submitting.
 
 ## User Preferences
 
@@ -73,3 +73,6 @@ PR titles and commit messages must use [Conventional Commits](https://www.conven
 - **Zero added latency**: Prefer patterns like stream multiplexing over explicit batching delays
 - **Linux + macOS support**: OS-specific optimizations must have viable fallbacks
 - **Clear plan separation**: When changes span multiple codebases (OCache vs TAG), maintain distinct plans
+- **High-signal code reviews only**: Focus exclusively on objective bugs and clear CLAUDE.md violations. Avoid subjective suggestions, nitpicks, pre-existing issues, linter-catchable issues, or general code quality concerns not explicitly mandated
+- **Makefile help target**: New Makefile targets must include corresponding entries in the `help` target with usage examples
+- **Local TLS testing**: Prefer Makefile targets for local TLS testing with self-signed certificates. Use `--insecure` / `-k` flags when needed


### PR DESCRIPTION
## Summary

This PR documents key learnings from the previous session about TAG development patterns:
- PR title format enforcement by CI and importance of pre-submission verification
- High-signal code review preferences (objective bugs and CLAUDE.md violations only)
- Makefile conventions for help targets, idempotent targets, and process cleanup
- TLS testing patterns including self-signed certificate handling and S3 test configuration
- Process management practices for local test targets

Changes made:
- Updated CLAUDE.md with PR title CI enforcement note and three new user preferences
- Enhanced .claude/rules/testing.md with TLS testing, idempotent target patterns, and process management sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or behavioral changes.
> 
> **Overview**
> Adds new developer/testing documentation around **local TLS workflows** (self-signed cert generation, `curl -k` health checks, and S3 test config/template selection) and **Makefile test-target hygiene** (idempotent artifact generation and process/port cleanup patterns).
> 
> Updates `CLAUDE.md` to note CI-enforced Conventional Commit PR titles and to codify preferences for *high-signal reviews*, requiring `make help` entries for new targets, and favoring Makefile-driven TLS testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f23db5ac1744a271d86a893b2c7a08a3fc774cc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->