### PR TITLE
ci: add warp benchmark integration job

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,64 @@
+name: Warp Benchmarks
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    # Nightly at 07:00 UTC
+    - cron: "0 7 * * *"
+
+env:
+  GO_VERSION: "1.24.2"
+  GOPRIVATE: github.com/tigrisdata
+
+jobs:
+  warp-benchmarks:
+    runs-on: namespace-profile-ubuntu-2404
+    permissions:
+      actions: write
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure git for private modules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Install system dependencies
+        run: make install-deps
+
+      - name: Start TAG (local mode)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make s3-test-local
+
+      - name: Run warp benchmarks
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make bench-warp
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: tests/benchmark/results/
+          if-no-files-found: warn
+
+      - name: Cleanup
+        if: always()
+        run: make s3-test-local-down

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,10 +14,10 @@ env:
 jobs:
   warp-benchmarks:
     runs-on: namespace-profile-ubuntu-2404
+    timeout-minutes: 30
     permissions:
       actions: write
       contents: read
-      packages: write
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tests/s3compat/python/s3-tests/
 tests/s3compat/python/.venv/
 tests/s3compat/python/s3tests.conf.generated
 
+# Warp benchmark results (the warp binary lives under .bin/, ignored above)
+tests/benchmark/results/
+
 # Coverage reports
 coverage.out
 coverage.html

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,17 @@ help:
 	@echo "SDK test targets (Go SDK tests):"
 	@echo "  test-sdk               - Run SDK tests (requires running TAG + AWS creds)"
 	@echo ""
+	@echo "Benchmark test targets (warp):"
+	@echo "  bench-warp             - Benchmark core S3 ops with warp (requires running TAG + AWS creds)"
+	@echo "  bench-warp-clean       - Remove cached warp binary and benchmark results"
+	@echo ""
+	@echo "  Benchmark usage:"
+	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
+	@echo "    export AWS_SECRET_ACCESS_KEY=<your-secret>"
+	@echo "    make s3-test-local      # Start TAG with embedded cache"
+	@echo "    make bench-warp         # Run warp benchmarks (GET/RANGE/PUT/HEAD/LIST/DELETE)"
+	@echo "    make s3-test-local-down # Stop local TAG and cleanup"
+	@echo ""
 	@echo "  Usage:"
 	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
 	@echo "    export AWS_SECRET_ACCESS_KEY=<your-secret>"
@@ -538,5 +549,28 @@ test-sdk: rocksdb-static
 		exit 1; \
 	fi
 	TAG_ENDPOINT=http://localhost:$(TAG_LOCAL_HTTP_PORT) $(CGO_ENV) go test $(BUILD_TAGS) -v -timeout 300s $(TESTFLAGS) ./tests/s3compat/sdk/...
+
+# Benchmark TAG's core S3 operations with warp (requires a running TAG + AWS creds).
+# Start TAG first with: make s3-test-local
+.PHONY: bench-warp
+bench-warp:
+	@echo "Running warp benchmarks against TAG..."
+	@if [ -z "$$AWS_ACCESS_KEY_ID" ] || [ -z "$$AWS_SECRET_ACCESS_KEY" ]; then \
+		echo "Error: AWS credentials not set."; \
+		echo "  export AWS_ACCESS_KEY_ID=<your-key>"; \
+		echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"; \
+		exit 1; \
+	fi
+	@if ! curl -s http://localhost:$(TAG_LOCAL_HTTP_PORT)/health > /dev/null 2>&1; then \
+		echo "Error: TAG not running at localhost:$(TAG_LOCAL_HTTP_PORT)"; \
+		echo "  Start TAG with: make s3-test-local"; \
+		exit 1; \
+	fi
+	cd tests/benchmark && TAG_HTTP_PORT=$(TAG_LOCAL_HTTP_PORT) ./run-warp.sh
+
+.PHONY: bench-warp-clean
+bench-warp-clean:
+	@echo "Cleaning up warp benchmark artifacts..."
+	rm -rf tests/benchmark/.bin tests/benchmark/results
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ help:
 	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
 	@echo "    export AWS_SECRET_ACCESS_KEY=<your-secret>"
 	@echo "    make s3-test-local      # Start TAG with embedded cache"
-	@echo "    make bench-warp         # Run warp benchmarks (GET/RANGE/PUT/HEAD/LIST/DELETE)"
+	@echo "    make bench-warp         # Run warp benchmarks (GET/RANGE/PUT/HEAD/LIST)"
 	@echo "    make s3-test-local-down # Stop local TAG and cleanup"
 	@echo ""
 	@echo "  Usage:"

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -4,14 +4,14 @@ Throughput/latency benchmarks for TAG's core S3 operations using
 [MinIO `warp`](https://github.com/minio/warp). They run `warp` against a local
 TAG instance (which proxies to Tigris) and exercise:
 
-| Operation | warp command | Object size |
-|-----------|--------------|-------------|
-| GET       | `warp get`   | 4 MiB |
+| Operation | warp command                 | Object size                  |
+| --------- | ---------------------------- | ---------------------------- |
+| GET       | `warp get`                   | 4 MiB                        |
 | GET RANGE | `warp get --range-size=4MiB` | 100 MiB object, 4 MiB ranges |
-| PUT       | `warp put`   | 4 MiB |
-| HEAD      | `warp stat`  | 4 MiB |
-| LIST V2   | `warp list`  | 4 MiB |
-| DELETE    | `warp delete`| 4 MiB |
+| PUT       | `warp put`                   | 4 MiB                        |
+| HEAD      | `warp stat`                  | 4 MiB                        |
+| LIST V2   | `warp list`                  | 4 MiB                        |
+| DELETE    | `warp delete`                | 4 MiB                        |
 
 This is a **smoke benchmark**: the run fails if any operation errors. It does not
 enforce performance thresholds — it captures numbers for inspection.
@@ -34,6 +34,7 @@ make s3-test-local-down # stop TAG + cleanup
 ## Results
 
 Per operation, `results/` gets:
+
 - `<op>.log` — full warp run output
 - `<op>.csv.zst` — raw benchmark data (re-analyzable with `warp analyze`)
 - `<op>.analyze.txt` — readable throughput / ops-s / latency-percentile summary
@@ -44,15 +45,15 @@ In CI the `results/` directory is uploaded as the `benchmark-results` artifact.
 
 `run-warp.sh` reads env vars (CI defaults are intentionally small):
 
-| Var | Default | Meaning |
-|-----|---------|---------|
-| `WARP_VERSION` | `v1.5.0` | warp version installed via `go install` |
-| `WARP_HOST` | `localhost:8080` | TAG host:port |
-| `WARP_BUCKET` | `tag-warp-benchmark` | bucket for benchmark data (cleared each run) |
-| `WARP_REGION` | `auto` | SigV4 region (must match TAG's region) |
-| `WARP_DURATION` | `30s` | duration per operation |
-| `WARP_CONCURRENT` | `4` | concurrent operations |
-| `WARP_OBJ_SIZE` / `WARP_OBJECTS` | `4MiB` / `100` | size / count for 4 MiB ops |
+| Var                                                              | Default                 | Meaning                                          |
+| ---------------------------------------------------------------- | ----------------------- | ------------------------------------------------ |
+| `WARP_VERSION`                                                   | `v1.5.0`                | warp version installed via `go install`          |
+| `WARP_HOST`                                                      | `localhost:8080`        | TAG host:port                                    |
+| `WARP_BUCKET`                                                    | `tag-warp-benchmark`    | bucket for benchmark data (cleared each run)     |
+| `WARP_REGION`                                                    | `auto`                  | SigV4 region (must match TAG's region)           |
+| `WARP_DURATION`                                                  | `30s`                   | duration per operation                           |
+| `WARP_CONCURRENT`                                                | `4`                     | concurrent operations                            |
+| `WARP_OBJ_SIZE` / `WARP_OBJECTS`                                 | `4MiB` / `100`          | size / count for 4 MiB ops                       |
 | `WARP_RANGE_OBJ_SIZE` / `WARP_RANGE_SIZE` / `WARP_RANGE_OBJECTS` | `100MiB` / `4MiB` / `8` | GET RANGE large object size / range size / count |
 
 Example, a heavier local run:

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -11,7 +11,6 @@ TAG instance (which proxies to Tigris) and exercise:
 | PUT       | `warp put`                   | 4 MiB                        |
 | HEAD      | `warp stat`                  | 4 MiB                        |
 | LIST V2   | `warp list`                  | 4 MiB                        |
-| DELETE    | `warp delete`                | 4 MiB                        |
 
 This is a **smoke benchmark**: the run fails if any operation errors. It does not
 enforce performance thresholds — it captures numbers for inspection.
@@ -25,7 +24,7 @@ export AWS_ACCESS_KEY_ID=<your-key>
 export AWS_SECRET_ACCESS_KEY=<your-secret>
 
 make s3-test-local      # build + start TAG on :8080 (proxies to Tigris)
-make bench-warp         # install warp (first run), run all 6 ops, write results/
+make bench-warp         # install warp (first run), run all 5 ops, write results/
 make s3-test-local-down # stop TAG + cleanup
 ```
 

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,0 +1,68 @@
+# TAG Warp Benchmarks
+
+Throughput/latency benchmarks for TAG's core S3 operations using
+[MinIO `warp`](https://github.com/minio/warp). They run `warp` against a local
+TAG instance (which proxies to Tigris) and exercise:
+
+| Operation | warp command | Object size |
+|-----------|--------------|-------------|
+| GET       | `warp get`   | 4 MiB |
+| GET RANGE | `warp get --range-size=4MiB` | 100 MiB object, 4 MiB ranges |
+| PUT       | `warp put`   | 4 MiB |
+| HEAD      | `warp stat`  | 4 MiB |
+| LIST V2   | `warp list`  | 4 MiB |
+| DELETE    | `warp delete`| 4 MiB |
+
+This is a **smoke benchmark**: the run fails if any operation errors. It does not
+enforce performance thresholds — it captures numbers for inspection.
+
+## Running locally
+
+Requires Tigris credentials (TAG's own read-only creds, used for signing):
+
+```bash
+export AWS_ACCESS_KEY_ID=<your-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret>
+
+make s3-test-local      # build + start TAG on :8080 (proxies to Tigris)
+make bench-warp         # install warp (first run), run all 6 ops, write results/
+make s3-test-local-down # stop TAG + cleanup
+```
+
+`make bench-warp-clean` removes the cached warp binary (`.bin/`) and `results/`.
+
+## Results
+
+Per operation, `results/` gets:
+- `<op>.log` — full warp run output
+- `<op>.csv.zst` — raw benchmark data (re-analyzable with `warp analyze`)
+- `<op>.analyze.txt` — readable throughput / ops-s / latency-percentile summary
+
+In CI the `results/` directory is uploaded as the `benchmark-results` artifact.
+
+## Tuning
+
+`run-warp.sh` reads env vars (CI defaults are intentionally small):
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `WARP_VERSION` | `v1.5.0` | warp version installed via `go install` |
+| `WARP_HOST` | `localhost:8080` | TAG host:port |
+| `WARP_BUCKET` | `tag-warp-benchmark` | bucket for benchmark data (cleared each run) |
+| `WARP_REGION` | `auto` | SigV4 region (must match TAG's region) |
+| `WARP_DURATION` | `30s` | duration per operation |
+| `WARP_CONCURRENT` | `4` | concurrent operations |
+| `WARP_OBJ_SIZE` / `WARP_OBJECTS` | `4MiB` / `100` | size / count for 4 MiB ops |
+| `WARP_RANGE_OBJ_SIZE` / `WARP_RANGE_SIZE` / `WARP_RANGE_OBJECTS` | `100MiB` / `4MiB` / `8` | GET RANGE large object size / range size / count |
+
+Example, a heavier local run:
+
+```bash
+WARP_DURATION=2m WARP_CONCURRENT=16 WARP_OBJECTS=500 make bench-warp
+```
+
+## CI
+
+The `.github/workflows/benchmark.yaml` job runs nightly (and on demand via
+**workflow_dispatch**). It starts TAG, runs `make bench-warp`, and uploads the
+`results/` directory. It is intentionally **not** run on every PR.

--- a/tests/benchmark/run-warp.sh
+++ b/tests/benchmark/run-warp.sh
@@ -17,8 +17,8 @@
 #   WARP_DURATION      duration per operation             (30s)
 #   WARP_CONCURRENT    concurrent operations              (4)
 #   WARP_OBJ_SIZE      object size for 4MiB ops           (4MiB)
-#   WARP_OBJECTS       object count for 4MiB ops          (100)
-#   WARP_RANGE_OBJ_SIZE large object size for GET RANGE    (100MiB)
+#   WARP_OBJECTS       object count for 4MiB ops          (2000)
+#   WARP_RANGE_OBJ_SIZE large object size for GET RANGE   (100MiB)
 #   WARP_RANGE_SIZE    range read size for GET RANGE      (4MiB)
 #   WARP_RANGE_OBJECTS object count for GET RANGE         (8)
 
@@ -67,7 +67,7 @@ REGION="${WARP_REGION:-auto}"
 DURATION="${WARP_DURATION:-30s}"
 CONCURRENT="${WARP_CONCURRENT:-4}"
 OBJ_SIZE="${WARP_OBJ_SIZE:-4MiB}"
-OBJECTS="${WARP_OBJECTS:-100}"
+OBJECTS="${WARP_OBJECTS:-2000}"
 RANGE_OBJ_SIZE="${WARP_RANGE_OBJ_SIZE:-100MiB}"
 RANGE_SIZE="${WARP_RANGE_SIZE:-4MiB}"
 RANGE_OBJECTS="${WARP_RANGE_OBJECTS:-8}"

--- a/tests/benchmark/run-warp.sh
+++ b/tests/benchmark/run-warp.sh
@@ -3,7 +3,7 @@
 # Modeled after tests/s3compat/python/run-tests.sh
 #
 # Drives MinIO warp against a locally running TAG (which proxies to Tigris) and
-# benchmarks the core S3 operations: GET, GET RANGE, PUT, HEAD, LIST V2, DELETE.
+# benchmarks the core S3 operations: GET, GET RANGE, PUT, HEAD, LIST V2.
 # This is a smoke benchmark: it fails if any operation errors, and writes a
 # human-readable `warp analyze` summary per operation into results/.
 #
@@ -17,7 +17,7 @@
 #   WARP_DURATION      duration per operation             (30s)
 #   WARP_CONCURRENT    concurrent operations              (4)
 #   WARP_OBJ_SIZE      object size for 4MiB ops           (4MiB)
-#   WARP_OBJECTS       object count for 4MiB ops          (2000)
+#   WARP_OBJECTS       object count for 4MiB ops          (100)
 #   WARP_RANGE_OBJ_SIZE large object size for GET RANGE   (100MiB)
 #   WARP_RANGE_SIZE    range read size for GET RANGE      (4MiB)
 #   WARP_RANGE_OBJECTS object count for GET RANGE         (8)
@@ -67,7 +67,7 @@ REGION="${WARP_REGION:-auto}"
 DURATION="${WARP_DURATION:-30s}"
 CONCURRENT="${WARP_CONCURRENT:-4}"
 OBJ_SIZE="${WARP_OBJ_SIZE:-4MiB}"
-OBJECTS="${WARP_OBJECTS:-2000}"
+OBJECTS="${WARP_OBJECTS:-100}"
 RANGE_OBJ_SIZE="${WARP_RANGE_OBJ_SIZE:-100MiB}"
 RANGE_SIZE="${WARP_RANGE_SIZE:-4MiB}"
 RANGE_OBJECTS="${WARP_RANGE_OBJECTS:-8}"
@@ -119,7 +119,6 @@ run_op "get-range" get    --obj.size="$RANGE_OBJ_SIZE" --objects="$RANGE_OBJECTS
 run_op "put"       put    --obj.size="$OBJ_SIZE"
 run_op "head"      stat   --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
 run_op "list"      list   --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
-run_op "delete"    delete --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
 
 # Report results
 echo ""

--- a/tests/benchmark/run-warp.sh
+++ b/tests/benchmark/run-warp.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Warp benchmark runner for TAG (issue #67)
+# Modeled after tests/s3compat/python/run-tests.sh
+#
+# Drives MinIO warp against a locally running TAG (which proxies to Tigris) and
+# benchmarks the core S3 operations: GET, GET RANGE, PUT, HEAD, LIST V2, DELETE.
+# This is a smoke benchmark: it fails if any operation errors, and writes a
+# human-readable `warp analyze` summary per operation into results/.
+#
+# Prerequisites: TAG running locally (e.g. `make s3-test-local`) and AWS creds.
+#
+# Tunable via env vars (CI-friendly defaults shown):
+#   WARP_VERSION       warp version to install            (v1.5.0)
+#   WARP_HOST          TAG host:port                      (localhost:${TAG_HTTP_PORT:-8080})
+#   WARP_BUCKET        bucket for benchmark data          (tag-warp-benchmark)
+#   WARP_REGION        SigV4 region (must match TAG)      (auto)
+#   WARP_DURATION      duration per operation             (30s)
+#   WARP_CONCURRENT    concurrent operations              (4)
+#   WARP_OBJ_SIZE      object size for 4MiB ops           (4MiB)
+#   WARP_OBJECTS       object count for 4MiB ops          (100)
+#   WARP_RANGE_OBJ_SIZE large object size for GET RANGE    (100MiB)
+#   WARP_RANGE_SIZE    range read size for GET RANGE      (4MiB)
+#   WARP_RANGE_OBJECTS object count for GET RANGE         (8)
+
+set -uo pipefail
+
+# Track operation failures
+FAILED_OPS=()
+PASSED_COUNT=0
+
+# Handle Ctrl+C to exit the entire script
+trap 'echo -e "\nInterrupted. Exiting..."; exit 130' INT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$SCRIPT_DIR/.bin"
+RESULTS_DIR="$SCRIPT_DIR/results"
+WARP="$BIN_DIR/warp"
+
+WARP_VERSION="${WARP_VERSION:-v1.5.0}"
+
+# Check for required environment variables
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    echo "Error: AWS credentials not set."
+    echo "  export AWS_ACCESS_KEY_ID=<your-key>"
+    echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"
+    exit 1
+fi
+
+mkdir -p "$BIN_DIR" "$RESULTS_DIR"
+
+# Bootstrap warp: install a pinned version via `go install` if not present.
+# warp publishes no release binaries, so we build from source (Go is required
+# to build TAG anyway). The binary is cached in .bin/ (git-ignored).
+if [ ! -x "$WARP" ]; then
+    echo "Installing warp $WARP_VERSION (this may take a minute)..."
+    if ! GOBIN="$BIN_DIR" go install "github.com/minio/warp@$WARP_VERSION"; then
+        echo "Error: Failed to install warp"
+        exit 1
+    fi
+fi
+echo "Using $("$WARP" --version 2>&1 | head -1)"
+
+# Benchmark configuration (env-overridable)
+HOST="${WARP_HOST:-localhost:${TAG_HTTP_PORT:-8080}}"
+BUCKET="${WARP_BUCKET:-tag-warp-benchmark}"
+REGION="${WARP_REGION:-auto}"
+DURATION="${WARP_DURATION:-30s}"
+CONCURRENT="${WARP_CONCURRENT:-4}"
+OBJ_SIZE="${WARP_OBJ_SIZE:-4MiB}"
+OBJECTS="${WARP_OBJECTS:-100}"
+RANGE_OBJ_SIZE="${WARP_RANGE_OBJ_SIZE:-100MiB}"
+RANGE_SIZE="${WARP_RANGE_SIZE:-4MiB}"
+RANGE_OBJECTS="${WARP_RANGE_OBJECTS:-8}"
+
+# Flags shared by every operation. TAG is plain HTTP locally, so no --tls.
+# --lookup=path matches TAG/SDK path-style addressing; warp clears the bucket
+# before and after each run by default (no --noclear), so ops don't interfere.
+COMMON=(
+    --host="$HOST"
+    --access-key="$AWS_ACCESS_KEY_ID"
+    --secret-key="$AWS_SECRET_ACCESS_KEY"
+    --region="$REGION"
+    --bucket="$BUCKET"
+    --lookup=path
+    --concurrent="$CONCURRENT"
+    --duration="$DURATION"
+)
+
+echo "TAG host: $HOST | bucket: $BUCKET | region: $REGION | duration: $DURATION | concurrent: $CONCURRENT"
+
+# run_op <name> <warp-subcommand> [op-specific flags...]
+# Runs a warp benchmark, tees output to results/<name>.log, and produces a
+# readable summary via `warp analyze` in results/<name>.analyze.txt.
+run_op() {
+    local name="$1"
+    shift
+    local benchdata="$RESULTS_DIR/$name"
+
+    echo ""
+    echo "=== Benchmark: $name ==="
+    if "$WARP" "$@" "${COMMON[@]}" --benchdata="$benchdata" 2>&1 | tee "$RESULTS_DIR/$name.log"; then
+        # warp appends .csv.zst to the --benchdata prefix
+        local matches=( "$benchdata"*.csv.zst )
+        local data="${matches[0]}"
+        if [ -f "$data" ]; then
+            "$WARP" analyze --no-color "$data" 2>&1 | tee "$RESULTS_DIR/$name.analyze.txt"
+        fi
+        PASSED_COUNT=$((PASSED_COUNT + 1))
+    else
+        echo "Operation '$name' FAILED"
+        FAILED_OPS+=("$name")
+    fi
+}
+
+# Core operations. All use 4MiB objects except GET RANGE, which reads 4MiB
+# ranges from 100MiB objects (--range-size implies ranged GETs).
+run_op "get"       get    --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
+run_op "get-range" get    --obj.size="$RANGE_OBJ_SIZE" --objects="$RANGE_OBJECTS" --range-size="$RANGE_SIZE"
+run_op "put"       put    --obj.size="$OBJ_SIZE"
+run_op "head"      stat   --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
+run_op "list"      list   --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
+run_op "delete"    delete --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
+
+# Report results
+echo ""
+echo "========================================="
+echo "Warp Benchmark Summary"
+echo "========================================="
+TOTAL=$((PASSED_COUNT + ${#FAILED_OPS[@]}))
+echo "Total: $TOTAL | Passed: $PASSED_COUNT | Failed: ${#FAILED_OPS[@]}"
+echo "Results (logs + analyze summaries): $RESULTS_DIR"
+echo ""
+
+if [ ${#FAILED_OPS[@]} -eq 0 ]; then
+    echo "All benchmarks completed successfully."
+    exit 0
+else
+    echo "FAILED OPERATIONS:"
+    for failed in "${FAILED_OPS[@]}"; do
+        echo "  - $failed"
+    done
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #67. Adds a benchmark integration job that runs [MinIO `warp`](https://github.com/minio/warp) against a local TAG instance (which proxies to Tigris), exercising the core S3 operations. Structured like the existing S3 compatibility test job (`s3-tests.yaml`) and reusing its TAG lifecycle targets.

Operations benchmarked (4 MiB objects, except GET RANGE):
- **GET**, **PUT**, **HEAD** (`warp stat`), **LIST V2** (`warp list`), **DELETE** — 4 MiB
- **GET RANGE** — reads **4 MiB ranges** from a **100 MiB** object (`warp get --range-size=4MiB`)

## Design decisions (confirmed)

- **Trigger:** `workflow_dispatch` + **nightly schedule** + `workflow_call`. Not on every PR — benchmarks are slow and perf numbers are noisy on shared runners.
- **Results:** smoke + artifact — the job fails if any warp op errors, and per-op `warp analyze` throughput/latency summaries are uploaded as the `benchmark-results` artifact. No hard perf thresholds.

## Changes

- `tests/benchmark/run-warp.sh` — installs a pinned warp (`go install`, since warp ships no release binaries), runs each op, writes `<op>.log` / `<op>.csv.zst` / `<op>.analyze.txt` to `results/`, exits non-zero on any failure. All sizes/durations/concurrency/object-counts are env-overridable with small CI defaults.
- `Makefile` — `bench-warp` (run against a running TAG) and `bench-warp-clean`, plus help entries/usage. Reuses `s3-test-local` / `s3-test-local-down`.
- `.github/workflows/benchmark.yaml` — the CI job (mirrors `s3-tests.yaml`; adds the artifact upload).
- `tests/benchmark/README.md` — usage + tuning knobs.
- `.gitignore` — ignore `tests/benchmark/results/`.

## Verification

- `go install github.com/minio/warp@v1.5.0` builds; subcommands and flags (`--range-size`, `--region`, `--lookup`, `--benchdata`, `analyze`) confirmed against `warp --help`.
- `run-warp.sh` is `shellcheck`-clean and `bash -n`-valid.
- `make -n bench-warp` expands correctly; `make help` shows the new block; `benchmark.yaml` is valid YAML.
- **Live end-to-end** run (warp against TAG→Tigris) was not run locally (no Tigris creds in this environment); it will run via `workflow_dispatch` / nightly using the repo's `AWS_*` secrets. Maintainers can trigger it with `gh workflow run benchmark.yaml`.

## Notes
- No application/Go code changes — CI + scripting only.
- Out of scope (future): cluster-mode benchmarking, perf-regression threshold gating / trend tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, shell, and Makefile-only changes; no runtime application code. Uses existing AWS secrets and local TAG lifecycle targets like other integration workflows.
> 
> **Overview**
> Adds **MinIO warp** smoke benchmarks for TAG’s core S3 paths (GET, ranged GET, PUT, HEAD, LIST) against a local TAG instance, with no perf thresholds—only fail-on-error and captured metrics.
> 
> **CI:** New `.github/workflows/benchmark.yaml` runs on nightly schedule, `workflow_dispatch`, and `workflow_call` (not on every PR). It mirrors the existing S3 compat job: checkout, Go/deps, `make s3-test-local`, `make bench-warp`, upload `tests/benchmark/results/` as `benchmark-results`, then `make s3-test-local-down`.
> 
> **Local/CI runner:** `tests/benchmark/run-warp.sh` pins and `go install`s warp, runs five ops with env-tunable duration/concurrency/sizes, writes logs, `.csv.zst`, and `warp analyze` summaries. `Makefile` adds `bench-warp` / `bench-warp-clean` and help text; `.gitignore` ignores benchmark results; `tests/benchmark/README.md` documents usage and tuning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa6f81bb70bf36b2bd2eb43883aaa00d2cb1df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->