### PR TITLE
Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,10 @@ endif
 
 # Testing targets
 .PHONY: test
-test: rocksdb-static
+test: build
 	@echo "Running unit tests..."
 	$(if $(TEST)$(TESTRUN),@echo "Filter: $(if $(TEST),$(TEST),$(TESTRUN))",)
-	$(CGO_ENV) go test -v -timeout 60s $(TESTFLAGS) ./auth/... ./cache/... ./config/... ./handlers/... ./metrics/... ./proxy/...
+	$(CGO_ENV) go test -v -timeout 60s $(TESTFLAGS) ./auth/... ./cache/... ./cmd/... ./config/... ./handlers/... ./metrics/... ./proxy/...
 
 .PHONY: test-all
 test-all: test test-integration
@@ -289,8 +289,8 @@ help:
 	@echo "  check         - Run all quality checks (fmt, vet, test)"
 	@echo ""
 	@echo "Run targets:"
-	@echo "  run           - Run TAG with default options"
-	@echo "  run-verbose   - Run TAG with debug logging"
+	@echo "  run           - Run TAG with default options (use --help for CLI flags)"
+	@echo "  run-verbose   - Run TAG with debug logging (use --version for version info)"
 	@echo ""
 	@echo "S3 compatibility test targets:"
 	@echo "  s3-test-local          - Start TAG locally with embedded cache"

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -40,7 +41,35 @@ func main() {
 	// Parse command line flags
 	configPath := flag.String("config", "", "Path to configuration file")
 	disableCache := flag.Bool("disable-cache", false, "Disable caching (pass-through mode)")
+	showVersion := flag.Bool("version", false, "Print version information and exit")
+	httpPort := flag.Int("http-port", 0, "HTTP port (env: TAG_HTTP_PORT)")
+	logLevel := flag.String("log-level", "", "Log level: debug, info, warn, error (env: TAG_LOG_LEVEL)")
+	logFormat := flag.String("log-format", "", "Log format: json or console (env: TAG_LOG_FORMAT)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: tag [options]\n\n")
+		fmt.Fprintf(os.Stderr, "TAG (Tigris Access Gateway) - S3-compatible caching proxy for Tigris\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		fmt.Fprintf(os.Stderr, "  --version              Print version information and exit\n")
+		fmt.Fprintf(os.Stderr, "  --config PATH          Path to YAML configuration file\n")
+		fmt.Fprintf(os.Stderr, "  --disable-cache        Disable caching (pass-through mode)\n")
+		fmt.Fprintf(os.Stderr, "  --http-port PORT       HTTP port (default: 8080, env: TAG_HTTP_PORT)\n")
+		fmt.Fprintf(os.Stderr, "  --log-level LEVEL      Log level: debug, info, warn, error (default: info, env: TAG_LOG_LEVEL)\n")
+		fmt.Fprintf(os.Stderr, "  --log-format FORMAT    Log format: json or console (default: json, env: TAG_LOG_FORMAT)\n")
+		fmt.Fprintf(os.Stderr, "\nConfiguration precedence: defaults < config file < environment variables < CLI flags\n")
+		fmt.Fprintf(os.Stderr, "See documentation for full list of environment variables (TAG_*).\n")
+	}
+
 	flag.Parse()
+
+	// Handle --version before any config loading
+	if *showVersion {
+		fmt.Printf("TAG (Tigris Access Gateway)\n")
+		fmt.Printf("  Version:    %s\n", Version)
+		fmt.Printf("  Build Time: %s\n", BuildTime)
+		fmt.Printf("  Git Commit: %s\n", GitCommit)
+		os.Exit(0)
+	}
 
 	// Load configuration first (before setting up logger, so we can use log format from config)
 	var cfg *config.Config
@@ -57,7 +86,24 @@ func main() {
 		cfg = config.NewDefault()
 	}
 
-	// Initialize logger based on configuration
+	// Override cache enabled from command line flag
+	if *disableCache {
+		cfg.Cache.SetEnabled(false)
+	}
+
+	// Apply convenience CLI flag overrides (only when explicitly set)
+	flag.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "http-port":
+			cfg.Server.HTTPPort = *httpPort
+		case "log-level":
+			cfg.Log.Level = *logLevel
+		case "log-format":
+			cfg.Log.Format = *logFormat
+		}
+	})
+
+	// Initialize logger based on configuration (after CLI overrides)
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	if cfg.Log.Format == "console" {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
@@ -78,11 +124,6 @@ func main() {
 
 	if *configPath == "" {
 		log.Info().Msg("Using default configuration")
-	}
-
-	// Override cache enabled from command line flag
-	if *disableCache {
-		cfg.Cache.SetEnabled(false)
 	}
 
 	log.Info().

--- a/cmd/tag/main_test.go
+++ b/cmd/tag/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// tagBinary returns the path to the pre-built TAG binary.
+// Tests expect the binary to be built before running (e.g., via "make build").
+func tagBinary(t *testing.T) string {
+	t.Helper()
+	binary := os.Getenv("TAG_TEST_BINARY")
+	if binary == "" {
+		binary = "../../tag"
+	}
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		t.Skipf("TAG binary not found at %s; run 'make build' first", binary)
+	}
+	return binary
+}
+
+func TestVersionFlag(t *testing.T) {
+	binary := tagBinary(t)
+
+	out, err := exec.Command(binary, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("tag --version failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	for _, expected := range []string{
+		"TAG (Tigris Access Gateway)",
+		"Version:",
+		"Build Time:",
+		"Git Commit:",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("tag --version output missing %q\ngot: %s", expected, output)
+		}
+	}
+}
+
+func TestVersionFlag_SingleDash(t *testing.T) {
+	binary := tagBinary(t)
+
+	out, err := exec.Command(binary, "-version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("tag -version failed: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "Version:") {
+		t.Errorf("tag -version should work same as --version\ngot: %s", out)
+	}
+}
+
+func TestHelpFlag(t *testing.T) {
+	binary := tagBinary(t)
+
+	// --help exits with code 2 via Go's flag package (flag.ErrHelp) with output to stderr
+	cmd := exec.Command(binary, "--help")
+	out, _ := cmd.CombinedOutput()
+
+	output := string(out)
+	for _, expected := range []string{
+		"Usage: tag [options]",
+		"--version",
+		"--config",
+		"--disable-cache",
+		"--http-port",
+		"--log-level",
+		"--log-format",
+		"TAG_HTTP_PORT",
+		"TAG_LOG_LEVEL",
+		"TAG_LOG_FORMAT",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("tag --help output missing %q\ngot: %s", expected, output)
+		}
+	}
+}
+
+func TestUnknownFlag(t *testing.T) {
+	binary := tagBinary(t)
+
+	cmd := exec.Command(binary, "--unknown-flag")
+	err := cmd.Run()
+	if err == nil {
+		t.Error("tag --unknown-flag should exit with non-zero status")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the main entrypoint’s startup/config precedence and logging initialization; misapplied flag overrides or early-exit behavior could change runtime defaults, though changes are localized and covered by new CLI tests.
> 
> **Overview**
> Adds a more user-friendly TAG CLI: introduces `--version` output, a custom `--help`/usage message, and optional CLI overrides for `http-port`, `log-level`, and `log-format` applied after config loading.
> 
> Updates the `Makefile` so `make test` builds the binary and includes `./cmd/...` tests, and adds `cmd/tag/main_test.go` integration-style tests that execute the built `tag` binary to validate `--version`, `--help`, and unknown-flag behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b94b69b2623b3eb5713c008ffc587cdb19107c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->