### PR TITLE
fix: fix metrics description

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,7 +11,7 @@ var (
 	RequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "tag_requests_total",
-			Help: "Total number of requests processed by TAG",
+			Help: "Total number of requests processed",
 		},
 		[]string{"operation", "status"},
 	)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String-only change to metric description; no impact to metric names, labels, or runtime behavior.
> 
> **Overview**
> Updates the Prometheus `RequestsTotal` metric metadata by changing its `Help` string to remove the TAG-specific wording (now "Total number of requests processed").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5bd2d8ee1357e2104f29fd1f86a3940ece9781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->