### PR TITLE
Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ See [tigrisdata/tag-deploy](https://github.com/tigrisdata/tag-deploy) for comple
 
 TAG supports all S3 API endpoints supported by Tigris, including bucket operations, object operations, multipart uploads, and more. See the [Tigris S3 API documentation](https://www.tigrisdata.com/docs/api/s3/) for the complete list of supported operations.
 
-### S3 Addressing Style
+### S3 Client Usage
 
 TAG supports **path-style** S3 access only. Virtual-hosted style requests are not supported.
 
@@ -161,7 +161,7 @@ When configuring S3 clients, ensure path-style addressing is enabled. See [docs/
 - Range requests trigger background fetch of full object (if within threshold)
 - PUT/DELETE operations invalidate the cache entry
 
-See [docs/usage.md](docs/usage.md) for examples using AWS CLI and Python boto3.
+See [docs/cache-control.md](docs/cache-control.md) for detailed cache control and revalidation documentation.
 
 ## Development
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ log:
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -84,7 +84,7 @@ log:
 func TestLoad_Defaults(t *testing.T) {
 	// Create a minimal config file (empty YAML)
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte("{}"), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -129,7 +129,7 @@ log:
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -172,7 +172,7 @@ cache:
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -193,7 +193,7 @@ cache:
 func TestLoad_InvalidYAML(t *testing.T) {
 	// Create an invalid YAML file
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte("invalid: yaml: content: ["), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte("invalid: yaml: content: ["), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -284,7 +284,7 @@ server:
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -307,7 +307,7 @@ cache:
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -335,7 +335,7 @@ upstream:
   transparent_proxy: false
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -398,7 +398,7 @@ upstream:
   endpoint: "https://evil.example.com"
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -441,7 +441,7 @@ cache:
   grpc_auth: false
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -524,7 +524,7 @@ server:
   tls_key_file: "/etc/tag/tls/key.pem"
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -564,7 +564,7 @@ server:
   tls_key_file: "/file/key.pem"
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -590,7 +590,7 @@ server:
   tls_cert_file: "/path/cert.pem"
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
@@ -606,7 +606,7 @@ server:
   tls_key_file: "/path/key.pem"
 `
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 

--- a/docs/cache-control.md
+++ b/docs/cache-control.md
@@ -1,0 +1,64 @@
+# Cache Control & Revalidation
+
+TAG supports RFC 7234-compliant cache revalidation. Clients can control caching behavior using standard `Cache-Control` headers, and TAG reports cache status via the `X-Cache` response header.
+
+## X-Cache Header Reference
+
+| Value         | Meaning                                                                          |
+| ------------- | -------------------------------------------------------------------------------- |
+| `HIT`         | Served from cache (includes revalidation that confirmed the object is unchanged) |
+| `MISS`        | Not in cache, fetched from upstream and now cached                               |
+| `REVALIDATED` | Revalidated with upstream, object changed, new content returned                  |
+| `BYPASS`      | Cache bypassed entirely (client requested `no-store`)                            |
+| `DISABLED`    | Caching is disabled server-side (`TAG_CACHE_DISABLED=true`)                      |
+
+## Force Revalidation
+
+Send `Cache-Control: no-cache` or `Cache-Control: max-age=0` to force TAG to check with upstream before serving a cached object. TAG sends a conditional request using the cached ETag. If the object hasn't changed, upstream returns 304 and TAG serves from cache (`X-Cache: HIT`). If changed, TAG streams the new content (`X-Cache: REVALIDATED`).
+
+```bash
+# Force revalidation on GET
+curl -H "Cache-Control: no-cache" http://localhost:8080/my-bucket/my-key
+
+# Force revalidation on HEAD
+curl -I -H "Cache-Control: no-cache" http://localhost:8080/my-bucket/my-key
+
+# Force revalidation on range request
+curl -H "Cache-Control: no-cache" -H "Range: bytes=0-99" \
+  http://localhost:8080/my-bucket/my-key
+```
+
+If the revalidation request to upstream fails, TAG serves the stale cached copy as a fallback.
+
+## Bypass Cache
+
+Send `Cache-Control: no-store` to skip the cache entirely. TAG forwards the request directly to upstream and does not cache the response.
+
+```bash
+curl -H "Cache-Control: no-store" http://localhost:8080/my-bucket/my-key
+```
+
+## Automatic Cache Invalidation
+
+TAG automatically invalidates cached objects when they are modified through TAG:
+
+- **PutObject** — Cache entry deleted before forwarding the upload
+- **DeleteObject** — Cache entry deleted before forwarding the delete
+- **DeleteObjects** (bulk) — Cache entries deleted for all keys in the request
+- **CopyObject** — Cache entry deleted for the destination key
+
+Objects modified directly on Tigris (bypassing TAG) remain in cache until they expire (default TTL: 60 minutes) or are revalidated via `Cache-Control: no-cache`.
+
+## Verifying Cache Behavior
+
+Check the `X-Cache` header to verify caching:
+
+```bash
+# Using curl to see cache headers
+curl -I http://localhost:8080/my-bucket/my-key \
+  -H "Authorization: AWS4-HMAC-SHA256 ..."
+
+# Response will include:
+# X-Cache: HIT    (served from cache)
+# X-Cache: MISS   (fetched from upstream, now cached)
+```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -194,6 +194,58 @@ rate(tag_background_fetches_triggered_total[5m])
 
 Number of currently active background fetches.
 
+### Revalidation Metrics
+
+#### tag_revalidations_triggered_total
+
+**Type:** Counter
+
+Number of cache revalidation attempts (conditional GET/HEAD to upstream). Incremented when a client sends `Cache-Control: no-cache` or `max-age=0` and a cached entry with an ETag exists.
+
+**Example queries:**
+```promql
+# Revalidation rate
+rate(tag_revalidations_triggered_total[5m])
+```
+
+#### tag_revalidations_not_modified_total
+
+**Type:** Counter
+
+Number of revalidations where upstream returned 304 Not Modified (cached entry is still fresh).
+
+**Example queries:**
+```promql
+# Revalidation 304 ratio (higher = better cache freshness)
+rate(tag_revalidations_not_modified_total[5m]) /
+rate(tag_revalidations_triggered_total[5m])
+```
+
+#### tag_revalidations_updated_total
+
+**Type:** Counter
+
+Number of revalidations where upstream returned 200 with new data (cached entry was stale).
+
+#### tag_revalidations_failed_total
+
+**Type:** Counter
+
+Number of revalidations that failed due to errors or unexpected status codes.
+
+#### tag_revalidations_stale_served_total
+
+**Type:** Counter
+
+Number of times stale cached data was served because the revalidation request to upstream failed.
+
+**Example queries:**
+```promql
+# Stale serve ratio (should be low)
+rate(tag_revalidations_stale_served_total[5m]) /
+rate(tag_revalidations_triggered_total[5m])
+```
+
 ### Upstream Metrics
 
 #### tag_upstream_request_duration_seconds
@@ -233,6 +285,46 @@ Total number of authentication failures.
 | Label | Description |
 |-------|-------------|
 | `reason` | Failure reason: `invalid_signature`, `unknown_key`, `expired` |
+
+### Transparent Proxy Metrics
+
+#### tag_local_auth_validations_total
+
+**Type:** Counter
+
+Local authentication validation attempts and results in transparent proxy mode.
+
+| Label | Description |
+|-------|-------------|
+| `result` | Validation result: `success`, `missing_auth`, `parse_error`, `unknown_key`, `signature_mismatch`, `authz_expired` |
+
+**Example queries:**
+```promql
+# Local auth success rate
+rate(tag_local_auth_validations_total{result="success"}[5m]) /
+sum(rate(tag_local_auth_validations_total[5m]))
+
+# Auth failure breakdown
+sum by (result) (rate(tag_local_auth_validations_total{result!="success"}[5m]))
+```
+
+#### tag_derived_key_store_size
+
+**Type:** Gauge
+
+Number of stored derived signing keys (learned from Tigris responses).
+
+#### tag_authz_cache_size
+
+**Type:** Gauge
+
+Number of active authorization cache entries (per access-key, per bucket).
+
+#### tag_proxy_signing_keys_received_total
+
+**Type:** Counter
+
+Number of signing key sets extracted from Tigris responses (used for local signature validation).
 
 ### Connection Metrics
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,20 +72,6 @@ aws s3 rm s3://my-bucket/my-key --endpoint-url http://localhost:8080
 aws s3api head-object --bucket my-bucket --key my-key --endpoint-url http://localhost:8080
 ```
 
-### Verifying Cache Behavior
-
-Check the `X-Cache` header to verify caching:
-
-```bash
-# Using curl to see cache headers
-curl -I http://localhost:8080/my-bucket/my-key \
-  -H "Authorization: AWS4-HMAC-SHA256 ..."
-
-# Response will include:
-# X-Cache: HIT    (served from cache)
-# X-Cache: MISS   (fetched from upstream, now cached)
-```
-
 ## Python (boto3)
 
 ### Installation

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -200,6 +200,46 @@ var (
 			Help: "Number of signing key sets extracted from Tigris responses",
 		},
 	)
+
+	// RevalidationsTriggered counts cache revalidation attempts.
+	RevalidationsTriggered = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_revalidations_triggered_total",
+			Help: "Number of cache revalidation attempts (conditional GET to upstream)",
+		},
+	)
+
+	// RevalidationsNotModified counts revalidations where upstream returned 304.
+	RevalidationsNotModified = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_revalidations_not_modified_total",
+			Help: "Number of revalidations where upstream returned 304 Not Modified",
+		},
+	)
+
+	// RevalidationsUpdated counts revalidations where upstream returned 200 with new data.
+	RevalidationsUpdated = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_revalidations_updated_total",
+			Help: "Number of revalidations where upstream returned 200 with new data",
+		},
+	)
+
+	// RevalidationsFailed counts revalidations that failed.
+	RevalidationsFailed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_revalidations_failed_total",
+			Help: "Number of revalidations that failed (error or unexpected status)",
+		},
+	)
+
+	// RevalidationsStaleServed counts times stale data was served due to revalidation error.
+	RevalidationsStaleServed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_revalidations_stale_served_total",
+			Help: "Number of times stale cached data was served due to revalidation failure",
+		},
+	)
 )
 
 // RecordRequest records a request with its duration and status.
@@ -281,4 +321,29 @@ func RecordRangeFromCacheHit() {
 // RecordLocalAuthValidation records a local auth validation result.
 func RecordLocalAuthValidation(result string) {
 	LocalAuthValidations.WithLabelValues(result).Inc()
+}
+
+// RecordRevalidationTriggered records a revalidation attempt.
+func RecordRevalidationTriggered() {
+	RevalidationsTriggered.Inc()
+}
+
+// RecordRevalidationNotModified records a 304 revalidation result.
+func RecordRevalidationNotModified() {
+	RevalidationsNotModified.Inc()
+}
+
+// RecordRevalidationUpdated records a 200 revalidation result (object changed).
+func RecordRevalidationUpdated() {
+	RevalidationsUpdated.Inc()
+}
+
+// RecordRevalidationFailed records a failed revalidation.
+func RecordRevalidationFailed() {
+	RevalidationsFailed.Inc()
+}
+
+// RecordRevalidationStaleServed records serving stale data due to revalidation failure.
+func RecordRevalidationStaleServed() {
+	RevalidationsStaleServed.Inc()
 }

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -116,7 +116,6 @@ func (s *Service) setupCacheListener(
 
 		// Build metadata from response headers
 		meta := cache.MetaFromHTTPHeaders(bucket, key, statusCode, headers)
-
 		// Check if still cacheable based on metadata
 		if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
 			pipeWriter.CloseWithError(nil)
@@ -421,10 +420,4 @@ func (s *Service) isWithinSizeThreshold(resp *http.Response) bool {
 	}
 	// Unknown size - allow caching (will be handled by cache layer)
 	return true
-}
-
-// shouldSkipCache checks if cache should be skipped for this request.
-func shouldSkipCache(r *http.Request) bool {
-	cc := r.Header.Get("Cache-Control")
-	return strings.Contains(cc, "no-cache") || strings.Contains(cc, "max-age=0")
 }

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -49,6 +49,19 @@ type RequestForwarder interface {
 	// Used for background cache population after a Range request cache miss.
 	// Caller is responsible for closing the response body.
 	DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error)
+
+	// DoConditionalGetRequest executes a conditional GET for cache revalidation.
+	// Sends If-None-Match and/or If-Modified-Since headers.
+	// If rangeHeader is non-empty, includes a Range header (for range+revalidation).
+	// Returns 304 if unchanged, 200/206 with body if changed.
+	// Caller is responsible for closing the response body.
+	DoConditionalGetRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64, rangeHeader string) (*http.Response, error)
+
+	// DoConditionalHeadRequest executes a conditional HEAD for cache revalidation of HEAD requests.
+	// Sends If-None-Match and/or If-Modified-Since headers.
+	// Returns 304 if unchanged, 200 with headers only if changed (no body).
+	// Caller is responsible for closing the response body.
+	DoConditionalHeadRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64) (*http.Response, error)
 }
 
 // AuthErrorCode represents the type of authentication error.
@@ -296,6 +309,58 @@ func (b *baseForwarder) DoFullObjectRequest(ctx context.Context, bucket, key, ac
 	metrics.RecordUpstreamRequest("GET", time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background fetch failed")
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// DoConditionalGetRequest executes a conditional GET request to upstream.
+// Used for cache revalidation: sends If-None-Match and/or If-Modified-Since headers
+// to check if a cached object is still fresh.
+// Returns 304 Not Modified if unchanged, 200 OK with body if changed.
+// Caller is responsible for closing the response body.
+func (b *baseForwarder) DoConditionalGetRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64, rangeHeader string) (*http.Response, error) {
+	return b.doConditionalRequest(ctx, "GET", bucket, key, accessKey, secretKey, etag, lastModified, rangeHeader)
+}
+
+// DoConditionalHeadRequest executes a conditional HEAD request to upstream.
+// Used for cache revalidation of HEAD requests: sends If-None-Match and/or
+// If-Modified-Since headers to check if a cached object is still fresh.
+// Returns 304 Not Modified if unchanged, 200 OK with headers only if changed.
+// Caller is responsible for closing the response body.
+func (b *baseForwarder) DoConditionalHeadRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64) (*http.Response, error) {
+	return b.doConditionalRequest(ctx, "HEAD", bucket, key, accessKey, secretKey, etag, lastModified, "")
+}
+
+// doConditionalRequest is the shared implementation for conditional GET/HEAD requests.
+// Sends If-None-Match and/or If-Modified-Since headers for cache revalidation.
+// Uses standard SigV4 signing because these are synthetic requests initiated by TAG.
+func (b *baseForwarder) doConditionalRequest(ctx context.Context, method, bucket, key, accessKey, secretKey, etag string, lastModified int64, rangeHeader string) (*http.Response, error) {
+	path := "/" + bucket + "/" + key
+
+	extraHeaders := http.Header{}
+	if etag != "" {
+		extraHeaders.Set("If-None-Match", etag)
+	}
+	if lastModified > 0 {
+		t := time.Unix(lastModified, 0).UTC()
+		extraHeaders.Set("If-Modified-Since", t.Format(http.TimeFormat))
+	}
+	if rangeHeader != "" {
+		extraHeaders.Set("Range", rangeHeader)
+	}
+
+	fwdReq, err := b.signer.SignRequest(ctx, method, path, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(method, time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msgf("Conditional %s failed", method)
 		return nil, err
 	}
 

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -58,11 +58,13 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 // HandleGetObject handles GET requests for objects with cache-first logic.
 // Uses streaming broadcast for request coalescing to reduce upstream load.
 // Supports conditional requests (If-None-Match, If-Modified-Since).
+// Supports client-triggered cache revalidation via Cache-Control: no-cache/max-age=0.
 func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
 	ctx := r.Context()
 	bucket, key := ParseBucketKey(r)
-	noCacheRead := shouldSkipCache(r)
+	forceRevalidate := shouldForceRevalidate(r)
+	bypassCache := shouldBypassCache(r)
 	rangeHeader := r.Header.Get("Range")
 
 	// Conditional request headers
@@ -72,7 +74,8 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	log.Debug().
 		Str("bucket", bucket).
 		Str("key", key).
-		Bool("no_cache", noCacheRead).
+		Bool("force_revalidate", forceRevalidate).
+		Bool("bypass_cache", bypassCache).
 		Str("if_none_match", ifNoneMatch).
 		Msg("HandleGetObject")
 
@@ -87,9 +90,10 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	// For range requests: check if full object is in cache, then serve range from it.
 	// Uses two-phase approach: GetMeta first, then GetBodyStream for direct streaming.
 	// Anonymous requests can also read from cache if the object's ACL is public-read.
+	// Cache-Control: no-store bypasses cache entirely; no-cache/max-age=0 triggers revalidation.
 	isAnonymous := isAnonymousRequest(r, result, err)
 
-	if (result == AuthValidated || isAnonymous) && !noCacheRead && s.cache.IsEnabled() {
+	if (result == AuthValidated || isAnonymous) && !bypassCache && s.cache.IsEnabled() {
 		meta, found, cacheErr := s.cache.GetMeta(ctx, bucket, key)
 		cacheHit := cacheErr == nil && found && meta != nil
 		// Anonymous requests can only be served from cache if the object's ACL allows it
@@ -98,116 +102,62 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache for anonymous request - object not public")
 		}
 		if cacheHit {
-			// If this is a Range request and we have the full object cached,
-			// serve the range from the cached object
-			if rangeHeader != "" {
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-				return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+			// Client-triggered revalidation: Cache-Control: no-cache/max-age=0
+			// For range requests, the Range header is included in the conditional GET
+			// so upstream returns 304 (serve range from cache) or 206 (stream range to client).
+			if forceRevalidate && meta.ETag != "" {
+				log.Debug().
+					Str("bucket", bucket).
+					Str("key", key).
+					Msg("Cache hit requires revalidation (client-triggered)")
+				return s.revalidateAndServe(ctx, w, r, bucket, key, accessKey, secretKey, meta, start)
 			}
 
-			// Check conditional request: If-None-Match
-			if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
-				metrics.RecordCacheHit()
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
-				w.Header().Set(XCacheHeader, XCacheHit)
-				w.Header().Set("ETag", meta.ETag)
-				w.WriteHeader(http.StatusNotModified)
-				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-				return nil
-			}
+			// If client forced revalidation but no ETag available, fall through to full miss
+			if forceRevalidate {
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Force revalidate but no ETag, falling through to upstream")
+				// Fall through to cache miss path below
+			} else {
+				// Fresh cache hit — serve from cache
 
-			// Check conditional request: If-Modified-Since
-			if ifModifiedSince != "" {
-				if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
-					if !meta.IsModifiedSince(t) {
-						metrics.RecordCacheHit()
-						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
-						w.Header().Set(XCacheHeader, XCacheHit)
-						w.Header().Set("ETag", meta.ETag)
-						w.WriteHeader(http.StatusNotModified)
-						metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-						return nil
-					}
+				// If this is a Range request and we have the full object cached,
+				// serve the range from the cached object
+				if rangeHeader != "" {
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
+					return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 				}
-			}
 
-			// Serve full response from cache with proper headers
-			// Handle zero-byte objects directly (no body to verify)
-			if meta.ContentLength == 0 {
-				metrics.RecordCacheHit()
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving zero-byte object from cache")
-				meta.WriteHeaders(w)
-				w.Header().Set(XCacheHeader, XCacheHit)
-				w.WriteHeader(meta.StatusCode)
-				metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-				return nil
-			}
-
-			// Small objects: buffer body directly (no goroutine/io.Pipe overhead)
-			// Uses GetBodyStream to buffer, reusing metadata from GetMeta above (2 gRPC calls total)
-			if meta.ContentLength <= smallObjectThreshold {
-				// Get buffer from pool to reduce allocations
-				bodyBuf := bufferPool.Get().(*bytes.Buffer)
-				bodyBuf.Reset()
-
-				bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
-				// Verify body was actually retrieved: ocache GetStream returns nil
-				// for not-found keys (by design), so we must check bytes written.
-				if bodyErr == nil && bodyBuf.Len() > 0 {
+				// Check conditional request: If-None-Match
+				if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
 					metrics.RecordCacheHit()
-					log.Debug().Str("bucket", bucket).Str("key", key).Int64("size", meta.ContentLength).Msg("Serving small object from cache (fast path)")
-					meta.WriteHeaders(w)
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
 					w.Header().Set(XCacheHeader, XCacheHit)
-					w.WriteHeader(meta.StatusCode)
-					n, _ := w.Write(bodyBuf.Bytes())
-					metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+					w.Header().Set("ETag", meta.ETag)
+					w.WriteHeader(http.StatusNotModified)
 					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-					putBuffer(bodyBuf) // Return buffer to pool
 					return nil
 				}
-				putBuffer(bodyBuf) // Return buffer to pool even on error/miss
-				// Fall through to upstream (cache miss handling below)
-				if bodyErr != nil {
-					log.Debug().Err(bodyErr).Str("bucket", bucket).Str("key", key).Msg("GetBodyStream failed for small object, falling back to upstream")
-				} else {
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache body empty despite meta hit, falling back to upstream")
-				}
-			} else {
-				// Large objects: use io.Pipe for streaming (avoids buffering entire object)
-				pr, pw := io.Pipe()
-				go func() {
-					err := s.cache.GetBodyStream(ctx, bucket, key, pw)
-					if err != nil {
-						pw.CloseWithError(err)
-					} else {
-						pw.Close()
+
+				// Check conditional request: If-Modified-Since
+				if ifModifiedSince != "" {
+					if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
+						if !meta.IsModifiedSince(t) {
+							metrics.RecordCacheHit()
+							log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
+							w.Header().Set(XCacheHeader, XCacheHit)
+							w.Header().Set("ETag", meta.ETag)
+							w.WriteHeader(http.StatusNotModified)
+							metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+							return nil
+						}
 					}
-				}()
+				}
 
-				// Read first byte to verify body exists before committing headers
-				firstByte := make([]byte, 1)
-				n, readErr := pr.Read(firstByte)
-				if readErr != nil {
-					// Body missing or error - close pipe and fall through to upstream
-					pr.Close()
-					log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).Msg("Cache body missing, falling back to upstream")
-					// Fall through to cache miss handling below
+				// Serve full response from cache
+				if cacheBodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); cacheBodyErr != nil {
+					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, falling through to upstream")
+					// Fall through to cache miss path
 				} else {
-					// Body verified - safe to write headers and stream
-					metrics.RecordCacheHit()
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving large object from cache (streaming)")
-					meta.WriteHeaders(w)
-					w.Header().Set(XCacheHeader, XCacheHit)
-					w.WriteHeader(meta.StatusCode)
-
-					// Write first byte and stream the rest
-					cw := &countingWriter{w: w}
-					cw.Write(firstByte[:n])
-					io.Copy(cw, pr)
-					pr.Close()
-
-					metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
-					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
 					return nil
 				}
 			}
@@ -230,6 +180,8 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	var xCache string
 	if !s.cache.IsEnabled() {
 		xCache = XCacheDisabled
+	} else if bypassCache {
+		xCache = XCacheBypass
 	} else {
 		xCache = XCacheMiss
 	}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -1,0 +1,428 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// revalidateAndServe sends a conditional GET to upstream and serves the result.
+// Supports both full-object and range requests. For range requests, the Range header
+// is included in the conditional GET so upstream returns 304 or 206.
+// On 304 Not Modified: serves from cached body (or range).
+// On 200/206 (changed): streams new body to client and updates cache.
+// On error: serves stale data from cache as fallback.
+func (s *Service) revalidateAndServe(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key, accessKey, secretKey string,
+	meta *cache.CachedObjectMeta,
+	start time.Time,
+) error {
+	metrics.RecordRevalidationTriggered()
+
+	rangeHeader := r.Header.Get("Range")
+
+	log.Debug().
+		Str("bucket", bucket).
+		Str("key", key).
+		Str("etag", meta.ETag).
+		Str("range", rangeHeader).
+		Msg("Revalidating cached object with upstream")
+
+	// Send conditional GET to upstream (includes Range header if present).
+	// Uses the parent context (not a separate timeout) to avoid truncating body
+	// streaming for large objects. The httpClient has its own 5-minute timeout.
+	resp, err := s.forwarder.DoConditionalGetRequest(ctx, bucket, key, accessKey, secretKey, meta.ETag, meta.LastModified, rangeHeader)
+	if err != nil {
+		// Upstream error — serve stale from cache
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Revalidation failed, serving stale")
+		metrics.RecordRevalidationFailed()
+		metrics.RecordRevalidationStaleServed()
+		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		revalErr := s.handleRevalidation304(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if revalErr == nil {
+			return nil
+		}
+		// Cache body unavailable despite 304 — fall through to upstream.
+		// serveFromCache returns errors before committing headers, so we can
+		// safely write a new response. Range errors may have partial headers
+		// committed (serveRangeFromCache writes headers before streaming), so
+		// we return those directly.
+		if rangeHeader != "" {
+			return revalErr
+		}
+		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
+			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
+		w.Header().Set(XCacheHeader, XCacheMiss)
+		forwardErr := s.forwarder.Forward(ctx, w, r)
+		status := "success"
+		if forwardErr != nil {
+			status = "error"
+		}
+		metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+		return forwardErr
+	case http.StatusOK:
+		// Full-object response (no range or upstream ignored range)
+		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
+	case http.StatusPartialContent:
+		// Range response — object changed, upstream returned only the requested range
+		return s.handleRevalidation206Range(ctx, w, r, bucket, key, accessKey, secretKey, resp, start)
+	default:
+		// Unexpected status (4xx, 5xx) — drain body for connection reuse, serve stale
+		io.Copy(io.Discard, resp.Body)
+		log.Warn().
+			Int("status", resp.StatusCode).
+			Str("bucket", bucket).
+			Str("key", key).
+			Msg("Revalidation got unexpected status, serving stale")
+		metrics.RecordRevalidationFailed()
+		metrics.RecordRevalidationStaleServed()
+		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+	}
+}
+
+// handleRevalidation304 handles a 304 Not Modified revalidation response.
+// Serves from cached body (or range if requested). Does not refresh cache TTL
+// because ocache has no TTL-refresh operation and re-writing data is inefficient.
+func (s *Service) handleRevalidation304(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key string,
+	meta *cache.CachedObjectMeta,
+	rangeHeader string,
+	start time.Time,
+) error {
+	metrics.RecordRevalidationNotModified()
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidation 304 - object unchanged")
+
+	// Serve range or full body from cache
+	if rangeHeader != "" {
+		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+	}
+	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+}
+
+// handleRevalidation200 handles a 200 OK revalidation response (object changed).
+// Streams the new body to the client while simultaneously updating the cache.
+func (s *Service) handleRevalidation200(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key string,
+	resp *http.Response,
+	start time.Time,
+) error {
+	metrics.RecordRevalidationUpdated()
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidation 200 - object changed, streaming new data")
+
+	// Build new metadata from upstream response
+	newMeta := cache.MetaFromHTTPHeaders(bucket, key, resp.StatusCode, resp.Header)
+
+	// Check if the new object should be cached
+	shouldCache := newMeta.IsCacheable(s.config.Cache.SizeThreshold) &&
+		s.cache.IsEnabled() &&
+		!s.hasNoCacheHeaders(resp.Header)
+
+	// Always delete stale cache entry when upstream confirms the object changed.
+	// Even if the new version is uncacheable (too large, no-store), the old cached
+	// version is known-stale and must not be served to future requests.
+	s.cache.Delete(context.Background(), bucket, key)
+
+	// Capture writeStartTime after Delete so our own tombstone doesn't block
+	// the subsequent cache write. A concurrent DELETE arriving after this point
+	// will have a newer tombstone that correctly blocks our write.
+	writeStartTime := time.Now().UnixNano()
+
+	// Write response headers to client
+	copyHeaders(w.Header(), resp.Header)
+	w.Header().Set(XCacheHeader, XCacheRevalidated)
+	w.WriteHeader(resp.StatusCode)
+
+	if !shouldCache {
+		// Not cacheable — just stream to client
+		n, copyErr := io.Copy(w, resp.Body)
+		metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+		status := "success"
+		if copyErr != nil {
+			status = "error"
+		}
+		metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+		return copyErr
+	}
+
+	// Stream to client AND cache simultaneously via TeeReader + pipe
+	pr, pw := io.Pipe()
+	ttl := int(s.config.Cache.TTL.Seconds())
+
+	// Background goroutine: write to cache from pipe reader
+	cacheErrCh := make(chan error, 1)
+	go func() {
+		cacheErr := s.cache.PutWithMetaStreamTombstoneAware(
+			context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime,
+		)
+		if cacheErr != nil {
+			log.Warn().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write failed during revalidation update")
+			// Drain remaining pipe data so the foreground TeeReader doesn't block.
+			// Without this, io.Pipe's zero-buffer causes pw.Write to hang.
+			io.Copy(io.Discard, pr)
+		}
+		cacheErrCh <- cacheErr
+	}()
+
+	// Foreground: stream to client via TeeReader (also writes to pipe for cache)
+	teeReader := io.TeeReader(resp.Body, pw)
+	n, copyErr := io.Copy(w, teeReader)
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+
+	// Close pipe writer to signal EOF to cache reader
+	if copyErr != nil {
+		pw.CloseWithError(copyErr)
+	} else {
+		pw.Close()
+	}
+
+	// Wait for cache write to complete (with timeout)
+	select {
+	case cacheErr := <-cacheErrCh:
+		if cacheErr != nil {
+			log.Debug().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write error after revalidation")
+		}
+	case <-time.After(cacheWriteTimeoutForSize(newMeta.ContentLength)):
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Cache write timeout after revalidation")
+	}
+
+	status := "success"
+	if copyErr != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	return copyErr
+}
+
+// serveFromCache serves an object from the cache body.
+// Used as fallback during revalidation (304 or error paths).
+func (s *Service) serveFromCache(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key string,
+	meta *cache.CachedObjectMeta,
+	start time.Time,
+) error {
+	// Zero-byte objects: no body to serve
+	if meta.ContentLength == 0 {
+		metrics.RecordCacheHit()
+		meta.WriteHeaders(w)
+		w.Header().Set(XCacheHeader, XCacheHit)
+		w.WriteHeader(meta.StatusCode)
+		metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+		return nil
+	}
+
+	// Small objects: buffer and serve
+	if meta.ContentLength <= smallObjectThreshold {
+		bodyBuf := bufferPool.Get().(*bytes.Buffer)
+		bodyBuf.Reset()
+
+		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
+		if bodyErr == nil && bodyBuf.Len() > 0 {
+			metrics.RecordCacheHit()
+			meta.WriteHeaders(w)
+			w.Header().Set(XCacheHeader, XCacheHit)
+			w.WriteHeader(meta.StatusCode)
+			n, _ := w.Write(bodyBuf.Bytes())
+			metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+			putBuffer(bodyBuf)
+			return nil
+		}
+		putBuffer(bodyBuf)
+		// Body unavailable — return error (caller may fall through to upstream)
+		if bodyErr != nil {
+			return fmt.Errorf("cache body read failed: %w", bodyErr)
+		}
+		return fmt.Errorf("cache body empty for %s/%s", bucket, key)
+	}
+
+	// Large objects: stream via pipe
+	pr, pw := io.Pipe()
+	go func() {
+		err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+		if err != nil {
+			pw.CloseWithError(err)
+		} else {
+			pw.Close()
+		}
+	}()
+
+	// Read first byte to verify body exists
+	firstByte := make([]byte, 1)
+	n, readErr := pr.Read(firstByte)
+	if readErr != nil {
+		pr.Close()
+		return fmt.Errorf("cache body unavailable: %w", readErr)
+	}
+
+	metrics.RecordCacheHit()
+	meta.WriteHeaders(w)
+	w.Header().Set(XCacheHeader, XCacheHit)
+	w.WriteHeader(meta.StatusCode)
+
+	cw := &countingWriter{w: w}
+	cw.Write(firstByte[:n])
+	io.Copy(cw, pr)
+	pr.Close()
+
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+	metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+	return nil
+}
+
+// handleRevalidation206Range handles a 206 Partial Content revalidation response.
+// The object changed and upstream returned only the requested range.
+// Streams the range to the client, deletes stale cache, and triggers a background
+// full-object fetch to repopulate the cache (same pattern as handleRangeWithBackgroundCache).
+func (s *Service) handleRevalidation206Range(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key, accessKey, secretKey string,
+	resp *http.Response,
+	start time.Time,
+) error {
+	metrics.RecordRevalidationUpdated()
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidation 206 - object changed, streaming range")
+
+	// Delete stale cache entry before repopulating
+	s.cache.Delete(context.Background(), bucket, key)
+
+	// Determine total object size from Content-Range header
+	totalSize := extractTotalSizeFromContentRange(resp.Header.Get("Content-Range"))
+
+	// Stream range response to client
+	copyHeaders(w.Header(), resp.Header)
+	w.Header().Set(XCacheHeader, XCacheRevalidated)
+	w.WriteHeader(resp.StatusCode)
+
+	n, copyErr := io.Copy(w, resp.Body)
+	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+
+	status := "success"
+	if copyErr != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+
+	// Trigger background full-object fetch to repopulate cache
+	if totalSize > 0 &&
+		totalSize <= s.config.Cache.SizeThreshold &&
+		s.cache.IsEnabled() &&
+		accessKey != "" && secretKey != "" {
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+	}
+
+	return copyErr
+}
+
+// serveStaleFromCache serves stale content from cache, handling both full and range requests.
+func (s *Service) serveStaleFromCache(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket, key string,
+	meta *cache.CachedObjectMeta,
+	rangeHeader string,
+	start time.Time,
+) error {
+	if rangeHeader != "" {
+		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+	}
+	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+}
+
+// revalidateAndServeHead sends a conditional HEAD to upstream for a HEAD request.
+// On 304: serves cached headers (no body).
+// On 200: serves new headers from upstream and invalidates stale cache.
+// On error: serves stale headers from cache.
+func (s *Service) revalidateAndServeHead(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key, accessKey, secretKey string,
+	meta *cache.CachedObjectMeta,
+	start time.Time,
+) error {
+	metrics.RecordRevalidationTriggered()
+
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidating cached HEAD with upstream (conditional HEAD)")
+
+	resp, err := s.forwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, meta.ETag, meta.LastModified)
+
+	// Object changed — serve new headers from upstream, invalidate cache
+	if err == nil && resp.StatusCode == http.StatusOK {
+		defer resp.Body.Close()
+		metrics.RecordRevalidationUpdated()
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD revalidation 200 - object changed")
+
+		s.cache.Delete(context.Background(), bucket, key)
+		io.Copy(io.Discard, resp.Body)
+
+		copyHeaders(w.Header(), resp.Header)
+		w.Header().Set(XCacheHeader, XCacheRevalidated)
+		w.WriteHeader(resp.StatusCode)
+		metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+		return nil
+	}
+
+	// 304, error, or unexpected status — record specific metrics, then serve cached headers
+	if err != nil {
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("HEAD revalidation failed, serving stale")
+		metrics.RecordRevalidationFailed()
+		metrics.RecordRevalidationStaleServed()
+	} else {
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusNotModified {
+			metrics.RecordRevalidationNotModified()
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD revalidation 304 - unchanged")
+		} else {
+			io.Copy(io.Discard, resp.Body)
+			log.Warn().Int("status", resp.StatusCode).Str("bucket", bucket).Str("key", key).Msg("HEAD revalidation unexpected status, serving stale")
+			metrics.RecordRevalidationFailed()
+			metrics.RecordRevalidationStaleServed()
+		}
+	}
+
+	metrics.RecordCacheHit()
+	meta.WriteHeaders(w)
+	w.Header().Set(XCacheHeader, XCacheHit)
+	w.WriteHeader(meta.StatusCode)
+	metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+	return nil
+}
+
+// shouldForceRevalidate checks if the client is requesting cache revalidation.
+// Per RFC 7234, Cache-Control: no-cache means "must revalidate with origin before serving".
+func shouldForceRevalidate(r *http.Request) bool {
+	cc := r.Header.Get("Cache-Control")
+	return strings.Contains(cc, "no-cache") || strings.Contains(cc, "max-age=0")
+}
+
+// shouldBypassCache checks if the client is requesting full cache bypass.
+// Cache-Control: no-store means "do not use or store cached data".
+func shouldBypassCache(r *http.Request) bool {
+	cc := r.Header.Get("Cache-Control")
+	return strings.Contains(cc, "no-store")
+}

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -1,0 +1,726 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// mockForwarder implements RequestForwarder for revalidation unit tests.
+type mockForwarder struct {
+	conditionalResp *http.Response
+	conditionalErr  error
+	// Track calls for verification
+	conditionalCalled bool
+	conditionalETag   string
+	// Optional Forward implementation for fallback tests
+	forwardFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+}
+
+func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	if m.forwardFunc != nil {
+		return m.forwardFunc(ctx, w, r)
+	}
+	return nil
+}
+
+func (m *mockForwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+	return nil, nil
+}
+
+func (m *mockForwarder) ValidateAndGetCredentials(r *http.Request) (AuthResult, string, string, error) {
+	return AuthValidated, "access", "secret", nil
+}
+
+func (m *mockForwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *mockForwarder) DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+	return nil, errors.New("mock: DoFullObjectRequest not implemented")
+}
+
+func (m *mockForwarder) DoConditionalGetRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64, rangeHeader string) (*http.Response, error) {
+	m.conditionalCalled = true
+	m.conditionalETag = etag
+	if m.conditionalErr != nil {
+		return nil, m.conditionalErr
+	}
+	return m.conditionalResp, nil
+}
+
+func (m *mockForwarder) DoConditionalHeadRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64) (*http.Response, error) {
+	m.conditionalCalled = true
+	m.conditionalETag = etag
+	if m.conditionalErr != nil {
+		return nil, m.conditionalErr
+	}
+	return m.conditionalResp, nil
+}
+
+// newTestService creates a Service with an in-memory cache for unit tests.
+func newTestService(forwarder RequestForwarder, cacheEnabled bool) (*Service, *cache.Cache) {
+	cfg := config.NewDefault()
+	if !cacheEnabled {
+		enabled := false
+		cfg.Cache.Enabled = &enabled
+	}
+
+	var c *cache.Cache
+	if cacheEnabled {
+		memCache := cacheclient.NewMemoryCache()
+		c = cache.NewCacheWithClient(memCache, &cfg.Cache)
+	} else {
+		c = cache.NewDisabledCache()
+	}
+
+	svc := NewService(forwarder, c, cfg)
+	return svc, c
+}
+
+func TestRevalidation304_ServesCachedBody(t *testing.T) {
+	// Setup: mock upstream returns 304 Not Modified
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	// Pre-populate cache with metadata and body
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	body := []byte("hello world!")
+	err := c.PutWithMeta(ctx, bucket, key, meta, body, 0)
+	if err != nil {
+		t.Fatalf("PutWithMeta() error = %v", err)
+	}
+
+	// Execute revalidation
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err = svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: conditional request was made
+	if !mock.conditionalCalled {
+		t.Error("expected conditional GET to be called")
+	}
+	if mock.conditionalETag != `"abc123"` {
+		t.Errorf("conditional ETag = %q, want %q", mock.conditionalETag, `"abc123"`)
+	}
+
+	// Verify: response served from cache
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+	if w.Body.String() != "hello world!" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "hello world!")
+	}
+}
+
+func TestRevalidation200_StreamsNewBody(t *testing.T) {
+	// Setup: mock upstream returns 200 with new body
+	newBody := "new content from upstream"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(newBody)),
+			Header: http.Header{
+				"Content-Type":   []string{"text/plain"},
+				"Content-Length": []string{"24"},
+				"Etag":           []string{`"newetag"`},
+			},
+		},
+	}
+
+	svc, _ := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"oldetag"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: new body streamed to client
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheRevalidated {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheRevalidated)
+	}
+	if w.Body.String() != newBody {
+		t.Errorf("body = %q, want %q", w.Body.String(), newBody)
+	}
+}
+
+func TestRevalidation200_UncacheableDeletesStale(t *testing.T) {
+	// Setup: mock upstream returns 200 with Cache-Control: no-store (uncacheable)
+	newBody := "uncacheable new content"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(newBody)),
+			Header: http.Header{
+				"Content-Type":   []string{"text/plain"},
+				"Content-Length": []string{"22"},
+				"Etag":           []string{`"newetag"`},
+				"Cache-Control":  []string{"no-store"},
+			},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	// Pre-populate cache with stale entry
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"oldetag"`,
+		ContentType:   "text/plain",
+		ContentLength: 10,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("stale data"), 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: new body streamed to client
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != newBody {
+		t.Errorf("body = %q, want %q", w.Body.String(), newBody)
+	}
+
+	// Verify: stale cache entry was deleted even though new response is uncacheable
+	_, found, _ := c.GetMeta(ctx, bucket, key)
+	if found {
+		t.Error("expected stale cache entry to be deleted when upstream returns uncacheable 200")
+	}
+}
+
+func TestRevalidationError_ServesStale(t *testing.T) {
+	// Setup: mock upstream returns error
+	mock := &mockForwarder{
+		conditionalErr: errors.New("upstream connection failed"),
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 10,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("stale data"), 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: stale data served
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q (stale fallback)", got, XCacheHit)
+	}
+	if w.Body.String() != "stale data" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "stale data")
+	}
+}
+
+func TestRevalidationUnexpectedStatus_ServesStale(t *testing.T) {
+	// Setup: mock upstream returns 500
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader("server error")),
+			Header:     http.Header{},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 10,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("stale data"), 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: stale data served on unexpected status
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+}
+
+func TestRevalidateAndServeHead_304(t *testing.T) {
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 100,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, make([]byte, 100), 0)
+
+	w := httptest.NewRecorder()
+	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServeHead() error = %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+	// HEAD: no body
+	if w.Body.Len() != 0 {
+		t.Errorf("HEAD body length = %d, want 0", w.Body.Len())
+	}
+}
+
+func TestRevalidateAndServeHead_200(t *testing.T) {
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Content-Length": []string{"200"},
+				"Etag":           []string{`"newetag"`},
+			},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"oldetag"`,
+		ContentType:   "text/plain",
+		ContentLength: 100,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, make([]byte, 100), 0)
+
+	w := httptest.NewRecorder()
+	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServeHead() error = %v", err)
+	}
+
+	// Verify: new headers from upstream
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheRevalidated {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheRevalidated)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+
+	// Verify: stale cache entry was invalidated
+	_, found, _ := c.GetMeta(ctx, bucket, key)
+	if found {
+		t.Error("expected cache entry to be deleted after HEAD revalidation 200")
+	}
+}
+
+func TestRevalidateAndServeHead_Error_ServesStale(t *testing.T) {
+	mock := &mockForwarder{
+		conditionalErr: errors.New("upstream timeout"),
+	}
+
+	svc, _ := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 100,
+		StatusCode:    http.StatusOK,
+	}
+
+	w := httptest.NewRecorder()
+	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServeHead() error = %v", err)
+	}
+
+	// Verify: stale headers served
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q (stale fallback)", got, XCacheHit)
+	}
+}
+
+func TestServeFromCache_ZeroByteObject(t *testing.T) {
+	mock := &mockForwarder{}
+	svc, _ := newTestService(mock, true)
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        "b",
+		Key:           "k",
+		ContentType:   "text/plain",
+		ContentLength: 0,
+		StatusCode:    http.StatusOK,
+	}
+
+	w := httptest.NewRecorder()
+	err := svc.serveFromCache(context.Background(), w, "b", "k", meta, time.Now())
+	if err != nil {
+		t.Fatalf("serveFromCache() error = %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body length = %d, want 0", w.Body.Len())
+	}
+}
+
+func TestServeFromCache_SmallObject(t *testing.T) {
+	mock := &mockForwarder{}
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	body := []byte("small cached body")
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ContentType:   "text/plain",
+		ContentLength: int64(len(body)),
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, body, 0)
+
+	w := httptest.NewRecorder()
+	err := svc.serveFromCache(ctx, w, bucket, key, meta, time.Now())
+	if err != nil {
+		t.Fatalf("serveFromCache() error = %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != "small cached body" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "small cached body")
+	}
+}
+
+func TestRevalidationRange304_ServesCachedRange(t *testing.T) {
+	// Setup: mock upstream returns 304 Not Modified (object unchanged)
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	// Pre-populate cache with full object
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	body := []byte("hello world!")
+	err := c.PutWithMeta(ctx, bucket, key, meta, body, 0)
+	if err != nil {
+		t.Fatalf("PutWithMeta() error = %v", err)
+	}
+
+	// Request with Range header + revalidation
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	r.Header.Set("Range", "bytes=0-4")
+	err = svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: conditional request was made
+	if !mock.conditionalCalled {
+		t.Error("expected conditional GET to be called")
+	}
+
+	// Verify: 206 Partial Content with correct range
+	if w.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPartialContent)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+	if w.Body.String() != "hello" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "hello")
+	}
+	if got := w.Header().Get("Content-Range"); got == "" {
+		t.Error("expected Content-Range header to be set")
+	}
+}
+
+func TestRevalidationRange206_StreamsRangeFromUpstream(t *testing.T) {
+	// Setup: mock upstream returns 206 Partial Content (object changed, range returned)
+	rangeBody := "new range!"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusPartialContent,
+			Body:       io.NopCloser(strings.NewReader(rangeBody)),
+			Header: http.Header{
+				"Content-Type":   []string{"text/plain"},
+				"Content-Length": []string{"10"},
+				"Content-Range":  []string{"bytes 0-9/100"},
+				"Etag":           []string{`"newetag"`},
+			},
+		},
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	// Pre-populate cache with old object
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"oldetag"`,
+		ContentType:   "text/plain",
+		ContentLength: 50,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("old cached content that is now stale and outdated!"), 0)
+
+	// Request with Range header + revalidation
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	r.Header.Set("Range", "bytes=0-9")
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: 206 with new range body from upstream
+	if w.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPartialContent)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheRevalidated {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheRevalidated)
+	}
+	if w.Body.String() != rangeBody {
+		t.Errorf("body = %q, want %q", w.Body.String(), rangeBody)
+	}
+
+	// Verify: stale cache entry was deleted
+	_, found, _ := c.GetMeta(ctx, bucket, key)
+	if found {
+		t.Error("expected stale cache entry to be deleted after 206 revalidation")
+	}
+}
+
+func TestRevalidationRangeError_ServesStaleRange(t *testing.T) {
+	// Setup: mock upstream returns error
+	mock := &mockForwarder{
+		conditionalErr: errors.New("upstream connection failed"),
+	}
+
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 10,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("stale data"), 0)
+
+	// Request with Range header + revalidation (upstream fails)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	r.Header.Set("Range", "bytes=0-4")
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	// Verify: stale range served from cache
+	if w.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPartialContent)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q (stale fallback)", got, XCacheHit)
+	}
+	if w.Body.String() != "stale" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "stale")
+	}
+}
+
+func TestRevalidation304_CacheBodyUnavailable_FallsThrough(t *testing.T) {
+	// Setup: mock upstream returns 304, but cache body has been evicted.
+	// Forward should be called as fallback to serve fresh content.
+	freshBody := "fresh from upstream"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+		forwardFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(freshBody))
+			return nil
+		},
+	}
+
+	// Create cache with separate reference to underlying client for body deletion
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	// Pre-populate cache with metadata and body
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0)
+
+	// Delete only the body key to simulate cache body eviction
+	_ = memCache.Delete(ctx, cache.MakeBodyKey(bucket, key))
+
+	// Execute revalidation — should fall through to Forward
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v (expected fallback to upstream)", err)
+	}
+
+	// Verify: fresh response from upstream (not InternalError)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
+		t.Errorf("X-Cache = %q, want %q (upstream fallback)", got, XCacheMiss)
+	}
+	if w.Body.String() != freshBody {
+		t.Errorf("body = %q, want %q", w.Body.String(), freshBody)
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -23,8 +23,9 @@ const (
 	XCacheHeader   = "X-Cache"
 	XCacheHit      = "HIT"
 	XCacheMiss     = "MISS"
-	XCacheBypass   = "BYPASS"   // Range requests bypass cache
-	XCacheDisabled = "DISABLED" // Cache is disabled
+	XCacheBypass      = "BYPASS"      // Cache-Control: no-store bypassed cache
+	XCacheDisabled    = "DISABLED"    // Cache is disabled
+	XCacheRevalidated = "REVALIDATED" // Object revalidated with upstream
 )
 
 // Service provides the core caching proxy logic.
@@ -109,16 +110,18 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 
 // HandleHeadObject handles HEAD requests for objects.
 // Serves from cached metadata when available (no body fetch needed).
+// Supports cache revalidation via Cache-Control: no-cache/max-age=0.
 func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
 	ctx := r.Context()
 	bucket, key := ParseBucketKey(r)
-	noCacheRead := shouldSkipCache(r)
+	forceRevalidate := shouldForceRevalidate(r)
+	bypassCache := shouldBypassCache(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleHeadObject")
 
 	// Validate credentials before serving from cache
-	result, _, _, err := s.forwarder.ValidateAndGetCredentials(r)
+	result, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
 	if err != nil {
 		metrics.RecordRequest("HeadObject", "auth_error", time.Since(start).Seconds())
 		return err
@@ -128,7 +131,7 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 	// Anonymous requests can also read from cache if the object's ACL is public-read.
 	isAnonymous := isAnonymousRequest(r, result, err)
 
-	if (result == AuthValidated || isAnonymous) && !noCacheRead && s.cache.IsEnabled() {
+	if (result == AuthValidated || isAnonymous) && !bypassCache && s.cache.IsEnabled() {
 		meta, found, cacheErr := s.cache.GetMeta(ctx, bucket, key)
 		cacheHit := cacheErr == nil && found && meta != nil
 		if cacheHit && isAnonymous && !meta.IsPublicRead() {
@@ -136,23 +139,34 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping HEAD cache for anonymous request - object not public")
 		}
 		if cacheHit {
-			metrics.RecordCacheHit()
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD served from cache")
-			meta.WriteHeaders(w)
-			w.Header().Set(XCacheHeader, XCacheHit)
-			w.WriteHeader(meta.StatusCode)
-			metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
-			return nil
+			// Client-triggered revalidation: Cache-Control: no-cache/max-age=0
+			if forceRevalidate && meta.ETag != "" {
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD cache hit requires revalidation (client-triggered)")
+				return s.revalidateAndServeHead(ctx, w, bucket, key, accessKey, secretKey, meta, start)
+			}
+
+			if !forceRevalidate {
+				metrics.RecordCacheHit()
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD served from cache")
+				meta.WriteHeaders(w)
+				w.Header().Set(XCacheHeader, XCacheHit)
+				w.WriteHeader(meta.StatusCode)
+				metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+				return nil
+			}
+			// forceRevalidate but no ETag — fall through to upstream
 		}
 		metrics.RecordCacheMiss()
 	}
 
 	// Cache miss - forward to upstream
 	// Set X-Cache header before forwarding (will be included in response)
-	if s.cache.IsEnabled() {
-		w.Header().Set(XCacheHeader, XCacheMiss)
-	} else {
+	if !s.cache.IsEnabled() {
 		w.Header().Set(XCacheHeader, XCacheDisabled)
+	} else if bypassCache {
+		w.Header().Set(XCacheHeader, XCacheBypass)
+	} else {
+		w.Header().Set(XCacheHeader, XCacheMiss)
 	}
 	err = s.forwarder.Forward(ctx, w, r)
 

--- a/proxy/service_test.go
+++ b/proxy/service_test.go
@@ -77,7 +77,7 @@ func TestParseBucketKey(t *testing.T) {
 	}
 }
 
-func TestShouldSkipCache(t *testing.T) {
+func TestShouldForceRevalidate(t *testing.T) {
 	tests := []struct {
 		name         string
 		cacheControl string
@@ -99,7 +99,7 @@ func TestShouldSkipCache(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "max-age with other directives",
+			name:         "max-age=0 with must-revalidate",
 			cacheControl: "max-age=0, must-revalidate",
 			want:         true,
 		},
@@ -132,9 +132,57 @@ func TestShouldSkipCache(t *testing.T) {
 				req.Header.Set("Cache-Control", tt.cacheControl)
 			}
 
-			got := shouldSkipCache(req)
+			got := shouldForceRevalidate(req)
 			if got != tt.want {
-				t.Errorf("shouldSkipCache() = %v, want %v", got, tt.want)
+				t.Errorf("shouldForceRevalidate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldBypassCache(t *testing.T) {
+	tests := []struct {
+		name         string
+		cacheControl string
+		want         bool
+	}{
+		{
+			name:         "no cache-control header",
+			cacheControl: "",
+			want:         false,
+		},
+		{
+			name:         "no-cache directive",
+			cacheControl: "no-cache",
+			want:         false,
+		},
+		{
+			name:         "no-store",
+			cacheControl: "no-store",
+			want:         true,
+		},
+		{
+			name:         "no-store with no-cache",
+			cacheControl: "no-cache, no-store",
+			want:         true,
+		},
+		{
+			name:         "normal max-age",
+			cacheControl: "max-age=3600",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+			if tt.cacheControl != "" {
+				req.Header.Set("Cache-Control", tt.cacheControl)
+			}
+
+			got := shouldBypassCache(req)
+			if got != tt.want {
+				t.Errorf("shouldBypassCache() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/tests/s3compat/sdk/go_sdk_test.go
+++ b/tests/s3compat/sdk/go_sdk_test.go
@@ -1235,6 +1235,404 @@ func TestSDK_UserMetadata_WithCache(t *testing.T) {
 }
 
 // ============================================================================
+// Cache Revalidation Tests
+// These tests verify RFC 7234-compliant cache revalidation using
+// Cache-Control: no-cache to trigger conditional requests (If-None-Match).
+// ============================================================================
+
+// noCacheHeaders returns headers that trigger cache revalidation.
+func noCacheHeaders() map[string]string {
+	return map[string]string{"Cache-Control": "no-cache"}
+}
+
+// TestSDK_Revalidation_GET_Unchanged verifies that GET with Cache-Control: no-cache
+// on an unchanged object returns the cached body after conditional validation (304 path).
+//
+// Flow:
+//  1. PUT object → GET (cache miss, learns ETag) → cache populated
+//  2. GET with Cache-Control: no-cache → TAG sends If-None-Match to upstream
+//  3. Upstream returns 304 Not Modified → TAG serves from cache with X-Cache: HIT
+func TestSDK_Revalidation_GET_Unchanged(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-get-unchanged")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	content := []byte("revalidation get unchanged test content")
+	if err := globalEnv.PutTestObject(bucket, "reval-get-key", content); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
+
+	// First GET: cache miss, populates cache and learns ETag
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-get-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	if string(body1) != string(content) {
+		t.Errorf("First GET: expected body %q, got %q", content, body1)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// Second GET with Cache-Control: no-cache → triggers revalidation
+	// Object is unchanged, so upstream returns 304 → TAG serves from cache
+	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-get-key", noCacheHeaders())
+	if err != nil {
+		t.Fatalf("Revalidation GET failed: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("Revalidation GET: expected 200, got %d", resp2.StatusCode)
+	}
+	if string(body2) != string(content) {
+		t.Errorf("Revalidation GET: expected body %q, got %q", content, body2)
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "HIT" {
+		t.Errorf("Revalidation GET (unchanged): expected X-Cache HIT, got %q", xCache)
+	}
+	t.Logf("Revalidation GET unchanged verified: X-Cache=%s", xCache)
+}
+
+// TestSDK_Revalidation_GET_Changed verifies that GET with Cache-Control: no-cache
+// on a changed object returns the new body from upstream (200 path).
+//
+// Flow:
+//  1. PUT object v1 → GET (cache miss) → cache populated with v1
+//  2. PUT object v2 (different content, new ETag)
+//  3. GET with Cache-Control: no-cache → TAG sends If-None-Match with v1's ETag
+//  4. Upstream returns 200 with v2 body → TAG streams new body, X-Cache: REVALIDATED
+func TestSDK_Revalidation_GET_Changed(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-get-changed")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	contentV1 := []byte("revalidation content version 1")
+	if err := globalEnv.PutTestObject(bucket, "reval-changed-key", contentV1); err != nil {
+		t.Fatalf("Failed to put test object v1: %v", err)
+	}
+
+	// First GET: cache miss, populates cache with v1
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-changed-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// PUT new content (v2) directly to Tigris, bypassing TAG's cache invalidation.
+	// TAG's cache still holds stale v1 with old ETag.
+	contentV2 := []byte("revalidation content version 2 - updated")
+	if err := globalEnv.PutTestObjectDirect(bucket, "reval-changed-key", contentV2); err != nil {
+		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// GET with Cache-Control: no-cache → revalidation
+	// Object changed, so upstream returns 200 with new body
+	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-changed-key", noCacheHeaders())
+	if err != nil {
+		t.Fatalf("Revalidation GET failed: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("Revalidation GET: expected 200, got %d", resp2.StatusCode)
+	}
+	if string(body2) != string(contentV2) {
+		t.Errorf("Revalidation GET: expected body %q, got %q", contentV2, body2)
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "REVALIDATED" {
+		t.Errorf("Revalidation GET (changed): expected X-Cache REVALIDATED, got %q", xCache)
+	}
+	t.Logf("Revalidation GET changed verified: X-Cache=%s", xCache)
+}
+
+// TestSDK_Revalidation_GETRange_Unchanged verifies that a range GET with
+// Cache-Control: no-cache on an unchanged object returns the correct byte range
+// from cache after conditional validation (304 path).
+//
+// Flow:
+//  1. PUT object → full GET (cache miss) → cache populated
+//  2. GET with Cache-Control: no-cache + Range: bytes=0-4
+//  3. Upstream returns 304 → TAG serves range from cache, X-Cache: HIT
+func TestSDK_Revalidation_GETRange_Unchanged(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-range-unchanged")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	content := []byte("revalidation range test data!!")
+	if err := globalEnv.PutTestObject(bucket, "reval-range-key", content); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
+
+	// Full GET to populate cache
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-range-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// Range GET with Cache-Control: no-cache → revalidation + range
+	headers := map[string]string{
+		"Cache-Control": "no-cache",
+		"Range":         "bytes=0-4",
+	}
+	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-range-key", headers)
+	if err != nil {
+		t.Fatalf("Revalidation range GET failed: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusPartialContent {
+		t.Fatalf("Revalidation range GET: expected 206, got %d", resp2.StatusCode)
+	}
+
+	expectedRange := string(content[0:5]) // "reval"
+	if string(body2) != expectedRange {
+		t.Errorf("Revalidation range GET: expected body %q, got %q", expectedRange, body2)
+	}
+
+	contentRange := resp2.Header.Get("Content-Range")
+	if contentRange == "" {
+		t.Error("Revalidation range GET: expected Content-Range header to be present")
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "HIT" {
+		t.Errorf("Revalidation range GET (unchanged): expected X-Cache HIT, got %q", xCache)
+	}
+	t.Logf("Revalidation range GET unchanged verified: X-Cache=%s, Content-Range=%s", xCache, contentRange)
+}
+
+// TestSDK_Revalidation_GETRange_Changed verifies that a range GET with
+// Cache-Control: no-cache on a changed object returns the correct byte range
+// from the new upstream response (206 path).
+//
+// Flow:
+//  1. PUT object v1 → full GET (cache miss) → cache populated with v1
+//  2. PUT object v2 (different content)
+//  3. GET with Cache-Control: no-cache + Range: bytes=0-4
+//  4. Upstream returns 206 with new range → X-Cache: REVALIDATED
+func TestSDK_Revalidation_GETRange_Changed(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-range-changed")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	contentV1 := []byte("version1 range revalidation data")
+	if err := globalEnv.PutTestObject(bucket, "reval-range-chg-key", contentV1); err != nil {
+		t.Fatalf("Failed to put test object v1: %v", err)
+	}
+
+	// Full GET to populate cache with v1
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-range-chg-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// PUT new content (v2) directly to Tigris, bypassing TAG's cache invalidation.
+	// TAG's cache still holds stale v1 with old ETag.
+	contentV2 := []byte("updated2 range revalidation data")
+	if err := globalEnv.PutTestObjectDirect(bucket, "reval-range-chg-key", contentV2); err != nil {
+		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// Range GET with Cache-Control: no-cache → revalidation
+	// Object changed, upstream returns 206 with new range
+	headers := map[string]string{
+		"Cache-Control": "no-cache",
+		"Range":         "bytes=0-4",
+	}
+	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-range-chg-key", headers)
+	if err != nil {
+		t.Fatalf("Revalidation range GET failed: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusPartialContent {
+		t.Fatalf("Revalidation range GET: expected 206, got %d", resp2.StatusCode)
+	}
+
+	expectedRange := string(contentV2[0:5]) // "updat"
+	if string(body2) != expectedRange {
+		t.Errorf("Revalidation range GET: expected body %q, got %q", expectedRange, body2)
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "REVALIDATED" {
+		t.Errorf("Revalidation range GET (changed): expected X-Cache REVALIDATED, got %q", xCache)
+	}
+	t.Logf("Revalidation range GET changed verified: X-Cache=%s", xCache)
+}
+
+// TestSDK_Revalidation_HEAD_Unchanged verifies that HEAD with Cache-Control: no-cache
+// on an unchanged object returns cached metadata after conditional validation (304 path).
+//
+// Flow:
+//  1. PUT object → GET (cache miss, populates cache + learns ETag)
+//  2. HEAD with Cache-Control: no-cache → TAG sends conditional HEAD to upstream
+//  3. Upstream returns 304 → TAG serves cached metadata with X-Cache: HIT
+func TestSDK_Revalidation_HEAD_Unchanged(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-head-unchanged")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	content := []byte("revalidation head unchanged test content")
+	if err := globalEnv.PutTestObject(bucket, "reval-head-key", content); err != nil {
+		t.Fatalf("Failed to put test object: %v", err)
+	}
+
+	// GET to populate cache and learn ETag
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-head-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// HEAD with Cache-Control: no-cache → revalidation
+	// Object unchanged → upstream 304 → serve cached metadata
+	resp2, err := globalEnv.DoRawHeadWithHeaders(bucket, "reval-head-key", noCacheHeaders())
+	if err != nil {
+		t.Fatalf("Revalidation HEAD failed: %v", err)
+	}
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("Revalidation HEAD: expected 200, got %d", resp2.StatusCode)
+	}
+
+	if resp2.ContentLength != int64(len(content)) {
+		t.Errorf("Revalidation HEAD: expected Content-Length %d, got %d", len(content), resp2.ContentLength)
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "HIT" {
+		t.Errorf("Revalidation HEAD (unchanged): expected X-Cache HIT, got %q", xCache)
+	}
+	t.Logf("Revalidation HEAD unchanged verified: X-Cache=%s, Content-Length=%d", xCache, resp2.ContentLength)
+}
+
+// TestSDK_Revalidation_HEAD_Changed verifies that HEAD with Cache-Control: no-cache
+// on a changed object returns new metadata from upstream (200 path).
+//
+// Flow:
+//  1. PUT object v1 → GET (cache miss) → cache populated with v1
+//  2. PUT object v2 (different size, new ETag)
+//  3. HEAD with Cache-Control: no-cache → TAG sends conditional HEAD to upstream
+//  4. Upstream returns 200 with new metadata → X-Cache: REVALIDATED
+func TestSDK_Revalidation_HEAD_Changed(t *testing.T) {
+	bucket, err := globalEnv.CreateTestBucket("reval-head-changed")
+	if err != nil {
+		t.Fatalf("Failed to create test bucket: %v", err)
+	}
+
+	contentV1 := []byte("head revalidation v1")
+	if err := globalEnv.PutTestObject(bucket, "reval-head-chg-key", contentV1); err != nil {
+		t.Fatalf("Failed to put test object v1: %v", err)
+	}
+
+	// GET to populate cache with v1
+	resp1, err := globalEnv.DoRawGet(bucket, "reval-head-chg-key")
+	if err != nil {
+		t.Fatalf("First GET failed: %v", err)
+	}
+	io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
+	}
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+
+	// Wait for cache to be populated
+	time.Sleep(500 * time.Millisecond)
+
+	// PUT new content v2 directly to Tigris, bypassing TAG's cache invalidation.
+	// TAG's cache still holds stale v1 with old ETag. Different size so Content-Length changes.
+	contentV2 := []byte("head revalidation v2 - updated with more content")
+	if err := globalEnv.PutTestObjectDirect(bucket, "reval-head-chg-key", contentV2); err != nil {
+		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// HEAD with Cache-Control: no-cache → revalidation
+	// Object changed → upstream 200 → new metadata
+	resp2, err := globalEnv.DoRawHeadWithHeaders(bucket, "reval-head-chg-key", noCacheHeaders())
+	if err != nil {
+		t.Fatalf("Revalidation HEAD failed: %v", err)
+	}
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("Revalidation HEAD: expected 200, got %d", resp2.StatusCode)
+	}
+
+	if resp2.ContentLength != int64(len(contentV2)) {
+		t.Errorf("Revalidation HEAD: expected Content-Length %d (v2), got %d", len(contentV2), resp2.ContentLength)
+	}
+
+	xCache := resp2.Header.Get("X-Cache")
+	if xCache != "REVALIDATED" {
+		t.Errorf("Revalidation HEAD (changed): expected X-Cache REVALIDATED, got %q", xCache)
+	}
+	t.Logf("Revalidation HEAD changed verified: X-Cache=%s, Content-Length=%d", xCache, resp2.ContentLength)
+}
+
+// ============================================================================
 // Extended S3 Operation Tests
 // These tests cover additional S3 scenarios from the Tigris e2e test suite.
 // ============================================================================

--- a/tests/s3compat/sdk/testutil.go
+++ b/tests/s3compat/sdk/testutil.go
@@ -43,6 +43,9 @@ type TestEnvironment struct {
 	BucketPrefix string
 	// S3Client is the pre-configured S3 client.
 	S3Client *s3.Client
+	// DirectS3Client connects directly to Tigris (bypassing TAG).
+	// Used by revalidation tests to modify objects without invalidating TAG's cache.
+	DirectS3Client *s3.Client
 
 	// buckets tracks created buckets for cleanup.
 	buckets []string
@@ -69,6 +72,16 @@ func NewTestEnvironment() (*TestEnvironment, error) {
 	// Create S3 client
 	env.S3Client = s3.NewFromConfig(aws.Config{}, func(o *s3.Options) {
 		o.BaseEndpoint = aws.String(env.Endpoint)
+		o.Region = env.Region
+		o.UsePathStyle = true
+		o.Credentials = credentials.NewStaticCredentialsProvider(
+			env.AccessKeyID, env.SecretAccessKey, "")
+	})
+
+	// Create direct-to-Tigris S3 client (bypasses TAG).
+	// Used by revalidation tests to modify objects without invalidating TAG's cache.
+	env.DirectS3Client = s3.NewFromConfig(aws.Config{}, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String("https://t3.storage.dev")
 		o.Region = env.Region
 		o.UsePathStyle = true
 		o.Credentials = credentials.NewStaticCredentialsProvider(
@@ -139,6 +152,18 @@ func (e *TestEnvironment) CreateTestBucket(suffix string) (string, error) {
 // PutTestObject uploads an object to the specified bucket via S3 SDK.
 func (e *TestEnvironment) PutTestObject(bucket, key string, data []byte) error {
 	_, err := e.S3Client.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(data),
+	})
+	return err
+}
+
+// PutTestObjectDirect uploads an object directly to Tigris, bypassing TAG.
+// This allows modifying objects without invalidating TAG's cache, which is needed
+// for testing the revalidation "changed" path (upstream returns 200, not 304).
+func (e *TestEnvironment) PutTestObjectDirect(bucket, key string, data []byte) error {
+	_, err := e.DirectS3Client.PutObject(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(data),
@@ -281,6 +306,37 @@ func (e *TestEnvironment) DoRawHeadUnauthenticated(bucket, key string) (*http.Re
 	req, err := http.NewRequestWithContext(context.Background(), "HEAD", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create unauthenticated HEAD request: %w", err)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// DoRawGetWithHeaders performs a SigV4-signed raw HTTP GET with custom headers.
+// Useful for testing Cache-Control, Range, and other request headers.
+// Caller is responsible for closing the response body.
+func (e *TestEnvironment) DoRawGetWithHeaders(bucket, key string, headers map[string]string) (*http.Response, error) {
+	return e.doRawRequestWithHeaders("GET", bucket, key, headers)
+}
+
+// DoRawHeadWithHeaders performs a SigV4-signed raw HTTP HEAD with custom headers.
+// Useful for testing Cache-Control and other request headers on HEAD requests.
+// Caller is responsible for closing the response body.
+func (e *TestEnvironment) DoRawHeadWithHeaders(bucket, key string, headers map[string]string) (*http.Response, error) {
+	return e.doRawRequestWithHeaders("HEAD", bucket, key, headers)
+}
+
+// doRawRequestWithHeaders performs a SigV4-signed raw HTTP request with custom headers.
+func (e *TestEnvironment) doRawRequestWithHeaders(method, bucket, key string, headers map[string]string) (*http.Response, error) {
+	signer := auth.NewRequestSigner(e.Endpoint, e.Region)
+	path := "/" + bucket + "/" + key
+
+	httpHeaders := make(http.Header)
+	for k, v := range headers {
+		httpHeaders.Set(k, v)
+	}
+
+	req, err := signer.SignRequest(context.Background(), method, path, nil, "", e.AccessKeyID, e.SecretAccessKey, httpHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign %s request with headers: %w", method, err)
 	}
 	return http.DefaultClient.Do(req)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core `GetObject`/`HeadObject` caching behavior by introducing conditional upstream requests, stale-fallback paths, and new cache-status semantics; bugs here could affect correctness and cache efficiency under load. Risk is mitigated by extensive new unit and S3-compat integration tests plus added Prometheus instrumentation.
> 
> **Overview**
> Adds RFC 7234-style cache revalidation: `Cache-Control: no-cache`/`max-age=0` now triggers conditional upstream `GET`/`HEAD` (If-None-Match/If-Modified-Since) when a cached ETag exists, serving cached data on `304` and streaming updated content on `200/206` with **stale-on-error fallback**.
> 
> Introduces explicit cache bypass via `Cache-Control: no-store` (`X-Cache: BYPASS`) and a new `X-Cache: REVALIDATED` status when upstream confirms the object changed; updates request handling to share a common `serveFromCache` path.
> 
> Adds new Prometheus counters for revalidation outcomes, plus documentation updates (`docs/cache-control.md`, metrics reference, README/usage tweaks) and comprehensive unit + S3 SDK tests (including a direct-to-Tigris client) to validate unchanged/changed/range/HEAD revalidation flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21a52d52dbe1cd3cbbf2596628994327cb7559a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->