### PR TITLE
Release

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,7 +11,7 @@ var (
 	RequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "tag_requests_total",
-			Help: "Total number of requests processed by TAG",
+			Help: "Total number of requests processed",
 		},
 		[]string{"operation", "status"},
 	)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String-only change to metric metadata; no impact on metric names, labels, or runtime behavior.
> 
> **Overview**
> Updates the Prometheus `RequestsTotal` counter help text for `tag_requests_total` to remove the TAG-specific wording ("processed by TAG" → "processed").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edcdf69048d6f9fee5ae0243aebd58b3b52fc8ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->