### PR TITLE
Release

### DIFF
--- a/cache/object.go
+++ b/cache/object.go
@@ -2,6 +2,7 @@
 package cache
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,31 +24,45 @@ const (
 // - Conditional requests (If-None-Match, If-Modified-Since)
 // - Proper response headers on cache hits
 type CachedObjectMeta struct {
-	Key           string            `json:"key"`
-	Bucket        string            `json:"bucket"`
-	ETag          string            `json:"etag,omitempty"`
-	ContentType   string            `json:"content_type,omitempty"`
-	ContentLength int64             `json:"content_length"`
-	LastModified  int64             `json:"last_modified"` // Unix timestamp (seconds)
-	CacheControl  string            `json:"cache_control,omitempty"`
-	StorageClass  string            `json:"storage_class,omitempty"`
-	ACL           string            `json:"acl,omitempty"`           // X-Amz-Acl canned ACL (e.g., "public-read")
-	UserMetadata  map[string]string `json:"user_metadata,omitempty"` // x-amz-meta-*
-	StatusCode    int               `json:"status_code"`             // Original HTTP status (200, etc.)
+	Key                  string            `json:"key"`
+	Bucket               string            `json:"bucket"`
+	ETag                 string            `json:"etag,omitempty"`
+	ContentType          string            `json:"content_type,omitempty"`
+	ContentLength        int64             `json:"content_length"`
+	LastModified         int64             `json:"last_modified"` // Unix timestamp (seconds)
+	CacheControl         string            `json:"cache_control,omitempty"`
+	StorageClass         string            `json:"storage_class,omitempty"`
+	ACL                  string            `json:"acl,omitempty"`                    // X-Amz-Acl canned ACL (e.g., "public-read")
+	ContentEncoding      string            `json:"content_encoding,omitempty"`       // Content-Encoding (e.g., "gzip")
+	ContentDisposition   string            `json:"content_disposition,omitempty"`    // Content-Disposition (e.g., "attachment; filename=...")
+	ContentLanguage      string            `json:"content_language,omitempty"`       // Content-Language
+	Expires              string            `json:"expires,omitempty"`                // Expires header (raw HTTP-date string)
+	ServerSideEncryption string            `json:"server_side_encryption,omitempty"` // x-amz-server-side-encryption
+	VersionID            string            `json:"version_id,omitempty"`             // x-amz-version-id
+	PartsCount           string            `json:"parts_count,omitempty"`            // x-amz-mp-parts-count
+	UserMetadata         map[string]string `json:"user_metadata,omitempty"`          // x-amz-meta-*
+	StatusCode           int               `json:"status_code"`                      // Original HTTP status (200, etc.)
 }
 
 // MetaFromHTTPHeaders builds CachedObjectMeta from S3 response headers.
 func MetaFromHTTPHeaders(bucket, key string, statusCode int, headers http.Header) *CachedObjectMeta {
 	meta := &CachedObjectMeta{
-		Key:          key,
-		Bucket:       bucket,
-		StatusCode:   statusCode,
-		ETag:         headers.Get("ETag"),
-		ContentType:  headers.Get("Content-Type"),
-		CacheControl: headers.Get("Cache-Control"),
-		StorageClass: headers.Get("x-amz-storage-class"),
-		ACL:          headers.Get("X-Amz-Acl"),
-		UserMetadata: make(map[string]string),
+		Key:                  key,
+		Bucket:               bucket,
+		StatusCode:           statusCode,
+		ETag:                 headers.Get("ETag"),
+		ContentType:          headers.Get("Content-Type"),
+		CacheControl:         headers.Get("Cache-Control"),
+		StorageClass:         headers.Get("x-amz-storage-class"),
+		ACL:                  headers.Get("X-Amz-Acl"),
+		ContentEncoding:      headers.Get("Content-Encoding"),
+		ContentDisposition:   headers.Get("Content-Disposition"),
+		ContentLanguage:      headers.Get("Content-Language"),
+		Expires:              headers.Get("Expires"),
+		ServerSideEncryption: headers.Get("x-amz-server-side-encryption"),
+		VersionID:            headers.Get("x-amz-version-id"),
+		PartsCount:           headers.Get("x-amz-mp-parts-count"),
+		UserMetadata:         make(map[string]string),
 	}
 
 	// Parse Content-Length
@@ -74,8 +89,23 @@ func MetaFromHTTPHeaders(bucket, key string, statusCode int, headers http.Header
 	return meta
 }
 
+// WriteHeaderOption customizes headers written by WriteHeaders.
+type WriteHeaderOption func(http.Header)
+
+// WithRangeHeaders overrides Content-Length for the range size and adds
+// Content-Range and Accept-Ranges headers for 206 Partial Content responses.
+func WithRangeHeaders(start, end, totalSize int64) WriteHeaderOption {
+	return func(h http.Header) {
+		contentLength := end - start + 1
+		h.Set("Content-Length", strconv.FormatInt(contentLength, 10))
+		h.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, totalSize))
+		h.Set("Accept-Ranges", "bytes")
+	}
+}
+
 // WriteHeaders writes object metadata to response headers.
-func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter) {
+// Options are applied after standard headers, allowing overrides (e.g., WithRangeHeaders).
+func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter, opts ...WriteHeaderOption) {
 	if m.ETag != "" {
 		w.Header().Set("ETag", m.ETag)
 	}
@@ -98,10 +128,36 @@ func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter) {
 	if m.ACL != "" {
 		w.Header().Set("X-Amz-Acl", m.ACL)
 	}
+	if m.ContentEncoding != "" {
+		w.Header().Set("Content-Encoding", m.ContentEncoding)
+	}
+	if m.ContentDisposition != "" {
+		w.Header().Set("Content-Disposition", m.ContentDisposition)
+	}
+	if m.ContentLanguage != "" {
+		w.Header().Set("Content-Language", m.ContentLanguage)
+	}
+	if m.Expires != "" {
+		w.Header().Set("Expires", m.Expires)
+	}
+	if m.ServerSideEncryption != "" {
+		w.Header().Set("x-amz-server-side-encryption", m.ServerSideEncryption)
+	}
+	if m.VersionID != "" {
+		w.Header().Set("x-amz-version-id", m.VersionID)
+	}
+	if m.PartsCount != "" {
+		w.Header().Set("x-amz-mp-parts-count", m.PartsCount)
+	}
 	// Write user metadata with lowercase keys per S3 convention
 	for k, v := range m.UserMetadata {
 		lk := strings.ToLower(k)
 		w.Header().Set(lk, v)
+	}
+
+	// Apply options (may override headers like Content-Length for range responses)
+	for _, opt := range opts {
+		opt(w.Header())
 	}
 }
 

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -2,139 +2,11 @@
 package handlers
 
 import (
-	"encoding/xml"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/s3err"
 )
-
-// ErrorCode represents an S3 error code.
-type ErrorCode string
-
-// S3 Error codes
-const (
-	ErrNone                         ErrorCode = ""
-	ErrAccessDenied                 ErrorCode = "AccessDenied"
-	ErrBucketNotEmpty               ErrorCode = "BucketNotEmpty"
-	ErrBucketAlreadyExists          ErrorCode = "BucketAlreadyExists"
-	ErrBucketAlreadyOwnedByYou      ErrorCode = "BucketAlreadyOwnedByYou"
-	ErrNoSuchBucket                 ErrorCode = "NoSuchBucket"
-	ErrNoSuchKey                    ErrorCode = "NoSuchKey"
-	ErrNoSuchUpload                 ErrorCode = "NoSuchUpload"
-	ErrInvalidAccessKeyId           ErrorCode = "InvalidAccessKeyId"
-	ErrSignatureDoesNotMatch        ErrorCode = "SignatureDoesNotMatch"
-	ErrInvalidBucketName            ErrorCode = "InvalidBucketName"
-	ErrInvalidObjectName            ErrorCode = "InvalidObjectName"
-	ErrInvalidPart                  ErrorCode = "InvalidPart"
-	ErrInvalidPartNumber            ErrorCode = "InvalidPartNumber"
-	ErrInvalidPartOrder             ErrorCode = "InvalidPartOrder"
-	ErrInternalError                ErrorCode = "InternalError"
-	ErrMalformedXML                 ErrorCode = "MalformedXML"
-	ErrMethodNotAllowed             ErrorCode = "MethodNotAllowed"
-	ErrNotImplemented               ErrorCode = "NotImplemented"
-	ErrRequestTimeout               ErrorCode = "RequestTimeout"
-	ErrServiceUnavailable           ErrorCode = "ServiceUnavailable"
-	ErrSlowDown                     ErrorCode = "SlowDown"
-	ErrInvalidRequest               ErrorCode = "InvalidRequest"
-	ErrMissingContentLength         ErrorCode = "MissingContentLength"
-	ErrIncompleteBody               ErrorCode = "IncompleteBody"
-	ErrInvalidRange                 ErrorCode = "InvalidRange"
-	ErrAuthorizationHeaderMalformed ErrorCode = "AuthorizationHeaderMalformed"
-	ErrInvalidArgument              ErrorCode = "InvalidArgument"
-	ErrBadContentLength             ErrorCode = "BadContentLength"
-)
-
-// ErrorResponse represents an S3 error response.
-type ErrorResponse struct {
-	XMLName   xml.Name  `xml:"Error"`
-	Code      ErrorCode `xml:"Code"`
-	Message   string    `xml:"Message"`
-	Resource  string    `xml:"Resource,omitempty"`
-	RequestID string    `xml:"RequestId,omitempty"`
-}
-
-// errorInfo holds error details for writing responses.
-type errorInfo struct {
-	HTTPStatus int
-	Code       ErrorCode
-	Message    string
-}
-
-// errorMap maps error codes to HTTP status and messages.
-var errorMap = map[ErrorCode]errorInfo{
-	ErrAccessDenied:                 {http.StatusForbidden, ErrAccessDenied, "Access Denied"},
-	ErrBucketNotEmpty:               {http.StatusConflict, ErrBucketNotEmpty, "The bucket you tried to delete is not empty"},
-	ErrBucketAlreadyExists:          {http.StatusConflict, ErrBucketAlreadyExists, "The requested bucket name is not available"},
-	ErrBucketAlreadyOwnedByYou:      {http.StatusConflict, ErrBucketAlreadyOwnedByYou, "Your previous request to create the named bucket succeeded"},
-	ErrNoSuchBucket:                 {http.StatusNotFound, ErrNoSuchBucket, "The specified bucket does not exist"},
-	ErrNoSuchKey:                    {http.StatusNotFound, ErrNoSuchKey, "The specified key does not exist"},
-	ErrNoSuchUpload:                 {http.StatusNotFound, ErrNoSuchUpload, "The specified multipart upload does not exist"},
-	ErrInvalidAccessKeyId:           {http.StatusForbidden, ErrInvalidAccessKeyId, "The AWS access key ID you provided does not exist in our records"},
-	ErrSignatureDoesNotMatch:        {http.StatusForbidden, ErrSignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided"},
-	ErrInvalidBucketName:            {http.StatusBadRequest, ErrInvalidBucketName, "The specified bucket is not valid"},
-	ErrInvalidObjectName:            {http.StatusBadRequest, ErrInvalidObjectName, "Object name is not valid"},
-	ErrInvalidPart:                  {http.StatusBadRequest, ErrInvalidPart, "One or more of the specified parts could not be found"},
-	ErrInvalidPartNumber:            {http.StatusBadRequest, ErrInvalidPartNumber, "The part number you specified is not valid"},
-	ErrInvalidPartOrder:             {http.StatusBadRequest, ErrInvalidPartOrder, "The list of parts was not in ascending order"},
-	ErrInternalError:                {http.StatusInternalServerError, ErrInternalError, "We encountered an internal error. Please try again."},
-	ErrMalformedXML:                 {http.StatusBadRequest, ErrMalformedXML, "The XML you provided was not well-formed"},
-	ErrMethodNotAllowed:             {http.StatusMethodNotAllowed, ErrMethodNotAllowed, "The specified method is not allowed against this resource"},
-	ErrNotImplemented:               {http.StatusNotImplemented, ErrNotImplemented, "A header you provided implies functionality that is not implemented"},
-	ErrRequestTimeout:               {http.StatusBadRequest, ErrRequestTimeout, "Your socket connection to the server was not read from or written to within the timeout period"},
-	ErrServiceUnavailable:           {http.StatusServiceUnavailable, ErrServiceUnavailable, "Service is unable to handle request"},
-	ErrSlowDown:                     {http.StatusServiceUnavailable, ErrSlowDown, "Please reduce your request rate"},
-	ErrInvalidRequest:               {http.StatusBadRequest, ErrInvalidRequest, "Invalid Request"},
-	ErrMissingContentLength:         {http.StatusLengthRequired, ErrMissingContentLength, "You must provide the Content-Length HTTP header"},
-	ErrIncompleteBody:               {http.StatusBadRequest, ErrIncompleteBody, "You did not provide the number of bytes specified by the Content-Length HTTP header"},
-	ErrInvalidRange:                 {http.StatusRequestedRangeNotSatisfiable, ErrInvalidRange, "The requested range is not satisfiable"},
-	ErrAuthorizationHeaderMalformed: {http.StatusBadRequest, ErrAuthorizationHeaderMalformed, "The authorization header is malformed"},
-	ErrInvalidArgument:              {http.StatusBadRequest, ErrInvalidArgument, "Invalid argument"},
-	ErrBadContentLength:             {http.StatusBadRequest, ErrBadContentLength, "The Content-Length you specified is invalid"},
-}
-
-// WriteError writes an S3 error response.
-func WriteError(w http.ResponseWriter, r *http.Request, code ErrorCode) {
-	info, ok := errorMap[code]
-	if !ok {
-		info = errorInfo{http.StatusInternalServerError, ErrInternalError, "Internal Server Error"}
-	}
-
-	WriteErrorWithMessage(w, r, code, info.Message)
-}
-
-// WriteErrorWithMessage writes an S3 error response with a custom message.
-func WriteErrorWithMessage(w http.ResponseWriter, r *http.Request, code ErrorCode, message string) {
-	info, ok := errorMap[code]
-	if !ok {
-		info = errorInfo{http.StatusInternalServerError, ErrInternalError, message}
-	}
-
-	resp := ErrorResponse{
-		Code:      code,
-		Message:   message,
-		Resource:  r.URL.Path,
-		RequestID: r.Header.Get("X-Request-ID"),
-	}
-
-	log.Debug().
-		Int("status", info.HTTPStatus).
-		Str("code", string(code)).
-		Str("message", message).
-		Str("path", r.URL.Path).
-		Msg("S3 error response")
-
-	w.Header().Set("Content-Type", "application/xml")
-	w.WriteHeader(info.HTTPStatus)
-	if err := xml.NewEncoder(w).Encode(resp); err != nil {
-		log.Error().Err(err).Msg("Failed to encode error response")
-	}
-}
-
-// WriteInternalError writes an internal server error response.
-func WriteInternalError(w http.ResponseWriter, r *http.Request, err error) {
-	log.Error().Err(err).Str("path", r.URL.Path).Msg("Internal error")
-	WriteError(w, r, ErrInternalError)
-}
 
 // WriteAuthError writes an S3 error response for authentication errors.
 // It maps proxy.AuthErrorCode to the appropriate S3 error code.
@@ -149,20 +21,20 @@ func WriteAuthError(w http.ResponseWriter, r *http.Request, code int, err error)
 		errCodeInternal          = 4
 	)
 
-	var s3Code ErrorCode
+	var s3Code s3err.ErrorCode
 	switch code {
 	case errCodeSignatureMismatch:
-		s3Code = ErrSignatureDoesNotMatch
+		s3Code = s3err.ErrSignatureDoesNotMatch
 	case errCodeInvalidAccessKey:
-		s3Code = ErrInvalidAccessKeyId
+		s3Code = s3err.ErrInvalidAccessKeyId
 	case errCodeExpiredRequest:
-		s3Code = ErrAccessDenied
+		s3Code = s3err.ErrAccessDenied
 	case errCodeMalformedAuth:
-		s3Code = ErrAuthorizationHeaderMalformed
+		s3Code = s3err.ErrAuthorizationHeaderMalformed
 	default:
-		s3Code = ErrInternalError
+		s3Code = s3err.ErrInternalError
 	}
 
 	log.Warn().Err(err).Str("path", r.URL.Path).Str("s3_code", string(s3Code)).Msg("Auth error")
-	WriteError(w, r, s3Code)
+	s3err.WriteError(w, r, s3Code)
 }

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy"
+	"github.com/tigrisdata/tag/s3err"
 )
 
 // Server is the HTTP server for S3-compatible API.
@@ -274,7 +275,7 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		WriteAuthError(w, r, int(authErr.Code), err)
 		return
 	}
-	WriteInternalError(w, r, err)
+	s3err.WriteInternalError(w, r, err)
 }
 
 // getBucketName extracts the bucket name from request path variables.
@@ -302,42 +303,42 @@ func validateBucketName(w http.ResponseWriter, r *http.Request) bool {
 	bucket := getBucketName(r)
 	if bucket == "" {
 		log.Error().Str("path", r.URL.Path).Msg("Empty bucket name")
-		WriteError(w, r, ErrInvalidArgument)
+		s3err.WriteError(w, r, s3err.ErrInvalidArgument)
 		return false
 	}
 
 	// Length check: 3-63 characters
 	if len(bucket) < 3 || len(bucket) > 63 {
 		log.Debug().Str("bucket", bucket).Msg("Bucket name length invalid")
-		WriteError(w, r, ErrInvalidBucketName)
+		s3err.WriteError(w, r, s3err.ErrInvalidBucketName)
 		return false
 	}
 
 	// Must match valid pattern (start/end with letter or number)
 	if !validBucketNameRegex.MatchString(bucket) {
 		log.Debug().Str("bucket", bucket).Msg("Bucket name format invalid")
-		WriteError(w, r, ErrInvalidBucketName)
+		s3err.WriteError(w, r, s3err.ErrInvalidBucketName)
 		return false
 	}
 
 	// Cannot contain consecutive dots (..)
 	if strings.Contains(bucket, "..") {
 		log.Debug().Str("bucket", bucket).Msg("Bucket name contains consecutive dots")
-		WriteError(w, r, ErrInvalidBucketName)
+		s3err.WriteError(w, r, s3err.ErrInvalidBucketName)
 		return false
 	}
 
 	// Cannot contain dot-dash (.-) or dash-dot (-.)
 	if strings.Contains(bucket, ".-") || strings.Contains(bucket, "-.") {
 		log.Debug().Str("bucket", bucket).Msg("Bucket name contains invalid dot-dash pattern")
-		WriteError(w, r, ErrInvalidBucketName)
+		s3err.WriteError(w, r, s3err.ErrInvalidBucketName)
 		return false
 	}
 
 	// Cannot contain underscore
 	if strings.Contains(bucket, "_") {
 		log.Debug().Str("bucket", bucket).Msg("Bucket name contains underscore")
-		WriteError(w, r, ErrInvalidBucketName)
+		s3err.WriteError(w, r, s3err.ErrInvalidBucketName)
 		return false
 	}
 
@@ -354,12 +355,12 @@ func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
 	if proxy.IsStreamingPayload(r.Header.Get("X-Amz-Content-Sha256")) {
 		v := r.Header.Get("X-Amz-Decoded-Content-Length")
 		if v == "" {
-			WriteError(w, r, ErrMissingContentLength)
+			s3err.WriteError(w, r, s3err.ErrMissingContentLength)
 			return false
 		}
 		decodedLen, err := strconv.ParseInt(v, 10, 64)
 		if err != nil || decodedLen < 0 {
-			WriteError(w, r, ErrBadContentLength)
+			s3err.WriteError(w, r, s3err.ErrBadContentLength)
 			return false
 		}
 		return true
@@ -367,16 +368,16 @@ func validateContentLength(w http.ResponseWriter, r *http.Request) bool {
 
 	v := r.Header.Get("Content-Length")
 	if v == "" {
-		WriteError(w, r, ErrMissingContentLength)
+		s3err.WriteError(w, r, s3err.ErrMissingContentLength)
 		return false
 	}
 	contentLength, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		WriteError(w, r, ErrBadContentLength)
+		s3err.WriteError(w, r, s3err.ErrBadContentLength)
 		return false
 	}
 	if contentLength < 0 {
-		WriteError(w, r, ErrBadContentLength)
+		s3err.WriteError(w, r, s3err.ErrBadContentLength)
 		return false
 	}
 	return true
@@ -413,7 +414,7 @@ func (s *Server) handleObject(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		handler = s.service.HandleDeleteObject
 	default:
-		WriteError(w, r, ErrMethodNotAllowed)
+		s3err.WriteError(w, r, s3err.ErrMethodNotAllowed)
 		return
 	}
 
@@ -430,7 +431,7 @@ func (s *Server) handleBucket(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete:
 		handleWithError(w, r, s.service.HandlePassthrough)
 	default:
-		WriteError(w, r, ErrMethodNotAllowed)
+		s3err.WriteError(w, r, s3err.ErrMethodNotAllowed)
 	}
 }
 

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -158,6 +158,7 @@ func newBaseForwarder(tigrisEndpoint, region string, maxIdleConnsPerHost int) ba
 				MaxIdleConns:        maxIdleConnsPerHost,
 				MaxIdleConnsPerHost: maxIdleConnsPerHost,
 				IdleConnTimeout:     90 * time.Second,
+				DisableCompression:  true, // Proxy must never auto-decompress upstream responses
 			},
 			Timeout: 5 * time.Minute,
 		},
@@ -195,6 +196,7 @@ func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Req
 	}
 	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
 
+	logUpstreamResponse(fwdReq, originalReq, resp.StatusCode, upstreamStart)
 	return nil
 }
 
@@ -243,6 +245,7 @@ func (b *baseForwarder) executeAndCapture(w http.ResponseWriter, fwdReq *http.Re
 	// Track bytes out from response body
 	metrics.BytesTransferred.WithLabelValues("out").Add(float64(len(capture.Body)))
 
+	logUpstreamResponse(fwdReq, originalReq, resp.StatusCode, upstreamStart)
 	return capture, nil
 }
 
@@ -398,6 +401,21 @@ func ensureAWSChunkedEncoding(req *http.Request) {
 
 	// Prepend aws-chunked (it's the outermost encoding layer)
 	req.Header.Set("Content-Encoding", "aws-chunked,"+ce)
+}
+
+// logUpstreamResponse logs a completed upstream request at debug level.
+func logUpstreamResponse(fwdReq *http.Request, originalReq *http.Request, statusCode int, upstreamStart time.Time) {
+	host := fwdReq.URL.Host
+	if originalReq != nil && originalReq.Host != "" {
+		host = originalReq.Host
+	}
+	log.Debug().
+		Str("method", fwdReq.Method).
+		Str("path", fwdReq.URL.Path).
+		Str("host", host).
+		Int("status", statusCode).
+		Int64("upstream_ms", time.Since(upstreamStart).Milliseconds()).
+		Msg("Upstream response")
 }
 
 // ResponseCapture holds captured response data.

--- a/proxy/forwarder_transparent.go
+++ b/proxy/forwarder_transparent.go
@@ -290,11 +290,15 @@ func (f *transparentForwarder) learnSigningKeys(resp *http.Response, r *http.Req
 		return
 	}
 
+	newKeys := 0
 	for _, entry := range entries {
 		keyBytes, err := hex.DecodeString(entry.SigningKey)
 		if err != nil {
 			log.Warn().Err(err).Str("date", entry.Date).Msg("Failed to decode signing key hex")
 			continue
+		}
+		if _, err := f.derivedKeyStore.GetSigningKey(authInfo.AccessKey, entry.Date, entry.Region); err != nil {
+			newKeys++
 		}
 		f.derivedKeyStore.Store(authInfo.AccessKey, entry.Date, entry.Region, keyBytes)
 	}
@@ -302,11 +306,13 @@ func (f *transparentForwarder) learnSigningKeys(resp *http.Response, r *http.Req
 	bucket, _ := ParseBucketKey(r)
 	f.authzCache.Grant(authInfo.AccessKey, bucket)
 
-	log.Debug().
-		Str("bucket", bucket).
-		Int("keys_learned", len(entries)).
-		Int("store_size", f.derivedKeyStore.Count()).
-		Msg("Signing keys learned successfully")
+	if newKeys > 0 {
+		log.Debug().
+			Str("bucket", bucket).
+			Int("keys_learned", newKeys).
+			Int("store_size", f.derivedKeyStore.Count()).
+			Msg("Signing keys learned successfully")
+	}
 
 	metrics.ProxySigningKeysReceived.Inc()
 	metrics.DerivedKeyStoreSize.Set(float64(f.derivedKeyStore.Count()))
@@ -326,4 +332,14 @@ func (f *transparentForwarder) handleAuthzRevocation(resp *http.Response, r *htt
 
 	bucket, _ := ParseBucketKey(r)
 	f.authzCache.Revoke(authInfo.AccessKey, bucket)
+	log.Debug().Str("access_key", maskAccessKey(authInfo.AccessKey)).Str("bucket", bucket).Msg("Authorization revoked (upstream 403)")
+}
+
+// maskAccessKey returns the last 4 characters of an access key prefixed with "...",
+// or the full key if it's too short to mask.
+func maskAccessKey(key string) string {
+	if len(key) <= 4 {
+		return key
+	}
+	return "..." + key[len(key)-4:]
 }

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy/broadcast"
+	"github.com/tigrisdata/tag/s3err"
 )
 
 // bufferPool provides reusable buffers for small object caching.
@@ -101,7 +102,7 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			// serve the range from the cached object
 			if rangeHeader != "" {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-				return s.serveRangeFromCache(ctx, w, bucket, key, meta, rangeHeader, start)
+				return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 			}
 
 			// Check conditional request: If-None-Match
@@ -579,6 +580,7 @@ func parseRangeHeader(rangeHeader string, totalSize int64) ([]byteRange, error) 
 func (s *Service) serveRangeFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
+	r *http.Request,
 	bucket, key string,
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
@@ -587,10 +589,9 @@ func (s *Service) serveRangeFromCache(
 	// Parse Range header
 	ranges, err := parseRangeHeader(rangeHeader, meta.ContentLength)
 	if err != nil || len(ranges) == 0 {
-		// Invalid range - return 416 Range Not Satisfiable
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
 		w.Header().Set(XCacheHeader, XCacheHit)
-		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
 		return nil
 	}
@@ -598,27 +599,16 @@ func (s *Service) serveRangeFromCache(
 	// Only support single range (multi-range is complex and rare)
 	if len(ranges) > 1 {
 		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Multi-range not supported from cache")
-		// For multi-range, return 416 - we don't support it
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
 		w.Header().Set(XCacheHeader, XCacheHit)
-		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
 		return nil
 	}
 
 	rng := ranges[0]
-	contentLength := rng.end - rng.start + 1
 
-	// Set response headers
-	if meta.ContentType != "" {
-		w.Header().Set("Content-Type", meta.ContentType)
-	}
-	w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, meta.ContentLength))
-	if meta.ETag != "" {
-		w.Header().Set("ETag", meta.ETag)
-	}
-	w.Header().Set("Accept-Ranges", "bytes")
+	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	w.Header().Set(XCacheHeader, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
 

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -183,7 +183,6 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 
 // HandlePassthrough handles requests that are passed through without caching.
 func (s *Service) HandlePassthrough(w http.ResponseWriter, r *http.Request) error {
-	log.Debug().Str("method", r.Method).Str("path", r.URL.Path).Msg("HandlePassthrough")
 	return s.forwarder.Forward(r.Context(), w, r)
 }
 

--- a/s3err/errors.go
+++ b/s3err/errors.go
@@ -1,0 +1,137 @@
+// Package s3err provides S3-compatible error types and response writers.
+package s3err
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ErrorCode represents an S3 error code.
+type ErrorCode string
+
+// S3 Error codes
+const (
+	ErrNone                         ErrorCode = ""
+	ErrAccessDenied                 ErrorCode = "AccessDenied"
+	ErrBucketNotEmpty               ErrorCode = "BucketNotEmpty"
+	ErrBucketAlreadyExists          ErrorCode = "BucketAlreadyExists"
+	ErrBucketAlreadyOwnedByYou      ErrorCode = "BucketAlreadyOwnedByYou"
+	ErrNoSuchBucket                 ErrorCode = "NoSuchBucket"
+	ErrNoSuchKey                    ErrorCode = "NoSuchKey"
+	ErrNoSuchUpload                 ErrorCode = "NoSuchUpload"
+	ErrInvalidAccessKeyId           ErrorCode = "InvalidAccessKeyId"
+	ErrSignatureDoesNotMatch        ErrorCode = "SignatureDoesNotMatch"
+	ErrInvalidBucketName            ErrorCode = "InvalidBucketName"
+	ErrInvalidObjectName            ErrorCode = "InvalidObjectName"
+	ErrInvalidPart                  ErrorCode = "InvalidPart"
+	ErrInvalidPartNumber            ErrorCode = "InvalidPartNumber"
+	ErrInvalidPartOrder             ErrorCode = "InvalidPartOrder"
+	ErrInternalError                ErrorCode = "InternalError"
+	ErrMalformedXML                 ErrorCode = "MalformedXML"
+	ErrMethodNotAllowed             ErrorCode = "MethodNotAllowed"
+	ErrNotImplemented               ErrorCode = "NotImplemented"
+	ErrRequestTimeout               ErrorCode = "RequestTimeout"
+	ErrServiceUnavailable           ErrorCode = "ServiceUnavailable"
+	ErrSlowDown                     ErrorCode = "SlowDown"
+	ErrInvalidRequest               ErrorCode = "InvalidRequest"
+	ErrMissingContentLength         ErrorCode = "MissingContentLength"
+	ErrIncompleteBody               ErrorCode = "IncompleteBody"
+	ErrInvalidRange                 ErrorCode = "InvalidRange"
+	ErrAuthorizationHeaderMalformed ErrorCode = "AuthorizationHeaderMalformed"
+	ErrInvalidArgument              ErrorCode = "InvalidArgument"
+	ErrBadContentLength             ErrorCode = "BadContentLength"
+)
+
+// ErrorResponse represents an S3 error response.
+type ErrorResponse struct {
+	XMLName   xml.Name  `xml:"Error"`
+	Code      ErrorCode `xml:"Code"`
+	Message   string    `xml:"Message"`
+	Resource  string    `xml:"Resource,omitempty"`
+	RequestID string    `xml:"RequestId,omitempty"`
+}
+
+// errorInfo holds error details for writing responses.
+type errorInfo struct {
+	HTTPStatus int
+	Code       ErrorCode
+	Message    string
+}
+
+// errorMap maps error codes to HTTP status and messages.
+var errorMap = map[ErrorCode]errorInfo{
+	ErrAccessDenied:                 {http.StatusForbidden, ErrAccessDenied, "Access Denied"},
+	ErrBucketNotEmpty:               {http.StatusConflict, ErrBucketNotEmpty, "The bucket you tried to delete is not empty"},
+	ErrBucketAlreadyExists:          {http.StatusConflict, ErrBucketAlreadyExists, "The requested bucket name is not available"},
+	ErrBucketAlreadyOwnedByYou:      {http.StatusConflict, ErrBucketAlreadyOwnedByYou, "Your previous request to create the named bucket succeeded"},
+	ErrNoSuchBucket:                 {http.StatusNotFound, ErrNoSuchBucket, "The specified bucket does not exist"},
+	ErrNoSuchKey:                    {http.StatusNotFound, ErrNoSuchKey, "The specified key does not exist"},
+	ErrNoSuchUpload:                 {http.StatusNotFound, ErrNoSuchUpload, "The specified multipart upload does not exist"},
+	ErrInvalidAccessKeyId:           {http.StatusForbidden, ErrInvalidAccessKeyId, "The AWS access key ID you provided does not exist in our records"},
+	ErrSignatureDoesNotMatch:        {http.StatusForbidden, ErrSignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided"},
+	ErrInvalidBucketName:            {http.StatusBadRequest, ErrInvalidBucketName, "The specified bucket is not valid"},
+	ErrInvalidObjectName:            {http.StatusBadRequest, ErrInvalidObjectName, "Object name is not valid"},
+	ErrInvalidPart:                  {http.StatusBadRequest, ErrInvalidPart, "One or more of the specified parts could not be found"},
+	ErrInvalidPartNumber:            {http.StatusBadRequest, ErrInvalidPartNumber, "The part number you specified is not valid"},
+	ErrInvalidPartOrder:             {http.StatusBadRequest, ErrInvalidPartOrder, "The list of parts was not in ascending order"},
+	ErrInternalError:                {http.StatusInternalServerError, ErrInternalError, "We encountered an internal error. Please try again."},
+	ErrMalformedXML:                 {http.StatusBadRequest, ErrMalformedXML, "The XML you provided was not well-formed"},
+	ErrMethodNotAllowed:             {http.StatusMethodNotAllowed, ErrMethodNotAllowed, "The specified method is not allowed against this resource"},
+	ErrNotImplemented:               {http.StatusNotImplemented, ErrNotImplemented, "A header you provided implies functionality that is not implemented"},
+	ErrRequestTimeout:               {http.StatusBadRequest, ErrRequestTimeout, "Your socket connection to the server was not read from or written to within the timeout period"},
+	ErrServiceUnavailable:           {http.StatusServiceUnavailable, ErrServiceUnavailable, "Service is unable to handle request"},
+	ErrSlowDown:                     {http.StatusServiceUnavailable, ErrSlowDown, "Please reduce your request rate"},
+	ErrInvalidRequest:               {http.StatusBadRequest, ErrInvalidRequest, "Invalid Request"},
+	ErrMissingContentLength:         {http.StatusLengthRequired, ErrMissingContentLength, "You must provide the Content-Length HTTP header"},
+	ErrIncompleteBody:               {http.StatusBadRequest, ErrIncompleteBody, "You did not provide the number of bytes specified by the Content-Length HTTP header"},
+	ErrInvalidRange:                 {http.StatusRequestedRangeNotSatisfiable, ErrInvalidRange, "The requested range is not satisfiable"},
+	ErrAuthorizationHeaderMalformed: {http.StatusBadRequest, ErrAuthorizationHeaderMalformed, "The authorization header is malformed"},
+	ErrInvalidArgument:              {http.StatusBadRequest, ErrInvalidArgument, "Invalid argument"},
+	ErrBadContentLength:             {http.StatusBadRequest, ErrBadContentLength, "The Content-Length you specified is invalid"},
+}
+
+// WriteError writes an S3 error response.
+func WriteError(w http.ResponseWriter, r *http.Request, code ErrorCode) {
+	info, ok := errorMap[code]
+	if !ok {
+		info = errorInfo{http.StatusInternalServerError, ErrInternalError, "Internal Server Error"}
+	}
+
+	WriteErrorWithMessage(w, r, code, info.Message)
+}
+
+// WriteErrorWithMessage writes an S3 error response with a custom message.
+func WriteErrorWithMessage(w http.ResponseWriter, r *http.Request, code ErrorCode, message string) {
+	info, ok := errorMap[code]
+	if !ok {
+		info = errorInfo{http.StatusInternalServerError, ErrInternalError, message}
+	}
+
+	resp := ErrorResponse{
+		Code:      code,
+		Message:   message,
+		Resource:  r.URL.Path,
+		RequestID: r.Header.Get("X-Request-ID"),
+	}
+
+	log.Debug().
+		Int("status", info.HTTPStatus).
+		Str("code", string(code)).
+		Str("message", message).
+		Str("path", r.URL.Path).
+		Msg("S3 error response")
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(info.HTTPStatus)
+	if err := xml.NewEncoder(w).Encode(resp); err != nil {
+		log.Error().Err(err).Msg("Failed to encode error response")
+	}
+}
+
+// WriteInternalError writes an internal server error response.
+func WriteInternalError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Error().Err(err).Str("path", r.URL.Path).Msg("Internal error")
+	WriteError(w, r, ErrInternalError)
+}

--- a/tests/s3compat/sdk/go_sdk_test.go
+++ b/tests/s3compat/sdk/go_sdk_test.go
@@ -1233,3 +1233,594 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 
 	t.Logf("User metadata caching verified")
 }
+
+// ============================================================================
+// Extended S3 Operation Tests
+// These tests cover additional S3 scenarios from the Tigris e2e test suite.
+// ============================================================================
+
+// TestSDK_PutObject_1MB verifies PUT and GET of a 1MB object.
+func TestSDK_PutObject_1MB(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("put-1mb")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	objectData := make([]byte, 1024*1024)
+	rand.Read(objectData)
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("1mb-key"),
+		Body:   bytes.NewReader(objectData),
+	})
+	if err != nil {
+		t.Fatalf("PutObject failed: %v", err)
+	}
+
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("1mb-key"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	if !bytes.Equal(body, objectData) {
+		t.Error("1MB PUT: downloaded content does not match original")
+	}
+}
+
+// TestSDK_MultipartUpload_MultipleParts verifies multipart upload with two 5MB parts
+// and full content verification via GET.
+func TestSDK_MultipartUpload_MultipleParts(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("multipart-multi")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	createResult, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-multi-key"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload failed: %v", err)
+	}
+
+	const partSize = 5 * 1024 * 1024
+	part1Data := make([]byte, partSize)
+	part2Data := make([]byte, partSize)
+	rand.Read(part1Data)
+	rand.Read(part2Data)
+
+	uploadResult1, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("multipart-multi-key"),
+		UploadId:   createResult.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       bytes.NewReader(part1Data),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 1 failed: %v", err)
+	}
+
+	uploadResult2, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("multipart-multi-key"),
+		UploadId:   createResult.UploadId,
+		PartNumber: aws.Int32(2),
+		Body:       bytes.NewReader(part2Data),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 2 failed: %v", err)
+	}
+
+	_, err = client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("multipart-multi-key"),
+		UploadId: createResult.UploadId,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{
+				{ETag: uploadResult1.ETag, PartNumber: aws.Int32(1)},
+				{ETag: uploadResult2.ETag, PartNumber: aws.Int32(2)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload failed: %v", err)
+	}
+
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-multi-key"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	expectedData := append(part1Data, part2Data...)
+	if !bytes.Equal(body, expectedData) {
+		t.Errorf("Multipart upload content mismatch: got %d bytes, want %d bytes", len(body), len(expectedData))
+	}
+}
+
+// TestSDK_MultipartUpload_SmallPart verifies multipart upload with a single small
+// (16KB) part, matching the small-part scenario from the Tigris e2e test suite.
+func TestSDK_MultipartUpload_SmallPart(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("multipart-small")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	createResult, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-small-key"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload failed: %v", err)
+	}
+
+	partData := make([]byte, 16*1024)
+	rand.Read(partData)
+
+	uploadResult, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("multipart-small-key"),
+		UploadId:   createResult.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       bytes.NewReader(partData),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart failed: %v", err)
+	}
+
+	_, err = client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("multipart-small-key"),
+		UploadId: createResult.UploadId,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{
+				{ETag: uploadResult.ETag, PartNumber: aws.Int32(1)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload failed: %v", err)
+	}
+
+	result, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-small-key"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject verification failed: %v", err)
+	}
+	defer result.Body.Close()
+
+	body, _ := io.ReadAll(result.Body)
+	if !bytes.Equal(body, partData) {
+		t.Errorf("Small multipart upload content mismatch: got %d bytes, want %d bytes", len(body), len(partData))
+	}
+}
+
+// TestSDK_MultipartUpload_Abort verifies that AbortMultipartUpload correctly cancels
+// an in-progress multipart upload.
+func TestSDK_MultipartUpload_Abort(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("multipart-abort")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	createResult, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-abort-key"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload failed: %v", err)
+	}
+
+	partData := make([]byte, 16*1024)
+	rand.Read(partData)
+
+	_, err = client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("multipart-abort-key"),
+		UploadId:   createResult.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       bytes.NewReader(partData),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart failed: %v", err)
+	}
+
+	_, err = client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("multipart-abort-key"),
+		UploadId: createResult.UploadId,
+	})
+	if err != nil {
+		t.Fatalf("AbortMultipartUpload failed: %v", err)
+	}
+
+	_, err = client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("multipart-abort-key"),
+	})
+	if err == nil {
+		t.Error("Expected error when getting aborted multipart object, got nil")
+	}
+}
+
+// TestSDK_GetObjectRange_Comprehensive verifies various range request scenarios,
+// matching the comprehensive range test coverage from the Tigris e2e suite.
+// Uses a 1024-byte random object and verifies byte-for-byte content for each range.
+func TestSDK_GetObjectRange_Comprehensive(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("range-comprehensive")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	const objSize = 1024
+	objectData := make([]byte, objSize)
+	rand.Read(objectData)
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("range-key"),
+		Body:   bytes.NewReader(objectData),
+	})
+	if err != nil {
+		t.Fatalf("PutObject failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		rangeHdr string
+		expected []byte
+	}{
+		{"first 128 bytes", "bytes=0-127", objectData[0:128]},
+		{"open-ended from start", "bytes=0-", objectData[0:]},
+		{"open-ended from middle", "bytes=128-", objectData[128:]},
+		{"middle range", "bytes=128-511", objectData[128:512]},
+		{"exact full range", "bytes=0-1023", objectData[0:]},
+		{"single byte at start", "bytes=0-0", objectData[0:1]},
+		{"two bytes from start", "bytes=0-1", objectData[0:2]},
+		{"end beyond object size", "bytes=0-4096", objectData[0:]},
+		{"start valid end beyond size", "bytes=512-4096", objectData[512:]},
+		{"suffix last 128 bytes", "bytes=-128", objectData[objSize-128:]},
+		{"suffix larger than object", "bytes=-4096", objectData[0:]},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String("range-key"),
+				Range:  aws.String(tc.rangeHdr),
+			})
+			if err != nil {
+				t.Fatalf("GetObject with Range %q failed: %v", tc.rangeHdr, err)
+			}
+			defer result.Body.Close()
+
+			body, _ := io.ReadAll(result.Body)
+			if !bytes.Equal(body, tc.expected) {
+				t.Errorf("Range %q: got %d bytes, want %d bytes", tc.rangeHdr, len(body), len(tc.expected))
+			}
+		})
+	}
+}
+
+// TestSDK_GetObjectRange_Invalid verifies that invalid range requests return errors.
+// Tests ranges where the start position is at or beyond the object size.
+func TestSDK_GetObjectRange_Invalid(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("range-invalid")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	objectData := make([]byte, 1024)
+	rand.Read(objectData)
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("range-invalid-key"),
+		Body:   bytes.NewReader(objectData),
+	})
+	if err != nil {
+		t.Fatalf("PutObject failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		rangeHdr string
+	}{
+		{"start equals object size", "bytes=1024-"},
+		{"start beyond object size", "bytes=1024-4096"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String("range-invalid-key"),
+				Range:  aws.String(tc.rangeHdr),
+			})
+			if err == nil {
+				t.Errorf("Expected error for invalid range %q, got nil", tc.rangeHdr)
+			}
+		})
+	}
+}
+
+// TestSDK_ContentEncodingPreservation verifies that Content-Encoding is preserved
+// through the proxy without altering the object data. The proxy must not attempt
+// to decompress or modify data based on Content-Encoding headers.
+func TestSDK_ContentEncodingPreservation(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("content-encoding")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		size int
+	}{
+		{"512B", 512},
+		{"1MB", 1024 * 1024},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := "ce-" + tc.name
+			objectData := make([]byte, tc.size)
+			rand.Read(objectData)
+
+			_, err := client.PutObject(ctx, &s3.PutObjectInput{
+				Bucket:          aws.String(bucket),
+				Key:             aws.String(key),
+				Body:            bytes.NewReader(objectData),
+				ContentEncoding: aws.String("gzip"),
+			})
+			if err != nil {
+				t.Fatalf("PutObject failed: %v", err)
+			}
+
+			// Verify content is returned unmodified
+			getResult, err := client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+			if err != nil {
+				t.Fatalf("GetObject failed: %v", err)
+			}
+			defer getResult.Body.Close()
+
+			body, _ := io.ReadAll(getResult.Body)
+			if !bytes.Equal(body, objectData) {
+				t.Errorf("Content mismatch: got %d bytes, want %d bytes", len(body), len(objectData))
+			}
+
+			// Verify Content-Encoding header is preserved
+			headResult, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+			if err != nil {
+				t.Fatalf("HeadObject failed: %v", err)
+			}
+
+			if aws.ToString(headResult.ContentEncoding) != "gzip" {
+				t.Errorf("Expected Content-Encoding %q, got %q", "gzip", aws.ToString(headResult.ContentEncoding))
+			}
+		})
+	}
+}
+
+// TestSDK_PutObject_Checksum verifies that checksums are preserved through the proxy
+// for PutObject operations. Tests SHA256, CRC32, and CRC32C at small (512B) and
+// medium (32KB) sizes, matching the Tigris e2e checksum test suite.
+func TestSDK_PutObject_Checksum(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("checksum-put")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		algo types.ChecksumAlgorithm
+		size int
+	}{
+		{"SHA256_512B", types.ChecksumAlgorithmSha256, 512},
+		{"SHA256_32KB", types.ChecksumAlgorithmSha256, 32 * 1024},
+		{"CRC32_512B", types.ChecksumAlgorithmCrc32, 512},
+		{"CRC32_32KB", types.ChecksumAlgorithmCrc32, 32 * 1024},
+		{"CRC32C_512B", types.ChecksumAlgorithmCrc32c, 512},
+		{"CRC32C_32KB", types.ChecksumAlgorithmCrc32c, 32 * 1024},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := "chk-" + tc.name
+			objectData := make([]byte, tc.size)
+			rand.Read(objectData)
+
+			_, err := client.PutObject(ctx, &s3.PutObjectInput{
+				Bucket:            aws.String(bucket),
+				Key:               aws.String(key),
+				Body:              bytes.NewReader(objectData),
+				ChecksumAlgorithm: tc.algo,
+			})
+			if err != nil {
+				t.Fatalf("PutObject failed: %v", err)
+			}
+
+			// Verify content round-trip
+			getResult, err := client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket:       aws.String(bucket),
+				Key:          aws.String(key),
+				ChecksumMode: types.ChecksumModeEnabled,
+			})
+			if err != nil {
+				t.Fatalf("GetObject failed: %v", err)
+			}
+			defer getResult.Body.Close()
+
+			body, _ := io.ReadAll(getResult.Body)
+			if !bytes.Equal(body, objectData) {
+				t.Errorf("Content mismatch: got %d bytes, want %d bytes", len(body), len(objectData))
+			}
+
+			// Verify checksum is present in GET response
+			switch tc.algo {
+			case types.ChecksumAlgorithmSha256:
+				if getResult.ChecksumSHA256 == nil || *getResult.ChecksumSHA256 == "" {
+					t.Error("Expected ChecksumSHA256 in GET response")
+				}
+			case types.ChecksumAlgorithmCrc32:
+				if getResult.ChecksumCRC32 == nil || *getResult.ChecksumCRC32 == "" {
+					t.Error("Expected ChecksumCRC32 in GET response")
+				}
+			case types.ChecksumAlgorithmCrc32c:
+				if getResult.ChecksumCRC32C == nil || *getResult.ChecksumCRC32C == "" {
+					t.Error("Expected ChecksumCRC32C in GET response")
+				}
+			}
+		})
+	}
+}
+
+// TestSDK_MultipartUpload_Checksum verifies that checksums are preserved through the
+// proxy for multipart uploads. Uses SHA256 with two 5MB parts and verifies content
+// round-trip and composite checksum presence.
+func TestSDK_MultipartUpload_Checksum(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("checksum-multipart")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	client := globalEnv.GetS3Client()
+	ctx := context.Background()
+
+	createResult, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String("chk-multipart-key"),
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload failed: %v", err)
+	}
+
+	const partSize = 5 * 1024 * 1024
+	part1Data := make([]byte, partSize)
+	part2Data := make([]byte, partSize)
+	rand.Read(part1Data)
+	rand.Read(part2Data)
+
+	uploadResult1, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String("chk-multipart-key"),
+		UploadId:          createResult.UploadId,
+		PartNumber:        aws.Int32(1),
+		Body:              bytes.NewReader(part1Data),
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 1 failed: %v", err)
+	}
+	if uploadResult1.ChecksumSHA256 == nil || *uploadResult1.ChecksumSHA256 == "" {
+		t.Error("Expected ChecksumSHA256 in UploadPart 1 response")
+	}
+
+	uploadResult2, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String("chk-multipart-key"),
+		UploadId:          createResult.UploadId,
+		PartNumber:        aws.Int32(2),
+		Body:              bytes.NewReader(part2Data),
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 2 failed: %v", err)
+	}
+	if uploadResult2.ChecksumSHA256 == nil || *uploadResult2.ChecksumSHA256 == "" {
+		t.Error("Expected ChecksumSHA256 in UploadPart 2 response")
+	}
+
+	completeResult, err := client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String("chk-multipart-key"),
+		UploadId: createResult.UploadId,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{
+				{ETag: uploadResult1.ETag, PartNumber: aws.Int32(1), ChecksumSHA256: uploadResult1.ChecksumSHA256},
+				{ETag: uploadResult2.ETag, PartNumber: aws.Int32(2), ChecksumSHA256: uploadResult2.ChecksumSHA256},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload failed: %v", err)
+	}
+
+	// Composite checksum should be present (format: <hash>-<num_parts>).
+	// Some environments may not return it; log for diagnostics but don't fail,
+	// since TAG proxies the XML body faithfully and cannot add missing fields.
+	if completeResult.ChecksumSHA256 != nil && *completeResult.ChecksumSHA256 != "" {
+		t.Logf("CompleteMultipartUpload ChecksumSHA256: %s", *completeResult.ChecksumSHA256)
+	} else {
+		t.Log("CompleteMultipartUpload did not return composite ChecksumSHA256")
+	}
+
+	// Verify content round-trip
+	getResult, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket:       aws.String(bucket),
+		Key:          aws.String("chk-multipart-key"),
+		ChecksumMode: types.ChecksumModeEnabled,
+	})
+	if err != nil {
+		t.Fatalf("GetObject failed: %v", err)
+	}
+	defer getResult.Body.Close()
+
+	body, _ := io.ReadAll(getResult.Body)
+	expectedData := append(part1Data, part2Data...)
+	if !bytes.Equal(body, expectedData) {
+		t.Errorf("Content mismatch: got %d bytes, want %d bytes", len(body), len(expectedData))
+	}
+
+	// Checksum should be present when ChecksumMode is enabled.
+	// Log the result for diagnostics — TAG forwards this header from upstream.
+	if getResult.ChecksumSHA256 != nil && *getResult.ChecksumSHA256 != "" {
+		t.Logf("GetObject ChecksumSHA256: %s", *getResult.ChecksumSHA256)
+	} else {
+		t.Log("GetObject did not return ChecksumSHA256 header")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core response header/error-writing and proxy transport behavior; mistakes could break client compatibility (range semantics, content encoding) or caching correctness, though changes are localized and well-covered by new tests.
> 
> **Overview**
> Improves S3 compatibility by expanding cached object metadata/header passthrough (e.g., `Content-Encoding`, `Content-Disposition`, `Expires`, SSE, versioning/parts count) and adding `WriteHeaders` options to correctly emit range (`206`) headers via `cache.WithRangeHeaders`.
> 
> Centralizes S3 XML error definitions/writers into new `s3err` package and switches handlers/range-cache paths to use it (including returning `InvalidRange` for unsatisfiable cached ranges). Tightens proxy correctness/observability by disabling Go transport auto-decompression (`DisableCompression: true`), adding upstream response debug logging, and reducing noisy key-learning logs while masking access keys on authZ revocation.
> 
> Greatly expands `tests/s3compat/sdk` coverage for larger PUTs, multipart variants, comprehensive/invalid range behavior, content-encoding preservation, and checksum passthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 719010f6fbdafadb09508923f034507f52820dd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->