### PR TITLE
fix: warm cache on client cancel to break cold-owner loop

### DIFF
--- a/proxy/cold_owner_test.go
+++ b/proxy/cold_owner_test.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tigrisdata/tag/proxy/broadcast"
+)
+
+// warmForwarder drives fetchAndBroadcast's cold-owner warm branch in isolation.
+// The inline upstream fetch (DoRequestWithCreds) returns doRequestErr;
+// DoFullObjectRequest — reached only via the deduplicated background warm —
+// reports the bucket/key it was asked to fetch on fullObjectFetch.
+type warmForwarder struct {
+	mockForwarder
+	doRequestErr    error
+	fullObjectFetch chan [2]string
+}
+
+func (m *warmForwarder) DoRequestWithCreds(_ context.Context, _ *http.Request, _, _ string) (*http.Response, error) {
+	return nil, m.doRequestErr
+}
+
+func (m *warmForwarder) DoFullObjectRequest(_ context.Context, bucket, key, _, _ string) (*http.Response, error) {
+	m.fullObjectFetch <- [2]string{bucket, key}
+	return nil, errors.New("warm: stop background fetch")
+}
+
+// runFetchAndBroadcast drives fetchAndBroadcast with a pre-canceled context (so
+// writeChunksToResponse returns promptly) and the given inline-fetch error.
+func runFetchAndBroadcast(t *testing.T, doRequestErr error) *warmForwarder {
+	t.Helper()
+	mock := &warmForwarder{
+		doRequestErr:    doRequestErr,
+		fullObjectFetch: make(chan [2]string, 1),
+	}
+	svc, _ := newTestService(mock, true) // empty in-memory cache → GetMeta reports !found
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the cold-owner peer/client deadline has already expired
+
+	bcaster := broadcast.NewBroadcaster(broadcast.DefaultChannelBuffer)
+	req := httptest.NewRequest(http.MethodGet, "/cold-bucket/cold-key", nil)
+	w := httptest.NewRecorder()
+
+	_ = svc.fetchAndBroadcast(ctx, w, req, "cold-bucket", "cold-key", "access", "secret", bcaster, time.Now(), "MISS")
+	return mock
+}
+
+// TestFetchAndBroadcast_WarmsOnContextCancel verifies that when the client
+// context is canceled before the inline fetch populates the cache (issue #63
+// path A) and the upstream was healthy (the fetch was aborted by cancellation,
+// surfacing a context error), fetchAndBroadcast hands warming off to the
+// deduplicated background fetcher.
+func TestFetchAndBroadcast_WarmsOnContextCancel(t *testing.T) {
+	mock := runFetchAndBroadcast(t, context.Canceled)
+
+	select {
+	case got := <-mock.fullObjectFetch:
+		if got[0] != "cold-bucket" || got[1] != "cold-key" {
+			t.Fatalf("background warm fetched %q/%q, want cold-bucket/cold-key", got[0], got[1])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a background warm fetch after a canceled request, but none occurred")
+	}
+}
+
+// TestFetchAndBroadcast_NoWarmOnUpstreamError verifies that when the upstream
+// itself failed (not the client), fetchAndBroadcast does NOT warm — even though
+// the client context is canceled — so a doomed retry never amplifies load
+// against an already-unhealthy upstream.
+func TestFetchAndBroadcast_NoWarmOnUpstreamError(t *testing.T) {
+	mock := runFetchAndBroadcast(t, errors.New("connection refused"))
+
+	select {
+	case got := <-mock.fullObjectFetch:
+		t.Fatalf("unexpected background warm fetch %q/%q on an upstream failure", got[0], got[1])
+	case <-time.After(200 * time.Millisecond):
+		// No warm — correct.
+	}
+}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -33,14 +33,6 @@ var bufferPool = sync.Pool{
 // allocation, and synchronization overhead for small objects.
 const smallObjectThreshold = 64 * 1024 // 64KB
 
-// upstreamFetchTimeout bounds the detached upstream fetch in fetchAndBroadcast.
-// The fetch runs on a context derived from the client request but with
-// cancellation/deadline stripped (context.WithoutCancel), so a client cancel
-// no longer abandons the in-flight fetch that feeds the cache writer. This
-// timeout caps how long that detached fetch may run. It mirrors the upstream
-// HTTP client timeout (see forwarder.go) so the two bounds stay aligned.
-const upstreamFetchTimeout = 5 * time.Minute
-
 // putBuffer returns a buffer to the pool only if it hasn't grown too large.
 // This prevents memory bloat from oversized buffers (e.g., if cached body
 // exceeds metadata claims due to corruption/inconsistency).
@@ -248,25 +240,27 @@ func (s *Service) fetchAndBroadcast(
 	// Subscribe ourselves as the first listener
 	listener := broadcaster.Subscribe()
 
-	// Detach the upstream fetch from the client request context. The fetch feeds
-	// the cache writer (via setupCacheListener inside streamFromUpstream), so if
-	// the client cancels mid-fetch on the raw ctx the source dies, the broadcast
-	// completes with context.Canceled, and the cache write never finalizes — the
-	// cold-owner cancel loop. WithoutCancel preserves request-scoped values
-	// (trace IDs) while dropping cancellation/deadline; the explicit timeout
-	// bounds the now-uncancelable fetch.
-	fetchCtx, fetchCancel := context.WithTimeout(context.WithoutCancel(ctx), upstreamFetchTimeout)
-
 	// Start the upstream fetch in a goroutine
 	go func() {
-		defer fetchCancel()
-		err := s.streamFromUpstream(fetchCtx, r, bucket, key, accessKey, secretKey, broadcaster)
+		err := s.streamFromUpstream(ctx, r, bucket, key, accessKey, secretKey, broadcaster)
 		broadcaster.Complete(err)
 	}()
 
-	// Receive chunks like any other listener. This stays on the client ctx so the
-	// client side still cancels normally; only the upstream fetch is detached.
+	// Receive chunks like any other listener
 	err := s.writeChunksToResponse(ctx, w, listener, xCache)
+
+	// If the client went away before the inline fetch could populate the cache
+	// (a cold owner whose deadline is shorter than the cold fetch cancels here),
+	// hand warming off to the deduplicated background fetcher so the object still
+	// warms — mirroring handleRangeWithBackgroundCache. The background fetch is
+	// detached, deduplicated, size-checked, and guarded by GetMeta(!found), so it
+	// is a no-op on the happy path (object already cached) and cannot accumulate
+	// redundant fetches under a client-cancel storm.
+	if err != nil && s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
+		if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
+			s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+		}
+	}
 
 	status := "success"
 	if err != nil {

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -33,6 +33,14 @@ var bufferPool = sync.Pool{
 // allocation, and synchronization overhead for small objects.
 const smallObjectThreshold = 64 * 1024 // 64KB
 
+// upstreamFetchTimeout bounds the detached upstream fetch in fetchAndBroadcast.
+// The fetch runs on a context derived from the client request but with
+// cancellation/deadline stripped (context.WithoutCancel), so a client cancel
+// no longer abandons the in-flight fetch that feeds the cache writer. This
+// timeout caps how long that detached fetch may run. It mirrors the upstream
+// HTTP client timeout (see forwarder.go) so the two bounds stay aligned.
+const upstreamFetchTimeout = 5 * time.Minute
+
 // putBuffer returns a buffer to the pool only if it hasn't grown too large.
 // This prevents memory bloat from oversized buffers (e.g., if cached body
 // exceeds metadata claims due to corruption/inconsistency).
@@ -240,13 +248,24 @@ func (s *Service) fetchAndBroadcast(
 	// Subscribe ourselves as the first listener
 	listener := broadcaster.Subscribe()
 
+	// Detach the upstream fetch from the client request context. The fetch feeds
+	// the cache writer (via setupCacheListener inside streamFromUpstream), so if
+	// the client cancels mid-fetch on the raw ctx the source dies, the broadcast
+	// completes with context.Canceled, and the cache write never finalizes — the
+	// cold-owner cancel loop. WithoutCancel preserves request-scoped values
+	// (trace IDs) while dropping cancellation/deadline; the explicit timeout
+	// bounds the now-uncancelable fetch.
+	fetchCtx, fetchCancel := context.WithTimeout(context.WithoutCancel(ctx), upstreamFetchTimeout)
+
 	// Start the upstream fetch in a goroutine
 	go func() {
-		err := s.streamFromUpstream(ctx, r, bucket, key, accessKey, secretKey, broadcaster)
+		defer fetchCancel()
+		err := s.streamFromUpstream(fetchCtx, r, bucket, key, accessKey, secretKey, broadcaster)
 		broadcaster.Complete(err)
 	}()
 
-	// Receive chunks like any other listener
+	// Receive chunks like any other listener. This stays on the client ctx so the
+	// client side still cancels normally; only the upstream fetch is detached.
 	err := s.writeChunksToResponse(ctx, w, listener, xCache)
 
 	status := "success"
@@ -608,13 +627,38 @@ func (s *Service) handleRangeWithBackgroundCache(
 	// Format: "bytes 0-499/1234" where 1234 is total size
 	totalSize := extractTotalSizeFromContentRange(resp.Header.Get("Content-Range"))
 
+	// Decide up front whether this response is cacheable. Conditions:
+	// - Response is 206 Partial Content (successful range response)
+	// - Total size is known and within cache threshold
+	// - Cache is enabled
+	// - We have valid credentials for the background fetch
+	cacheable := resp.StatusCode == http.StatusPartialContent &&
+		totalSize > 0 &&
+		totalSize <= s.config.Cache.SizeThreshold &&
+		s.cache.IsEnabled() &&
+		accessKey != "" && secretKey != ""
+
+	// Trigger the background full-object fetch via defer so it fires AFTER
+	// streaming completes regardless of the io.Copy outcome — success OR client
+	// cancel. For a cold owner whose client deadline is shorter than the cold
+	// fetch, io.Copy fails mid-stream; without this the warming fetch never runs
+	// and the same keys are re-fetched on every request (cold-miss/cancel loop).
+	// The fetch is detached + deduplicated and guarded by GetMeta(!found), so
+	// warming the key here is safe and never issues redundant fetches.
+	if cacheable {
+		defer func() {
+			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+			}
+		}()
+	}
+
 	// Write response headers
 	copyHeaders(w.Header(), resp.Header)
 	w.Header().Set(XCacheHeader, XCacheMiss)
 	w.WriteHeader(resp.StatusCode)
 
-	// Stream Range response body to client FIRST (before background fetch)
-	// This ensures the client request completes without resource contention
+	// Stream Range response body to client.
 	n, err := io.Copy(w, resp.Body)
 	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
 	if err != nil {
@@ -623,24 +667,6 @@ func (s *Service) handleRangeWithBackgroundCache(
 	}
 
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
-
-	// Trigger background fetch AFTER streaming completes to avoid resource contention.
-	// Conditions:
-	// - Response is 206 Partial Content (successful range response)
-	// - Total size is known and within cache threshold
-	// - Cache is enabled
-	// - We have valid credentials for the background fetch
-	// - Object is not already cached (prevents redundant fetches when many
-	//   parallel range requests each finish after a prior background fetch completes)
-	if resp.StatusCode == http.StatusPartialContent &&
-		totalSize > 0 &&
-		totalSize <= s.config.Cache.SizeThreshold &&
-		s.cache.IsEnabled() &&
-		accessKey != "" && secretKey != "" {
-		if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-			s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
-		}
-	}
 
 	return nil
 }

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -249,20 +249,27 @@ func (s *Service) fetchAndBroadcast(
 	// Receive chunks like any other listener
 	err := s.writeChunksToResponse(ctx, w, listener, xCache)
 
-	// If the client went away before the inline fetch could populate the cache
-	// (a cold owner whose deadline is shorter than the cold fetch cancels here),
-	// hand warming off to the deduplicated background fetcher so the object still
-	// warms — mirroring handleRangeWithBackgroundCache. The background fetch is
-	// detached, deduplicated, size-checked, and guarded by GetMeta(!found), so it
-	// is a no-op on the happy path (object already cached) and cannot accumulate
-	// redundant fetches under a client-cancel storm.
+	// If the client's context was canceled before the inline fetch could populate
+	// the cache — the cold-owner case, where a peer/client deadline shorter than
+	// the cold fetch aborts streamFromUpstream and starves the inline cache write —
+	// hand warming off to the deduplicated background fetcher (mirroring
+	// handleRangeWithBackgroundCache).
 	//
-	// Exclude ErrSlowConsumer: that drops only the fetcher's client-facing
-	// listener, while streamFromUpstream keeps feeding the separate cache listener
-	// on the still-live ctx, so the inline cache write is in flight and will
-	// finalize — warming here would race a redundant fetch against it.
-	if err != nil && err != broadcast.ErrSlowConsumer &&
-		s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
+	// Gate on ctx cancellation rather than the generic writeChunksToResponse error,
+	// deliberately:
+	//   - Upstream failures (connection refused, 5xx) don't cancel ctx, so we don't
+	//     amplify load against an unhealthy upstream with a doomed background retry.
+	//   - A slow-consumer drop doesn't cancel ctx, and streamFromUpstream keeps
+	//     feeding the separate cache listener, so the inline write finalizes — no
+	//     redundant parallel fetch.
+	// When ctx is canceled the inline write is starved; when it isn't, the inline
+	// write completes — exactly one path populates the cache, never both.
+	//
+	// The background fetch is detached, deduplicated, and GetMeta(!found)-guarded;
+	// fetchFullObjectToCache enforces the size threshold and skips the body download
+	// for oversized objects, so a canceled oversized request costs at most one
+	// deduplicated header round-trip, never a wasted body transfer.
+	if ctx.Err() != nil && s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
 		if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
 			s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
 		}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -253,25 +253,30 @@ func (s *Service) fetchAndBroadcast(
 	// the cache — the cold-owner case, where a peer/client deadline shorter than
 	// the cold fetch aborts streamFromUpstream and starves the inline cache write —
 	// hand warming off to the deduplicated background fetcher (mirroring
-	// handleRangeWithBackgroundCache).
+	// handleRangeWithBackgroundCache). Two gates, both required:
 	//
-	// Gate on ctx cancellation rather than the generic writeChunksToResponse error,
-	// deliberately:
-	//   - Upstream failures (connection refused, 5xx) don't cancel ctx, so we don't
-	//     amplify load against an unhealthy upstream with a doomed background retry.
-	//   - A slow-consumer drop doesn't cancel ctx, and streamFromUpstream keeps
-	//     feeding the separate cache listener, so the inline write finalizes — no
-	//     redundant parallel fetch.
-	// When ctx is canceled the inline write is starved; when it isn't, the inline
-	// write completes — exactly one path populates the cache, never both.
+	//  1. ctx.Err() != nil — only warm when the client went away. A slow-consumer
+	//     drop or any non-cancel failure leaves the inline write streaming to its
+	//     own cache listener on the live ctx, so it finalizes on its own; warming
+	//     there would race a redundant parallel fetch.
+	//  2. the upstream was healthy — wait for the fetch goroutine's recorded
+	//     outcome and skip warming on a genuine upstream failure (connection
+	//     refused, 5xx, mid-stream drop). Otherwise a sustained upstream outage
+	//     would have every timed-out client spawn a doomed background retry,
+	//     amplifying load against an already-sick upstream. (A canceled fetch that
+	//     was otherwise healthy completes with a context error, which still warms.)
 	//
 	// The background fetch is detached, deduplicated, and GetMeta(!found)-guarded;
 	// fetchFullObjectToCache enforces the size threshold and skips the body download
 	// for oversized objects, so a canceled oversized request costs at most one
 	// deduplicated header round-trip, never a wasted body transfer.
 	if ctx.Err() != nil && s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
-		if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-			s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+		<-broadcaster.Done() // the fetch goroutine above records the upstream outcome
+		if upErr := broadcaster.Error(); upErr == nil ||
+			errors.Is(upErr, context.Canceled) || errors.Is(upErr, context.DeadlineExceeded) {
+			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+			}
 		}
 	}
 

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -256,7 +256,13 @@ func (s *Service) fetchAndBroadcast(
 	// detached, deduplicated, size-checked, and guarded by GetMeta(!found), so it
 	// is a no-op on the happy path (object already cached) and cannot accumulate
 	// redundant fetches under a client-cancel storm.
-	if err != nil && s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
+	//
+	// Exclude ErrSlowConsumer: that drops only the fetcher's client-facing
+	// listener, while streamFromUpstream keeps feeding the separate cache listener
+	// on the still-live ctx, so the inline cache write is in flight and will
+	// finalize — warming here would race a redundant fetch against it.
+	if err != nil && err != broadcast.ErrSlowConsumer &&
+		s.cache.IsEnabled() && accessKey != "" && secretKey != "" {
 		if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
 			s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
 		}
@@ -633,12 +639,17 @@ func (s *Service) handleRangeWithBackgroundCache(
 		accessKey != "" && secretKey != ""
 
 	// Trigger the background full-object fetch via defer so it fires AFTER
-	// streaming completes regardless of the io.Copy outcome — success OR client
-	// cancel. For a cold owner whose client deadline is shorter than the cold
-	// fetch, io.Copy fails mid-stream; without this the warming fetch never runs
-	// and the same keys are re-fetched on every request (cold-miss/cancel loop).
-	// The fetch is detached + deduplicated and guarded by GetMeta(!found), so
-	// warming the key here is safe and never issues redundant fetches.
+	// streaming completes regardless of the io.Copy outcome — success OR error.
+	// For a cold owner whose client deadline is shorter than the cold fetch,
+	// io.Copy fails mid-stream; without this the warming fetch never runs and the
+	// same keys are re-fetched on every request (cold-miss/cancel loop).
+	//
+	// This intentionally also fires on upstream-side io.Copy errors (the range
+	// stream closing mid-transfer), not just client disconnects — io.Copy doesn't
+	// distinguish the two and warming is the right response to either. The fetch is
+	// detached, deduplicated (activeBackgroundFetches), and guarded by
+	// GetMeta(!found), so the cost is bounded to at most one background fetch per
+	// key and it's a no-op once the object is cached.
 	if cacheable {
 		defer func() {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {

--- a/tests/integration/cold_owner_test.go
+++ b/tests/integration/cold_owner_test.go
@@ -72,6 +72,10 @@ func TestColdOwner_RangeWarmsCacheOnClientCancel(t *testing.T) {
 	env := NewTestEnvironmentWithCacheHandler(handler)
 	defer env.Close()
 
+	// The shared embedded cache persists across tests and process re-runs
+	// (-count=N, retries), so evict any stale entry to keep the precondition
+	// repeatable.
+	_ = env.Cache.DeleteWithMeta(context.Background(), bucket, key)
 	require.False(t, env.IsCached(bucket, key), "object must start uncached")
 
 	// Issue a signed range request on a cancelable context, read a little, then
@@ -144,6 +148,10 @@ func TestColdOwner_FullObjectWarmsCacheOnClientCancel(t *testing.T) {
 	env := NewTestEnvironmentWithCacheHandler(handler)
 	defer env.Close()
 
+	// The shared embedded cache persists across tests and process re-runs
+	// (-count=N, retries), so evict any stale entry to keep the precondition
+	// repeatable.
+	_ = env.Cache.DeleteWithMeta(context.Background(), bucket, key)
 	require.False(t, env.IsCached(bucket, key), "object must start uncached")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/integration/cold_owner_test.go
+++ b/tests/integration/cold_owner_test.go
@@ -101,37 +101,44 @@ func TestColdOwner_RangeWarmsCacheOnClientCancel(t *testing.T) {
 
 // TestColdOwner_FullObjectWarmsCacheOnClientCancel reproduces issue #63 (path A):
 // a full-object cache miss must finish populating the cache even when the client
-// cancels mid-stream. The upstream fetch that feeds the (already-detached) cache
-// writer now runs on a detached context, so a client cancel no longer abandons
-// the in-flight fetch and starves the cache write.
+// cancels mid-stream. When the client cancels the inline fetch, warming is handed
+// off to the deduplicated background fetcher, which completes on a detached
+// context. Both the inline GET and the warming GET are full-object (no-Range)
+// requests, so the handler simply streams the whole body and tolerates the inline
+// request being cut mid-stream.
 func TestColdOwner_FullObjectWarmsCacheOnClientCancel(t *testing.T) {
 	const bucket = "cold-bucket"
 	const key = "blocks/compacted/02-full.sst"
 
-	body := make([]byte, 4096)
+	// Multi-MB body so TAG is blocked writing to the client when it disconnects,
+	// cutting the inline fetch deterministically on the write side.
+	body := make([]byte, 2*1024*1024)
 	for i := range body {
 		body[i] = byte('a' + (i % 26))
 	}
 	total := len(body)
 
-	fullStarted := make(chan struct{})
-	clientCanceled := make(chan struct{})
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.Itoa(total))
 		w.Header().Set("ETag", `"cold-full-etag"`)
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(http.StatusOK)
-
-		// Emit a prefix and flush so TAG starts streaming to the client, then wait
-		// until the client has canceled before sending the rest. This proves the
-		// fetch (and cache write) complete on the detached context after cancel.
-		_, _ = w.Write(body[:16])
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
+		flusher, _ := w.(http.Flusher)
+		for off := 0; off < total; off += 64 * 1024 {
+			end := off + 64*1024
+			if end > total {
+				end = total
+			}
+			if _, err := w.Write(body[off:end]); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if r.Context().Err() != nil {
+				return
+			}
 		}
-		close(fullStarted)
-		<-clientCanceled
-		_, _ = w.Write(body[16:])
 	}
 
 	env := NewTestEnvironmentWithCacheHandler(handler)
@@ -146,16 +153,13 @@ func TestColdOwner_FullObjectWarmsCacheOnClientCancel(t *testing.T) {
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
-	<-fullStarted
 	buf := make([]byte, 8)
 	_, _ = io.ReadFull(resp.Body, buf)
 	cancel()
 	_ = resp.Body.Close()
 
-	// Release the upstream to send the remaining bytes only after the client has
-	// canceled — the detached fetch must still complete the cache write.
-	close(clientCanceled)
-
+	// Despite the canceled client request, the background warm must populate the
+	// full object so the next request hits and the cold loop terminates.
 	require.True(t, env.WaitForCached(bucket, key, 5*time.Second),
 		"cache should warm after a canceled full-object request (issue #63 path A)")
 

--- a/tests/integration/cold_owner_test.go
+++ b/tests/integration/cold_owner_test.go
@@ -1,0 +1,165 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestColdOwner_RangeWarmsCacheOnClientCancel reproduces issue #63 (path B): a
+// byte-range cache miss must still warm the full object even when the client
+// cancels mid-stream. Previously the background fetch was triggered only after a
+// successful io.Copy, so a client whose deadline was shorter than the cold fetch
+// canceled the stream and the warming fetch never fired — a self-sustaining
+// cold-miss/cancel loop. The fix triggers the (detached, deduplicated) fetch via
+// defer so it runs regardless of the io.Copy outcome.
+func TestColdOwner_RangeWarmsCacheOnClientCancel(t *testing.T) {
+	const bucket = "cold-bucket"
+	const key = "blocks/compacted/01.sst"
+
+	// A multi-MB body ensures TAG is blocked writing to the client (its send
+	// buffers fill because the client stops reading) when the client disconnects,
+	// so io.Copy fails on the write side deterministically — the cold-owner
+	// mid-stream cancel, without relying on context propagation timing.
+	body := make([]byte, 2*1024*1024)
+	for i := range body {
+		body[i] = byte('A' + (i % 26))
+	}
+	total := len(body)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") != "" {
+			// Range request: stream the full body in chunks, stopping when the
+			// client goes away (write error) or the request is canceled.
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", total-1, total))
+			w.Header().Set("Content-Length", strconv.Itoa(total))
+			w.WriteHeader(http.StatusPartialContent)
+			flusher, _ := w.(http.Flusher)
+			for off := 0; off < total; off += 64 * 1024 {
+				end := off + 64*1024
+				if end > total {
+					end = total
+				}
+				if _, err := w.Write(body[off:end]); err != nil {
+					return
+				}
+				if flusher != nil {
+					flusher.Flush()
+				}
+				if r.Context().Err() != nil {
+					return
+				}
+			}
+			return
+		}
+
+		// Full-object background fetch (no Range header): return the whole body so
+		// the cache warms.
+		w.Header().Set("Content-Length", strconv.Itoa(total))
+		w.Header().Set("ETag", `"cold-etag"`)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}
+
+	env := NewTestEnvironmentWithCacheHandler(handler)
+	defer env.Close()
+
+	require.False(t, env.IsCached(bucket, key), "object must start uncached")
+
+	// Issue a signed range request on a cancelable context, read a little, then
+	// cancel — simulating the client walking away before the cold fetch completes.
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := env.Signer.SignRequest(ctx, http.MethodGet, "/"+bucket+"/"+key, nil, "", TestAccessKey, TestSecretKey, http.Header{})
+	require.NoError(t, err)
+	req.Header.Set("Range", "bytes=0-1048575")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	buf := make([]byte, 8)
+	_, _ = io.ReadFull(resp.Body, buf)
+	cancel()
+	_ = resp.Body.Close()
+
+	// Despite the canceled client request, the deferred background fetch must warm
+	// the full object so the next request hits and the cold loop terminates.
+	require.True(t, env.WaitForCached(bucket, key, 5*time.Second),
+		"cache should warm after a canceled range request (issue #63 path B)")
+
+	cachedBody, found := env.GetCachedObject(bucket, key)
+	require.True(t, found, "cached body should be retrievable")
+	require.Equal(t, body, cachedBody, "cached body should match full object")
+}
+
+// TestColdOwner_FullObjectWarmsCacheOnClientCancel reproduces issue #63 (path A):
+// a full-object cache miss must finish populating the cache even when the client
+// cancels mid-stream. The upstream fetch that feeds the (already-detached) cache
+// writer now runs on a detached context, so a client cancel no longer abandons
+// the in-flight fetch and starves the cache write.
+func TestColdOwner_FullObjectWarmsCacheOnClientCancel(t *testing.T) {
+	const bucket = "cold-bucket"
+	const key = "blocks/compacted/02-full.sst"
+
+	body := make([]byte, 4096)
+	for i := range body {
+		body[i] = byte('a' + (i % 26))
+	}
+	total := len(body)
+
+	fullStarted := make(chan struct{})
+	clientCanceled := make(chan struct{})
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(total))
+		w.Header().Set("ETag", `"cold-full-etag"`)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Emit a prefix and flush so TAG starts streaming to the client, then wait
+		// until the client has canceled before sending the rest. This proves the
+		// fetch (and cache write) complete on the detached context after cancel.
+		_, _ = w.Write(body[:16])
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		close(fullStarted)
+		<-clientCanceled
+		_, _ = w.Write(body[16:])
+	}
+
+	env := NewTestEnvironmentWithCacheHandler(handler)
+	defer env.Close()
+
+	require.False(t, env.IsCached(bucket, key), "object must start uncached")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := env.Signer.SignRequest(ctx, http.MethodGet, "/"+bucket+"/"+key, nil, "", TestAccessKey, TestSecretKey, http.Header{})
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	<-fullStarted
+	buf := make([]byte, 8)
+	_, _ = io.ReadFull(resp.Body, buf)
+	cancel()
+	_ = resp.Body.Close()
+
+	// Release the upstream to send the remaining bytes only after the client has
+	// canceled — the detached fetch must still complete the cache write.
+	close(clientCanceled)
+
+	require.True(t, env.WaitForCached(bucket, key, 5*time.Second),
+		"cache should warm after a canceled full-object request (issue #63 path A)")
+
+	cachedBody, found := env.GetCachedObject(bucket, key)
+	require.True(t, found, "cached body should be retrievable")
+	require.Equal(t, body, cachedBody, "cached body should match full object")
+}

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -357,6 +357,72 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	}
 }
 
+// NewTestEnvironmentWithCacheHandler creates a cache-enabled test environment whose
+// upstream is a custom HTTP handler (instead of gofakes3). This is useful for tests
+// that need precise control over the upstream response — e.g. blocking a range
+// response mid-stream to simulate a client cancel. Uses the shared embedded cache.
+func NewTestEnvironmentWithCacheHandler(upstreamHandler http.HandlerFunc) *TestEnvironment {
+	if sharedEmbeddedCache == nil {
+		panic("Shared embedded cache not initialized - TestMain must run first")
+	}
+
+	// Track upstream requests
+	var requestCount int32
+	counter := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	upstream := httptest.NewServer(counter(upstreamHandler))
+
+	// Create credential store with test credentials
+	credStore := auth.NewCredentialStore()
+	credStore.AddCredential(TestAccessKey, TestSecretKey)
+
+	// Create config with cache ENABLED
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTPPort: 8080,
+			BindIP:   "127.0.0.1",
+		},
+		Upstream: config.UpstreamConfig{
+			Endpoint: upstream.URL,
+			Region:   TestRegion,
+		},
+		Cache: config.CacheConfig{
+			TTL:           config.DefaultCacheTTL,
+			SizeThreshold: config.DefaultCacheSizeThreshold,
+		},
+	}
+
+	testCache := cache.NewCacheWithClient(sharedEmbeddedCache, &cfg.Cache)
+
+	forwarder := proxy.NewForwarder(credStore, cfg.Upstream.Endpoint, cfg.Upstream.Region, cfg.Upstream.MaxIdleConnsPerHost, nil, nil)
+	service := proxy.NewService(forwarder, testCache, cfg)
+
+	xCacheTracker := NewXCacheTracker()
+	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
+	tagServer := httptest.NewServer(wrappedRouter)
+
+	signer := auth.NewRequestSigner(tagServer.URL, TestRegion)
+
+	return &TestEnvironment{
+		UpstreamServer:       upstream,
+		TAGServer:            tagServer,
+		CredStore:            credStore,
+		Cache:                testCache,
+		Config:               cfg,
+		Service:              service,
+		Signer:               signer,
+		EmbeddedCache:        sharedEmbeddedCache,
+		UpstreamRequestCount: &requestCount,
+		XCacheTracker:        xCacheTracker,
+	}
+}
+
 // newTestEnvironmentWithUpstream creates a test environment with the given upstream server.
 // If useTLS is true, the TAG server uses HTTPS (required for SDK chunked encoding tests).
 func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Backend, useTLS bool) *TestEnvironment {


### PR DESCRIPTION
## Summary

Fixes #63.

A **cold** TAG node that still owns its share of the consistent-hash ring pins CPU at 40–70 cores and never warms its cache because cache population was gated on the **client request surviving**. When the client/peer deadline is shorter than a cold fetch from Tigris, the client cancels mid-fetch (`context canceled`), the in-flight fetch is abandoned, nothing is cached, and the same large compacted SSTs are re-fetched on every request — a self-sustaining cold-miss/cancel loop with no forward progress. This is the precondition produced by the standard "wipe the PVC + cold restart" remediation, so it triggers reliably.

Both instances of the root cause live in `proxy/get_object.go`. No ocache change is required (the cache `Put` is already on a detached context — the bug is in TAG's request orchestration).

## Changes

### B — range path (the hot path for this workload): `handleRangeWithBackgroundCache`
Trigger the background full-object fetch via `defer` so it fires after `io.Copy` **regardless of outcome** (success or client cancel). The fetch is already detached (`context.Background()`) + deduplicated (`activeBackgroundFetches`) and guarded by `GetMeta(...!found)`, so warming the key on cancel is safe and never issues redundant fetches. Happy-path "after streaming" ordering is preserved (the defer still runs after `io.Copy`).

### A — full-object path: `fetchAndBroadcast`
Run `streamFromUpstream` on `context.WithTimeout(context.WithoutCancel(ctx), upstreamFetchTimeout)` so the fetch that feeds the already-detached cache writer completes even after the client cancels. `writeChunksToResponse` stays on the client ctx so the client side still cancels normally. `WithoutCancel` preserves request-scoped values (trace IDs) while dropping cancellation/deadline; the explicit timeout (5m, mirroring the upstream HTTP client timeout) bounds the now-uncancelable fetch.

## Expected behavior after fix

The first fetch for a key populates the cache (subject to TTL/size policy) even when the triggering request is canceled, so the second request hits and the loop terminates after one fetch per key.

## Tests

- New `NewTestEnvironmentWithCacheHandler` — a cache-enabled integration env backed by a custom upstream handler, for precise control over upstream responses (e.g. holding/cutting a stream mid-flight).
- `TestColdOwner_RangeWarmsCacheOnClientCancel` (path B) and `TestColdOwner_FullObjectWarmsCacheOnClientCancel` (path A): cancel a request mid-stream and assert the full object still lands in cache.
- Full unit suite, cache integration suite, `go vet`, and `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path GetObject orchestration for cache misses; mitigations include deduplication, GetMeta guards, and skipping background warm on genuine upstream failures.
> 
> **Overview**
> Fixes **#63** by stopping the cold-miss/cancel loop where a short client deadline aborts the inline fetch before anything is cached, so the same keys are re-fetched forever on a cold TAG node.
> 
> On **full-object** cache misses (`fetchAndBroadcast`), after the client context is gone it waits for the upstream fetch outcome and, if the object is still uncached and the failure was cancellation/deadline (not a real upstream error), kicks off the existing **deduplicated** `triggerBackgroundCacheFetch` instead of leaving the key cold.
> 
> On **range** cache misses (`handleRangeWithBackgroundCache`), the background full-object warm is scheduled with a **`defer`** so it runs after `io.Copy` whether streaming succeeds or fails (client disconnect / mid-stream error), still guarded by cacheability checks and `GetMeta(!found)`.
> 
> Adds **`NewTestEnvironmentWithCacheHandler`** for integration tests with a controllable upstream, plus unit tests for warm vs no-warm on upstream failure, and integration tests that cancel mid-stream and assert the full object lands in cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb932b8aac0bd243590f316369b3023da0254b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->