### PR TITLE
feat: increase default cache TTL to 24h and add TAG_CACHE_TTL env var

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -31,7 +31,7 @@ type Cache struct {
 // NewCacheWithClient creates a cache with an injected client.
 // This allows tests to use an in-memory cache implementation like cacheclient.NewMemoryCache().
 func NewCacheWithClient(client cacheclient.CacheClient, cfg *config.CacheConfig) *Cache {
-	ttl := int64(3600) // Default 1 hour
+	ttl := int64(config.DefaultCacheTTL.Seconds())
 	enabled := true    // Default to enabled
 	if cfg != nil {
 		if cfg.TTL > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -116,7 +116,7 @@ type CredentialsConfig struct {
 // These fields map to github.com/tigrisdata/ocache/embedded.Config.
 type CacheConfig struct {
 	Enabled       *bool         `yaml:"enabled"`        // Enable caching (default: true when nil)
-	TTL           time.Duration `yaml:"ttl"`            // Default cache TTL (default: 60m)
+	TTL           time.Duration `yaml:"ttl"`            // Default cache TTL (default: 24h)
 	SizeThreshold int64         `yaml:"size_threshold"` // Max object size to cache in bytes (default: 1GB)
 
 	// OCache embedded configuration (see github.com/tigrisdata/ocache/embedded)

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ const (
 	DefaultUpstreamRegion = "auto"
 
 	// DefaultCacheTTL is the default cache TTL.
-	DefaultCacheTTL = 60 * time.Minute
+	DefaultCacheTTL = 24 * time.Hour
 
 	// DefaultCacheSizeThreshold is the max object size to cache (1GB).
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
@@ -316,6 +316,12 @@ func applyEnvOverrides(cfg *Config) {
 		if val := os.Getenv("TAG_CACHE_GRPC_AUTH"); val != "" {
 			disabled := val == "false" || val == "0"
 			cfg.Cache.SetGRPCAuth(!disabled)
+		}
+		// Override cache TTL from environment
+		if val := os.Getenv("TAG_CACHE_TTL"); val != "" {
+			if ttl, err := time.ParseDuration(val); err == nil && ttl > 0 {
+				cfg.Cache.TTL = ttl
+			}
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -163,6 +163,30 @@ log:
 	}
 }
 
+func TestLoad_CacheTTLOverrideByEnv(t *testing.T) {
+	content := `
+cache:
+  enabled: true
+  ttl: 10m
+`
+
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	t.Setenv("TAG_CACHE_TTL", "12h")
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Cache.TTL != 12*time.Hour {
+		t.Errorf("Cache.TTL = %v, want 12h", cfg.Cache.TTL)
+	}
+}
+
 func TestLoad_CacheDisabledByEnv(t *testing.T) {
 	// Create a config file with cache enabled
 	content := `

--- a/docs/cache-control.md
+++ b/docs/cache-control.md
@@ -47,7 +47,7 @@ TAG automatically invalidates cached objects when they are modified through TAG:
 - **DeleteObjects** (bulk) — Cache entries deleted for all keys in the request
 - **CopyObject** — Cache entry deleted for the destination key
 
-Objects modified directly on Tigris (bypassing TAG) remain in cache until they expire (default TTL: 60 minutes) or are revalidated via `Cache-Control: no-cache`.
+Objects modified directly on Tigris (bypassing TAG) remain in cache until they expire (default TTL: 24 hours, configurable via `TAG_CACHE_TTL`) or are revalidated via `Cache-Control: no-cache`.
 
 ## Verifying Cache Behavior
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,26 +4,27 @@ TAG can be configured via a YAML configuration file and/or environment variables
 
 ## Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `AWS_ACCESS_KEY_ID` | S3 access key (must have read-only access for all buckets accessed through TAG) | (required) |
-| `AWS_SECRET_ACCESS_KEY` | S3 secret key for authentication | (required) |
-| `TAG_UPSTREAM_ENDPOINT` | Tigris S3 endpoint URL | `https://t3.storage.dev` |
-| `TAG_MAX_IDLE_CONNS_PER_HOST` | HTTP connection pool size per upstream host | `100` |
-| `TAG_CACHE_DISABLED` | Disable caching (`true` or `1`) | `false` |
-| `TAG_CACHE_DISK_PATH` | Path to cache data directory | `/var/cache/tag` |
-| `TAG_CACHE_MAX_DISK_USAGE` | Max disk usage in bytes (0 = unlimited) | `0` |
-| `TAG_CACHE_NODE_ID` | Unique node identifier for cluster mode | (none) |
-| `TAG_CACHE_CLUSTER_ADDR` | Address for memberlist gossip | `:7000` |
-| `TAG_CACHE_GRPC_ADDR` | Address for gRPC server | `:9000` |
-| `TAG_CACHE_ADVERTISE_ADDR` | Address advertised to other nodes | (defaults to GRPC addr) |
-| `TAG_CACHE_SEED_NODES` | Comma-separated seed nodes for cluster discovery | (none) |
-| `TAG_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
-| `TAG_LOG_FORMAT` | Log format: `json` or `console` | `json` |
-| `TAG_TRANSPARENT_PROXY` | Disable transparent proxy mode (`false` or `0`) | `true` |
-| `TAG_TLS_CERT_FILE` | Path to TLS certificate file (PEM format) | (none) |
-| `TAG_TLS_KEY_FILE` | Path to TLS private key file (PEM format) | (none) |
-| `TAG_PPROF_ENABLED` | Enable pprof endpoints (`true` or `1`) | `false` |
+| Variable                      | Description                                                                     | Default                  |
+| ----------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`           | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
+| `AWS_SECRET_ACCESS_KEY`       | S3 secret key for authentication                                                | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`       | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
+| `TAG_MAX_IDLE_CONNS_PER_HOST` | HTTP connection pool size per upstream host                                     | `100`                    |
+| `TAG_CACHE_TTL`               | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
+| `TAG_CACHE_DISABLED`          | Disable caching (`true` or `1`)                                                 | `false`                  |
+| `TAG_CACHE_DISK_PATH`         | Path to cache data directory                                                    | `/var/cache/tag`         |
+| `TAG_CACHE_MAX_DISK_USAGE`    | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
+| `TAG_CACHE_NODE_ID`           | Unique node identifier for cluster mode                                         | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`      | Address for memberlist gossip                                                   | `:7000`                  |
+| `TAG_CACHE_GRPC_ADDR`         | Address for gRPC server                                                         | `:9000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`    | Address advertised to other nodes                                               | (defaults to GRPC addr)  |
+| `TAG_CACHE_SEED_NODES`        | Comma-separated seed nodes for cluster discovery                                | (none)                   |
+| `TAG_LOG_LEVEL`               | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
+| `TAG_LOG_FORMAT`              | Log format: `json` or `console`                                                 | `json`                   |
+| `TAG_TRANSPARENT_PROXY`       | Disable transparent proxy mode (`false` or `0`)                                 | `true`                   |
+| `TAG_TLS_CERT_FILE`           | Path to TLS certificate file (PEM format)                                       | (none)                   |
+| `TAG_TLS_KEY_FILE`            | Path to TLS private key file (PEM format)                                       | (none)                   |
+| `TAG_PPROF_ENABLED`           | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
 
 ## Configuration File
 
@@ -88,8 +89,9 @@ cache:
   enabled: true
 
   # Default TTL for cached objects
-  # Default: 60m
-  ttl: 60m
+  # Default: 24h
+  # Override with TAG_CACHE_TTL env var
+  ttl: 24h
 
   # Maximum object size to cache (in bytes)
   # Objects larger than this are not cached
@@ -155,28 +157,29 @@ log:
 
 Controls the HTTP server settings.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `http_port` | int | `8080` | Port for the S3 API |
-| `bind_ip` | string | `"0.0.0.0"` | IP address to bind to |
-| `pprof_enabled` | bool | `false` | Enable pprof profiling endpoints |
-| `tls_cert_file` | string | `""` | Path to TLS certificate file (PEM) |
-| `tls_key_file` | string | `""` | Path to TLS private key file (PEM) |
+| Field           | Type   | Default     | Description                        |
+| --------------- | ------ | ----------- | ---------------------------------- |
+| `http_port`     | int    | `8080`      | Port for the S3 API                |
+| `bind_ip`       | string | `"0.0.0.0"` | IP address to bind to              |
+| `pprof_enabled` | bool   | `false`     | Enable pprof profiling endpoints   |
+| `tls_cert_file` | string | `""`        | Path to TLS certificate file (PEM) |
+| `tls_key_file`  | string | `""`        | Path to TLS private key file (PEM) |
 
 ### Upstream
 
 Configures the connection to upstream Tigris storage.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `endpoint` | string | `"https://t3.storage.dev"` | Tigris S3 endpoint URL |
-| `region` | string | `"auto"` | AWS region for request signing |
-| `max_idle_conns_per_host` | int | `100` | HTTP connection pool size per host |
-| `transparent_proxy` | bool | `true` | Forward client requests as-is with proxy headers |
+| Field                     | Type   | Default                    | Description                                      |
+| ------------------------- | ------ | -------------------------- | ------------------------------------------------ |
+| `endpoint`                | string | `"https://t3.storage.dev"` | Tigris S3 endpoint URL                           |
+| `region`                  | string | `"auto"`                   | AWS region for request signing                   |
+| `max_idle_conns_per_host` | int    | `100`                      | HTTP connection pool size per host               |
+| `transparent_proxy`       | bool   | `true`                     | Forward client requests as-is with proxy headers |
 
 **Endpoint Validation:**
 
 The upstream endpoint must be one of the following allowed hosts:
+
 - `localhost` (for local development)
 - `*.tigris.dev` (e.g., `fly.storage.tigris.dev`)
 - `*.storage.dev` (e.g., `t3.storage.dev`)
@@ -199,6 +202,7 @@ TAG_TLS_CERT_FILE=/etc/tag/tls/cert.pem TAG_TLS_KEY_FILE=/etc/tag/tls/key.pem ./
 ```
 
 Or via configuration file:
+
 ```yaml
 server:
   tls_cert_file: "/etc/tag/tls/cert.pem"
@@ -206,6 +210,7 @@ server:
 ```
 
 The certificate file should contain the full chain (server certificate followed by intermediates). For development, you can generate self-signed certificates with:
+
 ```bash
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN=localhost'
 ```
@@ -214,25 +219,27 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 
 Controls the embedded cache behavior. TAG uses an embedded OCache instance with RocksDB storage.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | bool | `true` | Enable caching |
-| `ttl` | duration | `60m` | Default TTL for cached objects |
-| `size_threshold` | int64 | `1073741824` | Max object size to cache (bytes) |
-| `disk_path` | string | `/var/cache/tag` | Path to cache data directory |
-| `max_disk_usage_bytes` | int64 | `0` | Max disk usage (0 = unlimited) |
-| `node_id` | string | `""` | Unique node identifier for cluster mode |
-| `cluster_addr` | string | `:7000` | Address for memberlist gossip |
-| `grpc_addr` | string | `:9000` | Address for gRPC server |
-| `advertise_addr` | string | `""` | Address advertised to other nodes |
-| `seed_nodes` | []string | `[]` | Seed nodes for cluster discovery |
+| Field                  | Type     | Default          | Description                             |
+| ---------------------- | -------- | ---------------- | --------------------------------------- |
+| `enabled`              | bool     | `true`           | Enable caching                          |
+| `ttl`                  | duration | `24h`            | Default TTL for cached objects          |
+| `size_threshold`       | int64    | `1073741824`     | Max object size to cache (bytes)        |
+| `disk_path`            | string   | `/var/cache/tag` | Path to cache data directory            |
+| `max_disk_usage_bytes` | int64    | `0`              | Max disk usage (0 = unlimited)          |
+| `node_id`              | string   | `""`             | Unique node identifier for cluster mode |
+| `cluster_addr`         | string   | `:7000`          | Address for memberlist gossip           |
+| `grpc_addr`            | string   | `:9000`          | Address for gRPC server                 |
+| `advertise_addr`       | string   | `""`             | Address advertised to other nodes       |
+| `seed_nodes`           | []string | `[]`             | Seed nodes for cluster discovery        |
 
 **TTL Format:**
-- `60m` - 60 minutes (default)
+
+- `24h` - 24 hours (default)
 - `1h` - 1 hour
-- `24h` - 24 hours
+- `60m` - 60 minutes
 
 **Size Threshold Examples:**
+
 - `1073741824` - 1GB (default)
 - `104857600` - 100MB
 - `536870912` - 512MB
@@ -240,6 +247,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 **Cluster Mode:**
 
 For multi-node deployments, configure each node with:
+
 - A unique `node_id`
 - The same `seed_nodes` list (all nodes in the cluster)
 - Appropriate `advertise_addr` (reachable from other nodes)
@@ -248,17 +256,19 @@ For multi-node deployments, configure each node with:
 
 Controls request coalescing behavior for concurrent requests.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `chunk_size` | int | `65536` | Streaming chunk size (bytes) |
-| `channel_buffer` | int | `32` | Buffer size per listener (chunks) |
+| Field            | Type | Default | Description                       |
+| ---------------- | ---- | ------- | --------------------------------- |
+| `chunk_size`     | int  | `65536` | Streaming chunk size (bytes)      |
+| `channel_buffer` | int  | `32`    | Buffer size per listener (chunks) |
 
 **Memory Calculation:**
-```
+
+```text
 Memory per broadcast = chunk_size × channel_buffer × num_listeners
 ```
 
 With defaults (64KB chunks, 32 buffer):
+
 - 10 listeners: ~20MB
 - 100 listeners: ~200MB
 
@@ -266,12 +276,13 @@ With defaults (64KB chunks, 32 buffer):
 
 Controls logging output.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `level` | string | `"info"` | Log level |
+| Field    | Type   | Default  | Description                     |
+| -------- | ------ | -------- | ------------------------------- |
+| `level`  | string | `"info"` | Log level                       |
 | `format` | string | `"json"` | Log format: `json` or `console` |
 
 **Log Levels:**
+
 - `debug` - Verbose debugging information
 - `info` - Normal operation messages
 - `warn` - Warning conditions
@@ -287,12 +298,14 @@ TAG_PPROF_ENABLED=true ./tag
 ```
 
 **Endpoints** (when enabled):
+
 - `/debug/pprof/` - Index
 - `/debug/pprof/profile?seconds=30` - CPU profile
 - `/debug/pprof/heap` - Heap profile
 - `/debug/pprof/goroutine` - Goroutine stacks
 
 **Usage with go tool pprof:**
+
 ```bash
 go tool pprof http://localhost:8080/debug/pprof/profile?seconds=30
 go tool pprof http://localhost:8080/debug/pprof/heap
@@ -328,8 +341,8 @@ server:
 cache:
   enabled: true
   disk_path: "/var/cache/tag"
-  max_disk_usage_bytes: 107374182400  # 100GB
-  ttl: 60m
+  max_disk_usage_bytes: 107374182400 # 100GB
+  ttl: 24h
   size_threshold: 1073741824
   node_id: "tag-prod"
 
@@ -353,8 +366,8 @@ server:
 cache:
   enabled: true
   disk_path: "/var/cache/tag"
-  max_disk_usage_bytes: 107374182400  # 100GB
-  ttl: 60m
+  max_disk_usage_bytes: 107374182400 # 100GB
+  ttl: 24h
   size_threshold: 1073741824
   node_id: "tag-prod"
 
@@ -371,12 +384,12 @@ server:
 cache:
   enabled: true
   disk_path: "/var/cache/tag"
-  max_disk_usage_bytes: 107374182400  # 100GB per node
+  max_disk_usage_bytes: 107374182400 # 100GB per node
   ttl: 1h
   size_threshold: 1073741824
 
   # Cluster configuration
-  node_id: "tag-1"  # Unique per node
+  node_id: "tag-1" # Unique per node
   cluster_addr: ":7000"
   grpc_addr: ":9000"
   advertise_addr: "tag-1.tag-svc.default.svc.cluster.local:9000"
@@ -386,8 +399,8 @@ cache:
     - "tag-3.tag-svc.default.svc.cluster.local:7000"
 
 broadcast:
-  chunk_size: 131072    # 128KB chunks
-  channel_buffer: 64    # Larger buffer
+  chunk_size: 131072 # 128KB chunks
+  channel_buffer: 64 # Larger buffer
 
 log:
   level: "info"
@@ -395,9 +408,9 @@ log:
 
 ## Command Line Flags
 
-| Flag | Description |
-|------|-------------|
-| `--config` | Path to configuration file |
+| Flag              | Description                         |
+| ----------------- | ----------------------------------- |
+| `--config`        | Path to configuration file          |
 | `--disable-cache` | Disable caching (pass-through mode) |
 
 **Examples:**

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,12 +23,13 @@ curl http://localhost:8080/metrics
 
 Total number of requests processed by TAG.
 
-| Label | Description |
-|-------|-------------|
+| Label       | Description                                                          |
+| ----------- | -------------------------------------------------------------------- |
 | `operation` | S3 operation: `GetObject`, `PutObject`, `DeleteObject`, `HeadObject` |
-| `status` | Result: `success`, `error`, `auth_error`, `range_not_satisfiable` |
+| `status`    | Result: `success`, `error`, `auth_error`, `range_not_satisfiable`    |
 
 **Example queries:**
+
 ```promql
 # Request rate by operation
 rate(tag_requests_total[5m])
@@ -47,13 +48,14 @@ rate(tag_requests_total{operation="GetObject"}[5m])
 
 Request duration in seconds.
 
-| Label | Description |
-|-------|-------------|
+| Label       | Description  |
+| ----------- | ------------ |
 | `operation` | S3 operation |
 
 **Buckets:** Default Prometheus buckets (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10)
 
 **Example queries:**
+
 ```promql
 # P50 latency
 histogram_quantile(0.5, rate(tag_request_duration_seconds_bucket[5m]))
@@ -74,6 +76,7 @@ rate(tag_request_duration_seconds_sum[5m]) / rate(tag_request_duration_seconds_c
 Total number of cache hits.
 
 **Example queries:**
+
 ```promql
 # Cache hit rate
 rate(tag_cache_hits_total[5m])
@@ -95,12 +98,13 @@ Total number of cache misses.
 
 Total number of cache operations.
 
-| Label | Description |
-|-------|-------------|
-| `operation` | Operation type: `get`, `put`, `delete` |
-| `result` | Result: `hit`, `miss`, `success`, `error` |
+| Label       | Description                               |
+| ----------- | ----------------------------------------- |
+| `operation` | Operation type: `get`, `put`, `delete`    |
+| `result`    | Result: `hit`, `miss`, `success`, `error` |
 
 **Example queries:**
+
 ```promql
 # Cache operation breakdown
 sum by (operation, result) (rate(tag_cache_operations_total[5m]))
@@ -113,6 +117,7 @@ sum by (operation, result) (rate(tag_cache_operations_total[5m]))
 Number of range requests served from cached full objects.
 
 **Example queries:**
+
 ```promql
 # Range cache efficiency
 rate(tag_range_from_cache_hits_total[5m]) /
@@ -128,6 +133,7 @@ rate(tag_requests_total{operation="GetObject"}[5m])
 Number of requests that joined an existing broadcast stream.
 
 **Example queries:**
+
 ```promql
 # Coalescing ratio (higher is better)
 rate(tag_broadcast_shared_total[5m]) /
@@ -153,6 +159,7 @@ Number of listeners disconnected for being too slow.
 Number of currently active broadcast streams.
 
 **Example queries:**
+
 ```promql
 # Active broadcasts over time
 tag_active_broadcasts
@@ -182,6 +189,7 @@ Number of background fetches that completed successfully.
 Number of background fetches that failed.
 
 **Example queries:**
+
 ```promql
 # Background fetch success rate
 rate(tag_background_fetches_succeeded_total[5m]) /
@@ -203,6 +211,7 @@ Number of currently active background fetches.
 Number of cache revalidation attempts (conditional GET/HEAD to upstream). Incremented when a client sends `Cache-Control: no-cache` or `max-age=0` and a cached entry with an ETag exists.
 
 **Example queries:**
+
 ```promql
 # Revalidation rate
 rate(tag_revalidations_triggered_total[5m])
@@ -215,6 +224,7 @@ rate(tag_revalidations_triggered_total[5m])
 Number of revalidations where upstream returned 304 Not Modified (cached entry is still fresh).
 
 **Example queries:**
+
 ```promql
 # Revalidation 304 ratio (higher = better cache freshness)
 rate(tag_revalidations_not_modified_total[5m]) /
@@ -240,6 +250,7 @@ Number of revalidations that failed due to errors or unexpected status codes.
 Number of times stale cached data was served because the revalidation request to upstream failed.
 
 **Example queries:**
+
 ```promql
 # Stale serve ratio (should be low)
 rate(tag_revalidations_stale_served_total[5m]) /
@@ -254,11 +265,12 @@ rate(tag_revalidations_triggered_total[5m])
 
 Upstream (Tigris) request duration in seconds.
 
-| Label | Description |
-|-------|-------------|
+| Label    | Description                                 |
+| -------- | ------------------------------------------- |
 | `method` | HTTP method: `GET`, `PUT`, `DELETE`, `HEAD` |
 
 **Example queries:**
+
 ```promql
 # Upstream P99 latency
 histogram_quantile(0.99, rate(tag_upstream_request_duration_seconds_bucket[5m]))
@@ -270,8 +282,8 @@ histogram_quantile(0.99, rate(tag_upstream_request_duration_seconds_bucket[5m]))
 
 Total number of upstream errors.
 
-| Label | Description |
-|-------|-------------|
+| Label    | Description |
+| -------- | ----------- |
 | `method` | HTTP method |
 
 ### Authentication Metrics
@@ -282,8 +294,8 @@ Total number of upstream errors.
 
 Total number of authentication failures.
 
-| Label | Description |
-|-------|-------------|
+| Label    | Description                                                   |
+| -------- | ------------------------------------------------------------- |
 | `reason` | Failure reason: `invalid_signature`, `unknown_key`, `expired` |
 
 ### Transparent Proxy Metrics
@@ -294,11 +306,12 @@ Total number of authentication failures.
 
 Local authentication validation attempts and results in transparent proxy mode.
 
-| Label | Description |
-|-------|-------------|
+| Label    | Description                                                                                                       |
+| -------- | ----------------------------------------------------------------------------------------------------------------- |
 | `result` | Validation result: `success`, `missing_auth`, `parse_error`, `unknown_key`, `signature_mismatch`, `authz_expired` |
 
 **Example queries:**
+
 ```promql
 # Local auth success rate
 rate(tag_local_auth_validations_total{result="success"}[5m]) /
@@ -340,11 +353,12 @@ Number of active connections.
 
 Total bytes transferred.
 
-| Label | Description |
-|-------|-------------|
+| Label       | Description                     |
+| ----------- | ------------------------------- |
 | `direction` | Transfer direction: `in`, `out` |
 
 **Example queries:**
+
 ```promql
 # Throughput (bytes/sec)
 rate(tag_bytes_transferred_total[5m])
@@ -357,7 +371,7 @@ rate(tag_bytes_transferred_total{direction="out"}[5m])
 
 ```yaml
 scrape_configs:
-  - job_name: 'tag'
+  - job_name: "tag"
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
@@ -368,4 +382,3 @@ scrape_configs:
         action: keep
         regex: "8080"
 ```
-

--- a/docs/s3-compatibility-testing.md
+++ b/docs/s3-compatibility-testing.md
@@ -70,11 +70,11 @@ The test suite is organized into categories based on the [ceph/s3-tests](https:/
 | `test_copy`      | Object copy operations                                             | 9          |
 | `test_tagging`   | Object and bucket tagging operations                               | 15         |
 
-**Total: 214 tests**
+Total: 214 tests
 
 ## Architecture
 
-```
+```text
 ┌─────────────────┐     ┌─────────────────────────────┐     ┌─────────────────┐
 │   s3-tests      │────▶│            TAG              │────▶│     Tigris      │
 │  (ceph/pytest)  │     │   ┌─────────────────────┐   │     │ (t3.storage.dev)│
@@ -123,12 +123,12 @@ make s3-tests-clean
 
 ## Files
 
-| File                                       | Description                                               |
-| ------------------------------------------ | --------------------------------------------------------- |
-| `tests/s3compat/python/run-tests.sh`       | Test runner script (clones s3-tests, runs pytest via tox) |
-| `tests/s3compat/python/s3tests.conf`       | Test configuration template                               |
-| `tests/s3compat/sdk/go_sdk_test.go`        | Go SDK S3 compatibility tests                             |
-| `tests/s3compat/sdk/testutil.go`           | Go SDK test utilities and environment setup                |
+| File                                 | Description                                               |
+| ------------------------------------ | --------------------------------------------------------- |
+| `tests/s3compat/python/run-tests.sh` | Test runner script (clones s3-tests, runs pytest via tox) |
+| `tests/s3compat/python/s3tests.conf` | Test configuration template                               |
+| `tests/s3compat/sdk/go_sdk_test.go`  | Go SDK S3 compatibility tests                             |
+| `tests/s3compat/sdk/testutil.go`     | Go SDK test utilities and environment setup               |
 
 ## Future Improvements
 

--- a/tests/s3compat/sdk/go_sdk_test.go
+++ b/tests/s3compat/sdk/go_sdk_test.go
@@ -1335,8 +1335,7 @@ func TestSDK_Revalidation_GET_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	v1ETag := resp1.Header.Get("ETag")
-	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1348,28 +1347,38 @@ func TestSDK_Revalidation_GET_Changed(t *testing.T) {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
 	}
 
-	// Wait for the update to propagate on Tigris before testing revalidation
-	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-changed-key", v1ETag, 5*time.Second); err != nil {
+	// Wait for v2 content to be visible on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectContent(bucket, "reval-changed-key", contentV2, 5*time.Second); err != nil {
 		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// GET with Cache-Control: no-cache → revalidation
-	// Object changed, so upstream returns 200 with new body
-	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-changed-key", noCacheHeaders())
-	if err != nil {
-		t.Fatalf("Revalidation GET failed: %v", err)
-	}
-	body2, _ := io.ReadAll(resp2.Body)
-	resp2.Body.Close()
+	// Retry: TAG's conditional GET may briefly see stale data on a different
+	// Tigris node than WaitForObjectContent polled, so retry until convergence.
+	var body2 []byte
+	var xCache string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-changed-key", noCacheHeaders())
+		if err != nil {
+			t.Fatalf("Revalidation GET failed: %v", err)
+		}
+		body2, _ = io.ReadAll(resp2.Body)
+		resp2.Body.Close()
 
-	if resp2.StatusCode != http.StatusOK {
-		t.Fatalf("Revalidation GET: expected 200, got %d", resp2.StatusCode)
+		if resp2.StatusCode != http.StatusOK {
+			t.Fatalf("Revalidation GET: expected 200, got %d", resp2.StatusCode)
+		}
+		xCache = resp2.Header.Get("X-Cache")
+		if xCache == "REVALIDATED" {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
+
 	if string(body2) != string(contentV2) {
 		t.Errorf("Revalidation GET: expected body %q, got %q", contentV2, body2)
 	}
-
-	xCache := resp2.Header.Get("X-Cache")
 	if xCache != "REVALIDATED" {
 		t.Errorf("Revalidation GET (changed): expected X-Cache REVALIDATED, got %q", xCache)
 	}
@@ -1475,8 +1484,7 @@ func TestSDK_Revalidation_GETRange_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	v1ETag := resp1.Header.Get("ETag")
-	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1488,34 +1496,43 @@ func TestSDK_Revalidation_GETRange_Changed(t *testing.T) {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
 	}
 
-	// Wait for the update to propagate on Tigris before testing revalidation
-	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-range-chg-key", v1ETag, 5*time.Second); err != nil {
+	// Wait for v2 content to be visible on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectContent(bucket, "reval-range-chg-key", contentV2, 5*time.Second); err != nil {
 		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// Range GET with Cache-Control: no-cache → revalidation
-	// Object changed, upstream returns 206 with new range
+	// Retry: TAG's conditional GET may briefly see stale data on a different
+	// Tigris node than WaitForObjectContent polled.
 	headers := map[string]string{
 		"Cache-Control": "no-cache",
 		"Range":         "bytes=0-4",
 	}
-	resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-range-chg-key", headers)
-	if err != nil {
-		t.Fatalf("Revalidation range GET failed: %v", err)
-	}
-	body2, _ := io.ReadAll(resp2.Body)
-	resp2.Body.Close()
-
-	if resp2.StatusCode != http.StatusPartialContent {
-		t.Fatalf("Revalidation range GET: expected 206, got %d", resp2.StatusCode)
-	}
-
 	expectedRange := string(contentV2[0:5]) // "updat"
+	var body2 []byte
+	var xCache string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp2, err := globalEnv.DoRawGetWithHeaders(bucket, "reval-range-chg-key", headers)
+		if err != nil {
+			t.Fatalf("Revalidation range GET failed: %v", err)
+		}
+		body2, _ = io.ReadAll(resp2.Body)
+		resp2.Body.Close()
+
+		if resp2.StatusCode != http.StatusPartialContent && resp2.StatusCode != http.StatusOK {
+			t.Fatalf("Revalidation range GET: expected 206 or 200, got %d", resp2.StatusCode)
+		}
+		xCache = resp2.Header.Get("X-Cache")
+		if xCache == "REVALIDATED" {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
 	if string(body2) != expectedRange {
 		t.Errorf("Revalidation range GET: expected body %q, got %q", expectedRange, body2)
 	}
-
-	xCache := resp2.Header.Get("X-Cache")
 	if xCache != "REVALIDATED" {
 		t.Errorf("Revalidation range GET (changed): expected X-Cache REVALIDATED, got %q", xCache)
 	}
@@ -1609,8 +1626,7 @@ func TestSDK_Revalidation_HEAD_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	v1ETag := resp1.Header.Get("ETag")
-	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
+	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1622,32 +1638,42 @@ func TestSDK_Revalidation_HEAD_Changed(t *testing.T) {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
 	}
 
-	// Wait for the update to propagate on Tigris before testing revalidation
-	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-head-chg-key", v1ETag, 5*time.Second); err != nil {
+	// Wait for v2 content to be visible on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectContent(bucket, "reval-head-chg-key", contentV2, 5*time.Second); err != nil {
 		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// HEAD with Cache-Control: no-cache → revalidation
-	// Object changed → upstream 200 → new metadata
-	resp2, err := globalEnv.DoRawHeadWithHeaders(bucket, "reval-head-chg-key", noCacheHeaders())
-	if err != nil {
-		t.Fatalf("Revalidation HEAD failed: %v", err)
-	}
-	resp2.Body.Close()
+	// Retry: TAG's conditional HEAD may briefly see stale data on a different
+	// Tigris node than WaitForObjectContent polled.
+	var contentLength int64
+	var xCache string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp2, err := globalEnv.DoRawHeadWithHeaders(bucket, "reval-head-chg-key", noCacheHeaders())
+		if err != nil {
+			t.Fatalf("Revalidation HEAD failed: %v", err)
+		}
+		resp2.Body.Close()
 
-	if resp2.StatusCode != http.StatusOK {
-		t.Fatalf("Revalidation HEAD: expected 200, got %d", resp2.StatusCode)
+		if resp2.StatusCode != http.StatusOK {
+			t.Fatalf("Revalidation HEAD: expected 200, got %d", resp2.StatusCode)
+		}
+		contentLength = resp2.ContentLength
+		xCache = resp2.Header.Get("X-Cache")
+		if xCache == "REVALIDATED" {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
 
-	if resp2.ContentLength != int64(len(contentV2)) {
-		t.Errorf("Revalidation HEAD: expected Content-Length %d (v2), got %d", len(contentV2), resp2.ContentLength)
+	if contentLength != int64(len(contentV2)) {
+		t.Errorf("Revalidation HEAD: expected Content-Length %d (v2), got %d", len(contentV2), contentLength)
 	}
-
-	xCache := resp2.Header.Get("X-Cache")
 	if xCache != "REVALIDATED" {
 		t.Errorf("Revalidation HEAD (changed): expected X-Cache REVALIDATED, got %q", xCache)
 	}
-	t.Logf("Revalidation HEAD changed verified: X-Cache=%s, Content-Length=%d", xCache, resp2.ContentLength)
+	t.Logf("Revalidation HEAD changed verified: X-Cache=%s, Content-Length=%d", xCache, contentLength)
 }
 
 // ============================================================================

--- a/tests/s3compat/sdk/go_sdk_test.go
+++ b/tests/s3compat/sdk/go_sdk_test.go
@@ -1335,7 +1335,8 @@ func TestSDK_Revalidation_GET_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+	v1ETag := resp1.Header.Get("ETag")
+	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1345,6 +1346,11 @@ func TestSDK_Revalidation_GET_Changed(t *testing.T) {
 	contentV2 := []byte("revalidation content version 2 - updated")
 	if err := globalEnv.PutTestObjectDirect(bucket, "reval-changed-key", contentV2); err != nil {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// Wait for the update to propagate on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-changed-key", v1ETag, 5*time.Second); err != nil {
+		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// GET with Cache-Control: no-cache → revalidation
@@ -1469,7 +1475,8 @@ func TestSDK_Revalidation_GETRange_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+	v1ETag := resp1.Header.Get("ETag")
+	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1479,6 +1486,11 @@ func TestSDK_Revalidation_GETRange_Changed(t *testing.T) {
 	contentV2 := []byte("updated2 range revalidation data")
 	if err := globalEnv.PutTestObjectDirect(bucket, "reval-range-chg-key", contentV2); err != nil {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// Wait for the update to propagate on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-range-chg-key", v1ETag, 5*time.Second); err != nil {
+		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// Range GET with Cache-Control: no-cache → revalidation
@@ -1597,7 +1609,8 @@ func TestSDK_Revalidation_HEAD_Changed(t *testing.T) {
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("First GET: expected 200, got %d", resp1.StatusCode)
 	}
-	t.Logf("First GET: X-Cache=%s", resp1.Header.Get("X-Cache"))
+	v1ETag := resp1.Header.Get("ETag")
+	t.Logf("First GET: X-Cache=%s, ETag=%s", resp1.Header.Get("X-Cache"), v1ETag)
 
 	// Wait for cache to be populated
 	time.Sleep(500 * time.Millisecond)
@@ -1607,6 +1620,11 @@ func TestSDK_Revalidation_HEAD_Changed(t *testing.T) {
 	contentV2 := []byte("head revalidation v2 - updated with more content")
 	if err := globalEnv.PutTestObjectDirect(bucket, "reval-head-chg-key", contentV2); err != nil {
 		t.Fatalf("Failed to put test object v2 direct: %v", err)
+	}
+
+	// Wait for the update to propagate on Tigris before testing revalidation
+	if err := globalEnv.WaitForObjectUpdate(bucket, "reval-head-chg-key", v1ETag, 5*time.Second); err != nil {
+		t.Fatalf("Object update did not propagate: %v", err)
 	}
 
 	// HEAD with Cache-Control: no-cache → revalidation

--- a/tests/s3compat/sdk/testutil.go
+++ b/tests/s3compat/sdk/testutil.go
@@ -171,6 +171,25 @@ func (e *TestEnvironment) PutTestObjectDirect(bucket, key string, data []byte) e
 	return err
 }
 
+// WaitForObjectUpdate polls Tigris directly until the object's ETag differs from
+// previousETag, confirming that a direct PUT has propagated. This prevents race
+// conditions in revalidation tests where TAG's conditional GET could arrive before
+// the update is visible on all Tigris servers.
+func (e *TestEnvironment) WaitForObjectUpdate(bucket, key, previousETag string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := e.DirectS3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err == nil && resp.ETag != nil && *resp.ETag != previousETag {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("object %s/%s ETag did not change from %s within %v", bucket, key, previousETag, timeout)
+}
+
 // PutTestObjectWithContentType uploads an object with a specific content type.
 func (e *TestEnvironment) PutTestObjectWithContentType(bucket, key string, data []byte, contentType string) error {
 	_, err := e.S3Client.PutObject(context.Background(), &s3.PutObjectInput{

--- a/tests/s3compat/sdk/testutil.go
+++ b/tests/s3compat/sdk/testutil.go
@@ -171,23 +171,26 @@ func (e *TestEnvironment) PutTestObjectDirect(bucket, key string, data []byte) e
 	return err
 }
 
-// WaitForObjectUpdate polls Tigris directly until the object's ETag differs from
-// previousETag, confirming that a direct PUT has propagated. This prevents race
-// conditions in revalidation tests where TAG's conditional GET could arrive before
-// the update is visible on all Tigris servers.
-func (e *TestEnvironment) WaitForObjectUpdate(bucket, key, previousETag string, timeout time.Duration) error {
+// WaitForObjectContent polls Tigris directly until the object body matches the
+// expected content. This confirms a direct PUT has fully propagated, avoiding
+// race conditions where TAG's conditional GET could see stale data.
+func (e *TestEnvironment) WaitForObjectContent(bucket, key string, expectedContent []byte, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		resp, err := e.DirectS3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+		resp, err := e.DirectS3Client.GetObject(context.Background(), &s3.GetObjectInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 		})
-		if err == nil && resp.ETag != nil && *resp.ETag != previousETag {
-			return nil
+		if err == nil {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if bytes.Equal(body, expectedContent) {
+				return nil
+			}
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return fmt.Errorf("object %s/%s ETag did not change from %s within %v", bucket, key, previousETag, timeout)
+	return fmt.Errorf("object %s/%s content did not match expected within %v", bucket, key, timeout)
 }
 
 // PutTestObjectWithContentType uploads an object with a specific content type.


### PR DESCRIPTION
## Summary
- Change default cache TTL from 60 minutes to 24 hours for better cache hit rates
- Add `TAG_CACHE_TTL` environment variable for runtime configuration (e.g. `TAG_CACHE_TTL=12h`)
- Update documentation and add test for env var override

## Test plan
- [x] `TestLoad_CacheTTLOverrideByEnv` — verifies env var overrides YAML config
- [x] Existing `TestLoad_Defaults` and `TestNewDefault` — verify new 24h default
- [ ] Manual: set `TAG_CACHE_TTL=30m` and verify cache TTL in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default caching behavior by extending object TTL from 60m to 24h, which can increase stale-content windows if upstream objects change outside TAG. Adds a new env override path for TTL parsing that affects runtime cache configuration.
> 
> **Overview**
> **Increases the default cache TTL from 60 minutes to 24 hours** and wires cache construction to use `config.DefaultCacheTTL` rather than an inline constant.
> 
> Adds support for overriding cache TTL via the `TAG_CACHE_TTL` environment variable (duration parsing with positive-value validation), plus a new config test to ensure env values take precedence.
> 
> Updates docs to reflect the new default TTL and document `TAG_CACHE_TTL`, and hardens S3 revalidation SDK tests by waiting for direct-to-upstream writes to propagate and retrying until `X-Cache: REVALIDATED` is observed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7559e4090c5d1c2911e00c78ddb53b947088961a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->