### PR TITLE
fix: bound S3 ingress + cache-populate concurrency (thread-exhaustion/OOM fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ This covers all private repos under the `tigrisdata` org (e.g., `ocache`). Witho
 - **Two-Key Cache Storage**: Objects stored as `meta|bucket|key` (headers/ETag) and `body|bucket|key` (raw bytes)
 - **Tombstone Invalidation**: Writes tombstone marker before DELETE to prevent stale async cache writes
 - **Ingress Admission**: `server.max_inflight_requests` (default 1024) bounds concurrently-served S3 requests; excess is shed with 503 SlowDown. Operational endpoints (`/health`, `/metrics`, `/debug/pprof/*`) are exempt. `0`/unset = default, negative = disabled.
-- **Semaphore-Gated Cache Writes**: `cache.max_concurrent_writes` (default 100) bounds concurrent cache-populate operations; when saturated, objects are served from upstream without being cached. `0`/unset = default, negative = disabled.
+- **Semaphore-Gated Cache Writes**: `cache.max_concurrent_writes` (default 256) bounds concurrent cache-populate operations; when saturated, objects are served from upstream without being cached. `0`/unset = default, negative = disabled.
 
 ## Key Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ This covers all private repos under the `tigrisdata` org (e.g., `ocache`). Witho
 - **Broadcast/Subscriber Pattern**: Request coalescing via `proxy/broadcast/` - streams chunks to multiple listeners simultaneously
 - **Two-Key Cache Storage**: Objects stored as `meta|bucket|key` (headers/ETag) and `body|bucket|key` (raw bytes)
 - **Tombstone Invalidation**: Writes tombstone marker before DELETE to prevent stale async cache writes
-- **Semaphore-Gated Background Ops**: `cacheSemaphore` (100 concurrent) limits background cache writes
+- **Ingress Admission**: `server.max_inflight_requests` (default 1024) bounds concurrently-served S3 requests; excess is shed with 503 SlowDown. Operational endpoints (`/health`, `/metrics`, `/debug/pprof/*`) are exempt. `0`/unset = default, negative = disabled.
+- **Semaphore-Gated Cache Writes**: `cache.max_concurrent_writes` (default 100) bounds concurrent cache-populate operations; when saturated, objects are served from upstream without being cached. `0`/unset = default, negative = disabled.
 
 ## Key Dependencies
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -181,61 +181,6 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	return nil
 }
 
-// GetWithMeta retrieves object metadata and body from cache.
-// Returns metadata, body reader, found flag, and any error.
-func (c *Cache) GetWithMeta(ctx context.Context, bucket, key string) (*CachedObjectMeta, io.Reader, bool, error) {
-	if !c.IsEnabled() {
-		return nil, nil, false, nil
-	}
-
-	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
-
-	// Get metadata first
-	metaBytes, err := c.client.Get(ctx, metaKey)
-	if err != nil {
-		if isNotFoundError(err) {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (meta)")
-			return nil, nil, false, nil
-		}
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta get error")
-		return nil, nil, false, err
-	}
-
-	if metaBytes == nil {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (meta nil)")
-		return nil, nil, false, nil
-	}
-
-	// Decode metadata
-	meta, err := DecodeMeta(metaBytes)
-	if err != nil {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta decode error")
-		return nil, nil, false, err
-	}
-
-	// Get body as stream
-	var buf bytes.Buffer
-	err = c.client.GetStream(ctx, bodyKey, &buf)
-	if err != nil {
-		if isNotFoundError(err) {
-			// Metadata exists but body doesn't - inconsistent state
-			log.Warn().Str("bucket", bucket).Str("key", key).Msg("Cache inconsistent: meta without body")
-			return nil, nil, false, nil
-		}
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body get error")
-		return nil, nil, false, err
-	}
-
-	log.Debug().
-		Str("bucket", bucket).
-		Str("key", key).
-		Int("meta_size", len(metaBytes)).
-		Int("body_size", buf.Len()).
-		Msg("Cache hit with metadata")
-	return meta, &buf, true, nil
-}
-
 // GetMeta retrieves only object metadata from cache (no body).
 // Use this for HEAD requests to avoid fetching the body.
 func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectMeta, bool, error) {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -121,21 +121,6 @@ func TestCache_IsClosed(t *testing.T) {
 func TestCache_DisabledOperationsReturnNil(t *testing.T) {
 	cache := &Cache{enabled: false}
 
-	// GetWithMeta should return not found for disabled cache
-	meta, reader, found, err := cache.GetWithMeta(t.Context(), "bucket", "key")
-	if err != nil {
-		t.Errorf("GetWithMeta() error = %v, want nil", err)
-	}
-	if found {
-		t.Error("GetWithMeta() found = true, want false")
-	}
-	if reader != nil {
-		t.Error("GetWithMeta() reader != nil, want nil")
-	}
-	if meta != nil {
-		t.Error("GetWithMeta() meta != nil, want nil")
-	}
-
 	// PutWithMeta should succeed silently
 	testMeta := &CachedObjectMeta{Bucket: "bucket", Key: "key"}
 	if err := cache.PutWithMeta(t.Context(), "bucket", "key", testMeta, []byte("data"), 60); err != nil {

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -304,7 +304,7 @@ func main() {
 	service := proxy.NewService(forwarder, objectCache, cfg)
 
 	// 6. Initialize HTTP server
-	server := handlers.NewServer(service, cfg.Server.BindIP, cfg.Server.HTTPPort, cfg.Server.PprofEnabled)
+	server := handlers.NewServer(service, cfg.Server.BindIP, cfg.Server.HTTPPort, cfg.Server.PprofEnabled, cfg.Server.MaxInflightRequests)
 	if cfg.Server.TLSEnabled() {
 		server.SetTLS(cfg.Server.TLSCertFile, cfg.Server.TLSKeyFile)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,11 @@ const (
 	// DefaultBindIP is the default bind address.
 	DefaultBindIP = "0.0.0.0"
 
+	// DefaultServerMaxInflightRequests is the default ceiling on concurrently-served
+	// S3 requests. Sized so that, with streaming (per-request memory ~MiB), the
+	// worst case stays well within typical container memory limits.
+	DefaultServerMaxInflightRequests = 1024
+
 	// DefaultUpstreamEndpoint is the default Tigris S3 endpoint.
 	DefaultUpstreamEndpoint = "https://t3.storage.dev"
 
@@ -86,6 +91,10 @@ type ServerConfig struct {
 	PprofEnabled bool   `yaml:"pprof_enabled"` // Enable pprof endpoints (default: false)
 	TLSCertFile  string `yaml:"tls_cert_file"` // Path to TLS certificate file (PEM format)
 	TLSKeyFile   string `yaml:"tls_key_file"`  // Path to TLS private key file (PEM format)
+	// MaxInflightRequests bounds concurrently-served S3 requests; excess requests
+	// are shed with 503 SlowDown so overload becomes backpressure rather than
+	// unbounded goroutine/thread/memory growth (default: DefaultServerMaxInflightRequests).
+	MaxInflightRequests int `yaml:"max_inflight_requests"`
 }
 
 // TLSEnabled returns whether TLS is configured.
@@ -230,6 +239,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Server.BindIP == "" {
 		cfg.Server.BindIP = DefaultBindIP
+	}
+	if cfg.Server.MaxInflightRequests == 0 {
+		cfg.Server.MaxInflightRequests = DefaultServerMaxInflightRequests
 	}
 	// PprofEnabled defaults to false (disabled for security)
 	// Use TAG_PPROF_ENABLED=true to enable

--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,7 @@ const (
 
 	// DefaultCacheMaxConcurrentWrites is the default ceiling on concurrent
 	// cache-populate operations.
-	DefaultCacheMaxConcurrentWrites = 100
+	DefaultCacheMaxConcurrentWrites = 256
 )
 
 // Config holds all configuration for TAG.
@@ -381,6 +381,12 @@ func applyEnvOverrides(cfg *Config) {
 				cfg.Cache.RecoveryWorkers = workers
 			}
 		}
+		// Override concurrent cache-write limit from environment
+		if val := os.Getenv("TAG_CACHE_MAX_CONCURRENT_WRITES"); val != "" {
+			if n, err := strconv.Atoi(val); err == nil && n > 0 {
+				cfg.Cache.MaxConcurrentWrites = n
+			}
+		}
 	}
 
 	// Override log level from environment
@@ -397,6 +403,13 @@ func applyEnvOverrides(cfg *Config) {
 	if port := os.Getenv("TAG_HTTP_PORT"); port != "" {
 		if p, err := strconv.Atoi(port); err == nil && p > 0 {
 			cfg.Server.HTTPPort = p
+		}
+	}
+
+	// Override the ingress in-flight request limit from environment
+	if val := os.Getenv("TAG_MAX_INFLIGHT_REQUESTS"); val != "" {
+		if n, err := strconv.Atoi(val); err == nil && n > 0 {
+			cfg.Server.MaxInflightRequests = n
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -97,7 +97,8 @@ type ServerConfig struct {
 	TLSKeyFile   string `yaml:"tls_key_file"`  // Path to TLS private key file (PEM format)
 	// MaxInflightRequests bounds concurrently-served S3 requests; excess requests
 	// are shed with 503 SlowDown so overload becomes backpressure rather than
-	// unbounded goroutine/thread/memory growth (default: DefaultServerMaxInflightRequests).
+	// unbounded goroutine/thread/memory growth. 0 or unset uses
+	// DefaultServerMaxInflightRequests; a negative value disables the limit.
 	MaxInflightRequests int `yaml:"max_inflight_requests"`
 }
 
@@ -158,7 +159,8 @@ type CacheConfig struct {
 	// MaxConcurrentWrites bounds concurrent cache-populate operations (upstream
 	// fetch + streaming write). When saturated, the object is still served from
 	// upstream but not cached, so the memory/I/O-heavy write path can't grow
-	// unbounded (default: DefaultCacheMaxConcurrentWrites).
+	// unbounded. 0 or unset uses DefaultCacheMaxConcurrentWrites; a negative
+	// value disables the limit.
 	MaxConcurrentWrites int `yaml:"max_concurrent_writes"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,10 @@ const (
 	// startup file recovery. Mirrors ocache storage.DefaultRecoveryWorkers; kept
 	// as a literal so the config package stays free of the cgo/RocksDB dependency.
 	DefaultCacheRecoveryWorkers = 16
+
+	// DefaultCacheMaxConcurrentWrites is the default ceiling on concurrent
+	// cache-populate operations.
+	DefaultCacheMaxConcurrentWrites = 100
 )
 
 // Config holds all configuration for TAG.
@@ -151,6 +155,11 @@ type CacheConfig struct {
 	// Advanced storage tuning (maps to ocache stor.StorageConfig).
 	DeleteBatchSize int `yaml:"delete_batch_size"` // File deletions processed per deletion-queue batch (default: DefaultCacheDeleteBatchSize)
 	RecoveryWorkers int `yaml:"recovery_workers"`  // Parallel workers for startup file recovery (default: DefaultCacheRecoveryWorkers)
+	// MaxConcurrentWrites bounds concurrent cache-populate operations (upstream
+	// fetch + streaming write). When saturated, the object is still served from
+	// upstream but not cached, so the memory/I/O-heavy write path can't grow
+	// unbounded (default: DefaultCacheMaxConcurrentWrites).
+	MaxConcurrentWrites int `yaml:"max_concurrent_writes"`
 }
 
 // IsEnabled returns whether caching is enabled.
@@ -281,6 +290,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Cache.RecoveryWorkers == 0 {
 		cfg.Cache.RecoveryWorkers = DefaultCacheRecoveryWorkers
+	}
+	if cfg.Cache.MaxConcurrentWrites == 0 {
+		cfg.Cache.MaxConcurrentWrites = DefaultCacheMaxConcurrentWrites
 	}
 
 	// Broadcast defaults

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,8 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_SEED_NODES`        | Comma-separated seed nodes for cluster discovery                                | (none)                   |
 | `TAG_CACHE_DELETE_BATCH_SIZE` | File deletions processed per deletion-queue batch                               | `1000`                   |
 | `TAG_CACHE_RECOVERY_WORKERS`  | Parallel workers for startup file recovery                                      | `16`                     |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                    | `256`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`   | Max concurrently-served S3 requests before shedding with 503 SlowDown           | `1024`                   |
 | `TAG_LOG_LEVEL`               | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
 | `TAG_LOG_FORMAT`              | Log format: `json` or `console`                                                 | `json`                   |
 | `TAG_TRANSPARENT_PROXY`       | Disable transparent proxy mode (`false` or `0`)                                 | `true`                   |
@@ -52,6 +54,13 @@ server:
   # Enable pprof profiling endpoints
   # Default: false (disabled for security)
   pprof_enabled: false
+
+  # Max concurrently-served S3 requests; excess is shed with 503 SlowDown so
+  # overload becomes backpressure instead of unbounded goroutine/memory growth.
+  # Operational endpoints (/health, /metrics, /debug/pprof/*) are exempt.
+  # Default: 1024 (0 or unset = default; negative = disabled)
+  # Override with TAG_MAX_INFLIGHT_REQUESTS env var
+  max_inflight_requests: 1024
 
   # Path to TLS certificate file (PEM format)
   # When both tls_cert_file and tls_key_file are set, TAG serves HTTPS
@@ -141,6 +150,13 @@ cache:
   # Override with TAG_CACHE_RECOVERY_WORKERS env var
   recovery_workers: 16
 
+  # Max concurrent cache-populate operations (upstream fetch + streaming write).
+  # When saturated, objects are served from upstream without being cached, so the
+  # memory/I/O-heavy write path can't grow unbounded.
+  # Default: 256 (0 or unset = default; negative = disabled)
+  # Override with TAG_CACHE_MAX_CONCURRENT_WRITES env var
+  max_concurrent_writes: 256
+
 # Broadcast configuration (request coalescing)
 broadcast:
   # Chunk size for streaming (in bytes)
@@ -176,6 +192,7 @@ Controls the HTTP server settings.
 | `pprof_enabled` | bool   | `false`     | Enable pprof profiling endpoints   |
 | `tls_cert_file` | string | `""`        | Path to TLS certificate file (PEM) |
 | `tls_key_file`  | string | `""`        | Path to TLS private key file (PEM) |
+| `max_inflight_requests` | int | `1024` | Max concurrently-served S3 requests before shedding with 503 SlowDown (`0`/unset = default, negative = disabled). `/health`, `/metrics`, `/debug/pprof/*` are exempt. |
 
 ### Upstream
 
@@ -231,20 +248,21 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 
 Controls the embedded cache behavior. TAG uses an embedded OCache instance with RocksDB storage.
 
-| Field                  | Type     | Default          | Description                             |
-| ---------------------- | -------- | ---------------- | --------------------------------------- |
-| `enabled`              | bool     | `true`           | Enable caching                          |
-| `ttl`                  | duration | `24h`            | Default TTL for cached objects          |
-| `size_threshold`       | int64    | `1073741824`     | Max object size to cache (bytes)        |
-| `disk_path`            | string   | `/var/cache/tag` | Path to cache data directory            |
-| `max_disk_usage_bytes` | int64    | `0`              | Max disk usage (0 = unlimited)          |
-| `node_id`              | string   | `""`             | Unique node identifier for cluster mode |
-| `cluster_addr`         | string   | `:7000`          | Address for memberlist gossip           |
-| `grpc_addr`            | string   | `:9000`          | Address for gRPC server                 |
-| `advertise_addr`       | string   | `""`             | Address advertised to other nodes       |
-| `seed_nodes`           | []string | `[]`             | Seed nodes for cluster discovery        |
+| Field                  | Type     | Default          | Description                                       |
+| ---------------------- | -------- | ---------------- | ------------------------------------------------- |
+| `enabled`              | bool     | `true`           | Enable caching                                    |
+| `ttl`                  | duration | `24h`            | Default TTL for cached objects                    |
+| `size_threshold`       | int64    | `1073741824`     | Max object size to cache (bytes)                  |
+| `disk_path`            | string   | `/var/cache/tag` | Path to cache data directory                      |
+| `max_disk_usage_bytes` | int64    | `0`              | Max disk usage (0 = unlimited)                    |
+| `node_id`              | string   | `""`             | Unique node identifier for cluster mode           |
+| `cluster_addr`         | string   | `:7000`          | Address for memberlist gossip                     |
+| `grpc_addr`            | string   | `:9000`          | Address for gRPC server                           |
+| `advertise_addr`       | string   | `""`             | Address advertised to other nodes                 |
+| `seed_nodes`           | []string | `[]`             | Seed nodes for cluster discovery                  |
 | `delete_batch_size`    | int      | `1000`           | File deletions processed per deletion-queue batch |
 | `recovery_workers`     | int      | `16`             | Parallel workers for startup file recovery        |
+| `max_concurrent_writes` | int     | `256`            | Max concurrent cache-populate operations (`0`/unset = default, negative = disabled) |
 
 **TTL Format:**
 

--- a/handlers/admission_test.go
+++ b/handlers/admission_test.go
@@ -4,86 +4,96 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gorilla/mux"
 )
 
-// TestAdmissionMiddleware_ShedsWhenFull verifies that once the in-flight limit
-// is reached, further S3 requests are shed with 503 SlowDown rather than being
-// admitted (which is what converts overload into backpressure instead of
-// unbounded goroutine/thread growth).
-func TestAdmissionMiddleware_ShedsWhenFull(t *testing.T) {
-	s := &Server{admissionSem: make(chan struct{}, 1)}
+// buildAdmissionTestRouter builds a router mirroring a representative subset of
+// the real route registration, with the admission middleware applied. Routing
+// through real mux matching is what populates the {bucket} route variable that
+// admission exemption keys off — so these tests exercise the exemption exactly
+// as it behaves in production (rather than string-matching raw paths).
+func buildAdmissionTestRouter(s *Server, sentinel http.HandlerFunc) http.Handler {
+	r := mux.NewRouter()
+	r.SkipClean(true)
+	r.Use(s.admissionMiddleware)
 
-	block := make(chan struct{})
-	entered := make(chan struct{})
-	h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		entered <- struct{}{} // signal the slot is held
-		<-block               // hold it until released
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	// First request occupies the only slot.
-	go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/key", nil))
-	<-entered
-
-	// Second request must be shed with 503 SlowDown.
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/bucket/key2", nil))
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 (SlowDown) when admission full, got %d", rec.Code)
+	r.HandleFunc("/health", sentinel).Methods("GET")
+	r.Handle("/metrics", sentinel).Methods("GET")
+	if s.pprofEnabled {
+		r.HandleFunc("/debug/pprof/", sentinel)
+		r.HandleFunc("/debug/pprof/heap", sentinel)
 	}
-
-	// Releasing the first frees the slot.
-	close(block)
+	r.HandleFunc("/{bucket}/{object:.+}", sentinel).Methods("GET", "HEAD", "PUT", "DELETE")
+	r.HandleFunc("/{bucket}", sentinel).Methods("GET")
+	return r
 }
 
-// TestAdmissionMiddleware_ExemptPathsBypass verifies operational endpoints are
-// never shed, even when the admission limit is fully occupied. pprof paths are
-// only exempt when pprof is enabled.
-func TestAdmissionMiddleware_ExemptPathsBypass(t *testing.T) {
+// TestAdmission_ShedsS3RequestWhenFull verifies an S3 object request is shed
+// with 503 SlowDown once the in-flight limit is reached.
+func TestAdmission_ShedsS3RequestWhenFull(t *testing.T) {
+	s := &Server{admissionSem: make(chan struct{}, 1)}
+	s.admissionSem <- struct{}{} // occupy the only slot
+
+	router := buildAdmissionTestRouter(s, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("S3 request must be shed, not served, when admission is full")
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/my-bucket/my-key", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (SlowDown), got %d", rec.Code)
+	}
+}
+
+// TestAdmission_ExemptOperationalEndpoints verifies /health, /metrics, and the
+// pprof endpoints are never shed, even when the limit is fully occupied.
+func TestAdmission_ExemptOperationalEndpoints(t *testing.T) {
 	s := &Server{admissionSem: make(chan struct{}, 1), pprofEnabled: true}
 	s.admissionSem <- struct{}{} // fully occupied
 
+	served := 0
+	router := buildAdmissionTestRouter(s, func(w http.ResponseWriter, r *http.Request) { served++ })
+
 	for _, p := range []string{"/health", "/metrics", "/debug/pprof/", "/debug/pprof/heap"} {
-		called := false
-		h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
-		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
-		if !called {
-			t.Fatalf("exempt path %s must bypass admission even when full", p)
-		}
-	}
-}
-
-// TestAdmissionMiddleware_DebugBucketNotExempt guards against the exemption
-// being bypassed by S3 objects: path-style URLs are /{bucket}/{key}, so an
-// object in a bucket named "debug" (/debug/my-key) must still be subject to
-// admission and shed with 503 when full. It must also not be exempt as a pprof
-// path when pprof is disabled.
-func TestAdmissionMiddleware_DebugBucketNotExempt(t *testing.T) {
-	for _, pprofEnabled := range []bool{false, true} {
-		s := &Server{admissionSem: make(chan struct{}, 1), pprofEnabled: pprofEnabled}
-		s.admissionSem <- struct{}{} // fully occupied
-
 		rec := httptest.NewRecorder()
-		h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Fatalf("object in bucket 'debug' must not bypass admission (pprofEnabled=%v)", pprofEnabled)
-		}))
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/my-key", nil))
-		if rec.Code != http.StatusServiceUnavailable {
-			t.Fatalf("bucket 'debug' object should be shed (503) when full, got %d (pprofEnabled=%v)", rec.Code, pprofEnabled)
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		if rec.Code == http.StatusServiceUnavailable {
+			t.Fatalf("operational endpoint %s must not be shed", p)
 		}
+	}
+	if served != 4 {
+		t.Fatalf("expected 4 operational requests served, got %d", served)
 	}
 }
 
-// TestAdmissionMiddleware_NilSemUnlimited verifies a nil semaphore (limit <= 0)
-// disables admission control entirely.
-func TestAdmissionMiddleware_NilSemUnlimited(t *testing.T) {
-	s := &Server{} // admissionSem nil = unlimited
-	calls := 0
-	h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { calls++ }))
-	for i := 0; i < 5; i++ {
-		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/b/k", nil))
+// TestAdmission_PprofLikeS3KeyNotExempt is the regression test for the pprof
+// prefix bypass: with pprof enabled, an object key that looks like a pprof path
+// (bucket "debug", key "pprof/large-object") does not match the exact pprof
+// routes, so mux routes it to the object handler with a {bucket} var — it must
+// be subject to admission, not exempt.
+func TestAdmission_PprofLikeS3KeyNotExempt(t *testing.T) {
+	s := &Server{admissionSem: make(chan struct{}, 1), pprofEnabled: true}
+	s.admissionSem <- struct{}{} // fully occupied
+
+	router := buildAdmissionTestRouter(s, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("an S3 object with a pprof/-like key must be subject to admission")
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/large-object", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for S3 object /debug/pprof/large-object, got %d", rec.Code)
 	}
-	if calls != 5 {
-		t.Fatalf("nil admissionSem must not limit; got %d calls", calls)
+}
+
+// TestAdmission_NilSemUnlimited verifies a nil semaphore disables admission.
+func TestAdmission_NilSemUnlimited(t *testing.T) {
+	s := &Server{} // admissionSem nil = unlimited
+	served := 0
+	router := buildAdmissionTestRouter(s, func(w http.ResponseWriter, r *http.Request) { served++ })
+	for i := 0; i < 5; i++ {
+		router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/b/k", nil))
+	}
+	if served != 5 {
+		t.Fatalf("nil admissionSem must not limit; got %d served", served)
 	}
 }

--- a/handlers/admission_test.go
+++ b/handlers/admission_test.go
@@ -26,6 +26,7 @@ func buildAdmissionTestRouter(s *Server, sentinel http.HandlerFunc) http.Handler
 	}
 	r.HandleFunc("/{bucket}/{object:.+}", sentinel).Methods("GET", "HEAD", "PUT", "DELETE")
 	r.HandleFunc("/{bucket}", sentinel).Methods("GET")
+	r.HandleFunc("/", sentinel).Methods("GET") // ListBuckets (service-level)
 	return r
 }
 
@@ -82,6 +83,23 @@ func TestAdmission_PprofLikeS3KeyNotExempt(t *testing.T) {
 	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/large-object", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 for S3 object /debug/pprof/large-object, got %d", rec.Code)
+	}
+}
+
+// TestAdmission_ListBucketsSubjectToAdmission verifies the service-level
+// ListBuckets route ("/") is bounded by admission — it proxies upstream and has
+// no {bucket} var, so it must not be treated as an exempt operational endpoint.
+func TestAdmission_ListBucketsSubjectToAdmission(t *testing.T) {
+	s := &Server{admissionSem: make(chan struct{}, 1)}
+	s.admissionSem <- struct{}{} // fully occupied
+
+	router := buildAdmissionTestRouter(s, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("ListBuckets (GET /) must be subject to admission")
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for ListBuckets when admission full, got %d", rec.Code)
 	}
 }
 

--- a/handlers/admission_test.go
+++ b/handlers/admission_test.go
@@ -37,17 +37,39 @@ func TestAdmissionMiddleware_ShedsWhenFull(t *testing.T) {
 }
 
 // TestAdmissionMiddleware_ExemptPathsBypass verifies operational endpoints are
-// never shed, even when the admission limit is fully occupied.
+// never shed, even when the admission limit is fully occupied. pprof paths are
+// only exempt when pprof is enabled.
 func TestAdmissionMiddleware_ExemptPathsBypass(t *testing.T) {
-	s := &Server{admissionSem: make(chan struct{}, 1)}
+	s := &Server{admissionSem: make(chan struct{}, 1), pprofEnabled: true}
 	s.admissionSem <- struct{}{} // fully occupied
 
-	for _, p := range []string{"/health", "/metrics", "/debug/pprof/"} {
+	for _, p := range []string{"/health", "/metrics", "/debug/pprof/", "/debug/pprof/heap"} {
 		called := false
 		h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
 		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
 		if !called {
 			t.Fatalf("exempt path %s must bypass admission even when full", p)
+		}
+	}
+}
+
+// TestAdmissionMiddleware_DebugBucketNotExempt guards against the exemption
+// being bypassed by S3 objects: path-style URLs are /{bucket}/{key}, so an
+// object in a bucket named "debug" (/debug/my-key) must still be subject to
+// admission and shed with 503 when full. It must also not be exempt as a pprof
+// path when pprof is disabled.
+func TestAdmissionMiddleware_DebugBucketNotExempt(t *testing.T) {
+	for _, pprofEnabled := range []bool{false, true} {
+		s := &Server{admissionSem: make(chan struct{}, 1), pprofEnabled: pprofEnabled}
+		s.admissionSem <- struct{}{} // fully occupied
+
+		rec := httptest.NewRecorder()
+		h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("object in bucket 'debug' must not bypass admission (pprofEnabled=%v)", pprofEnabled)
+		}))
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/my-key", nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("bucket 'debug' object should be shed (503) when full, got %d (pprofEnabled=%v)", rec.Code, pprofEnabled)
 		}
 	}
 }

--- a/handlers/admission_test.go
+++ b/handlers/admission_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAdmissionMiddleware_ShedsWhenFull verifies that once the in-flight limit
+// is reached, further S3 requests are shed with 503 SlowDown rather than being
+// admitted (which is what converts overload into backpressure instead of
+// unbounded goroutine/thread growth).
+func TestAdmissionMiddleware_ShedsWhenFull(t *testing.T) {
+	s := &Server{admissionSem: make(chan struct{}, 1)}
+
+	block := make(chan struct{})
+	entered := make(chan struct{})
+	h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entered <- struct{}{} // signal the slot is held
+		<-block               // hold it until released
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request occupies the only slot.
+	go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/key", nil))
+	<-entered
+
+	// Second request must be shed with 503 SlowDown.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/bucket/key2", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (SlowDown) when admission full, got %d", rec.Code)
+	}
+
+	// Releasing the first frees the slot.
+	close(block)
+}
+
+// TestAdmissionMiddleware_ExemptPathsBypass verifies operational endpoints are
+// never shed, even when the admission limit is fully occupied.
+func TestAdmissionMiddleware_ExemptPathsBypass(t *testing.T) {
+	s := &Server{admissionSem: make(chan struct{}, 1)}
+	s.admissionSem <- struct{}{} // fully occupied
+
+	for _, p := range []string{"/health", "/metrics", "/debug/pprof/"} {
+		called := false
+		h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
+		if !called {
+			t.Fatalf("exempt path %s must bypass admission even when full", p)
+		}
+	}
+}
+
+// TestAdmissionMiddleware_NilSemUnlimited verifies a nil semaphore (limit <= 0)
+// disables admission control entirely.
+func TestAdmissionMiddleware_NilSemUnlimited(t *testing.T) {
+	s := &Server{} // admissionSem nil = unlimited
+	calls := 0
+	h := s.admissionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { calls++ }))
+	for i := 0; i < 5; i++ {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/b/k", nil))
+	}
+	if calls != 5 {
+		t.Fatalf("nil admissionSem must not limit; got %d calls", calls)
+	}
+}

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -27,14 +27,21 @@ type Server struct {
 	pprofEnabled bool
 	tlsCertFile  string
 	tlsKeyFile   string
+	// admissionSem bounds concurrently-served S3 requests. nil disables admission
+	// control (unlimited).
+	admissionSem chan struct{}
 }
 
 // NewServer creates a new HTTP server.
-func NewServer(service *proxy.Service, bindIP string, port int, pprofEnabled bool) *Server {
+func NewServer(service *proxy.Service, bindIP string, port int, pprofEnabled bool, maxInflight int) *Server {
 	s := &Server{
 		service:      service,
 		bindAddr:     fmt.Sprintf("%s:%d", bindIP, port),
 		pprofEnabled: pprofEnabled,
+	}
+
+	if maxInflight > 0 {
+		s.admissionSem = make(chan struct{}, maxInflight)
 	}
 
 	s.router = s.setupRouter()
@@ -57,6 +64,39 @@ func (s *Server) connectionTrackingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// admissionMiddleware bounds the number of concurrently-served S3 requests. When
+// the limit is saturated it sheds with 503 SlowDown so that overload becomes
+// backpressure instead of unbounded goroutine/OS-thread/memory growth (the
+// thread-exhaustion / OOM failure mode). Operational endpoints (health, metrics,
+// pprof) are exempt so probes and observability keep working under load.
+func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.admissionSem == nil || isExemptFromAdmission(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		select {
+		case s.admissionSem <- struct{}{}:
+			metrics.InflightRequests.Inc()
+			defer func() {
+				<-s.admissionSem
+				metrics.InflightRequests.Dec()
+			}()
+			next.ServeHTTP(w, r)
+		default:
+			metrics.AdmissionShed.Inc()
+			s3err.WriteError(w, r, s3err.ErrSlowDown)
+		}
+	})
+}
+
+// isExemptFromAdmission reports whether a path is a non-S3 operational endpoint
+// that must not be subject to admission control.
+func isExemptFromAdmission(path string) bool {
+	return path == "/health" || path == "/metrics" || strings.HasPrefix(path, "/debug/")
+}
+
 // setupRouter configures the S3-compatible routes.
 func (s *Server) setupRouter() *mux.Router {
 	r := mux.NewRouter()
@@ -64,6 +104,9 @@ func (s *Server) setupRouter() *mux.Router {
 
 	// Apply connection tracking middleware
 	r.Use(s.connectionTrackingMiddleware)
+
+	// Bound concurrently-served S3 requests (sheds with 503 SlowDown when full)
+	r.Use(s.admissionMiddleware)
 
 	// Health check endpoint
 	r.HandleFunc("/health", s.handleHealth).Methods("GET")

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -71,7 +71,7 @@ func (s *Server) connectionTrackingMiddleware(next http.Handler) http.Handler {
 // pprof) are exempt so probes and observability keep working under load.
 func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.admissionSem == nil || !isS3Request(r) {
+		if s.admissionSem == nil || isExemptFromAdmission(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -91,19 +91,27 @@ func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// isS3Request reports whether the matched route is an S3 bucket/object
-// operation, identified by a {bucket} path variable. Admission control applies
-// only to these; the static operational endpoints (/health, /metrics,
-// /debug/pprof/*) carry no route variables and are exempt.
+// isExemptFromAdmission reports whether a request is a non-S3 operational
+// endpoint that must not be subject to admission control. It is a positive
+// allowlist of the operational routes (/health, /metrics, /debug/pprof/*); every
+// other route — including S3 object, bucket, and service-level ListBuckets ("/")
+// operations — is subject to admission.
 //
-// Exemption is decided by the matched route, not by string-matching the request
-// path, because S3 object keys are arbitrary. A path like /debug/pprof/large-key
-// does not match the exact pprof handlers, so mux routes it to the object
-// handler (bucket "debug", key "pprof/large-key") — with a {bucket} var set — and
-// it is correctly subject to admission rather than bypassing it.
-func isS3Request(r *http.Request) bool {
-	_, hasBucket := mux.Vars(r)["bucket"]
-	return hasBucket
+// The decision is made on the matched route's *path template*, not the request
+// path. Templates are fixed at registration (e.g. "/{bucket}/{object:.+}",
+// "/debug/pprof/heap"), so arbitrary S3 object keys cannot forge an exempt path:
+// a request to /debug/pprof/large-key matches the object route whose template is
+// "/{bucket}/{object:.+}", so it is correctly subject to admission.
+func isExemptFromAdmission(r *http.Request) bool {
+	route := mux.CurrentRoute(r)
+	if route == nil {
+		return false
+	}
+	tmpl, err := route.GetPathTemplate()
+	if err != nil {
+		return false
+	}
+	return tmpl == "/health" || tmpl == "/metrics" || strings.HasPrefix(tmpl, "/debug/pprof/")
 }
 
 // setupRouter configures the S3-compatible routes.

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -71,7 +71,7 @@ func (s *Server) connectionTrackingMiddleware(next http.Handler) http.Handler {
 // pprof) are exempt so probes and observability keep working under load.
 func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.admissionSem == nil || isExemptFromAdmission(r.URL.Path) {
+		if s.admissionSem == nil || s.isExemptFromAdmission(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -93,8 +93,19 @@ func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 
 // isExemptFromAdmission reports whether a path is a non-S3 operational endpoint
 // that must not be subject to admission control.
-func isExemptFromAdmission(path string) bool {
-	return path == "/health" || path == "/metrics" || strings.HasPrefix(path, "/debug/")
+//
+// Matching is deliberately precise: path-style S3 objects are /{bucket}/{key},
+// so a broad prefix like "/debug/" would also exempt objects in a bucket named
+// "debug" and let them bypass admission. /health and /metrics are matched
+// exactly (their routes are registered before the bucket routes, so they always
+// shadow same-named buckets). The pprof routes are only registered when pprof is
+// enabled — and, being registered before the bucket routes, they then shadow any
+// "debug" bucket — so we only exempt "/debug/pprof/" when pprof is enabled.
+func (s *Server) isExemptFromAdmission(path string) bool {
+	if path == "/health" || path == "/metrics" {
+		return true
+	}
+	return s.pprofEnabled && strings.HasPrefix(path, "/debug/pprof/")
 }
 
 // setupRouter configures the S3-compatible routes.

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -71,7 +71,7 @@ func (s *Server) connectionTrackingMiddleware(next http.Handler) http.Handler {
 // pprof) are exempt so probes and observability keep working under load.
 func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.admissionSem == nil || s.isExemptFromAdmission(r.URL.Path) {
+		if s.admissionSem == nil || !isS3Request(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -91,21 +91,19 @@ func (s *Server) admissionMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// isExemptFromAdmission reports whether a path is a non-S3 operational endpoint
-// that must not be subject to admission control.
+// isS3Request reports whether the matched route is an S3 bucket/object
+// operation, identified by a {bucket} path variable. Admission control applies
+// only to these; the static operational endpoints (/health, /metrics,
+// /debug/pprof/*) carry no route variables and are exempt.
 //
-// Matching is deliberately precise: path-style S3 objects are /{bucket}/{key},
-// so a broad prefix like "/debug/" would also exempt objects in a bucket named
-// "debug" and let them bypass admission. /health and /metrics are matched
-// exactly (their routes are registered before the bucket routes, so they always
-// shadow same-named buckets). The pprof routes are only registered when pprof is
-// enabled — and, being registered before the bucket routes, they then shadow any
-// "debug" bucket — so we only exempt "/debug/pprof/" when pprof is enabled.
-func (s *Server) isExemptFromAdmission(path string) bool {
-	if path == "/health" || path == "/metrics" {
-		return true
-	}
-	return s.pprofEnabled && strings.HasPrefix(path, "/debug/pprof/")
+// Exemption is decided by the matched route, not by string-matching the request
+// path, because S3 object keys are arbitrary. A path like /debug/pprof/large-key
+// does not match the exact pprof handlers, so mux routes it to the object
+// handler (bucket "debug", key "pprof/large-key") — with a {bucket} var set — and
+// it is correctly subject to admission rather than bypassing it.
+func isS3Request(r *http.Request) bool {
+	_, hasBucket := mux.Vars(r)["bucket"]
+	return hasBucket
 }
 
 // setupRouter configures the S3-compatible routes.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -87,6 +87,24 @@ var (
 		},
 	)
 
+	// InflightRequests tracks the number of S3 requests currently admitted and
+	// being served (bounded by the ingress admission limit).
+	InflightRequests = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "tag_inflight_requests",
+			Help: "Number of S3 requests currently admitted and in flight",
+		},
+	)
+
+	// AdmissionShed counts S3 requests rejected with 503 SlowDown because the
+	// ingress admission limit was saturated.
+	AdmissionShed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_admission_shed_total",
+			Help: "Total S3 requests shed with 503 SlowDown due to the ingress admission limit",
+		},
+	)
+
 	// BytesTransferred tracks bytes transferred.
 	BytesTransferred = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -105,6 +105,16 @@ var (
 		},
 	)
 
+	// CachePopulateSkipped counts cache-populate operations skipped because the
+	// concurrent-cache-write limit was saturated (the object is still served from
+	// upstream, just not cached).
+	CachePopulateSkipped = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_cache_populate_skipped_total",
+			Help: "Total cache populates skipped due to the concurrent-cache-write limit",
+		},
+	)
+
 	// BytesTransferred tracks bytes transferred.
 	BytesTransferred = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/proxy/cache_slot_test.go
+++ b/proxy/cache_slot_test.go
@@ -1,0 +1,36 @@
+package proxy
+
+import "testing"
+
+// TestService_CacheSlotLimit verifies the concurrent-cache-write limiter admits
+// up to its capacity, rejects beyond it (so callers skip caching instead of
+// spawning unbounded populate work), and frees slots on release.
+func TestService_CacheSlotLimit(t *testing.T) {
+	s := &Service{cacheSemaphore: make(chan struct{}, 2)}
+
+	if !s.acquireCacheSlot() {
+		t.Fatal("1st acquire should succeed")
+	}
+	if !s.acquireCacheSlot() {
+		t.Fatal("2nd acquire should succeed")
+	}
+	if s.acquireCacheSlot() {
+		t.Fatal("3rd acquire should fail when the limit (2) is reached")
+	}
+
+	s.releaseCacheSlot()
+	if !s.acquireCacheSlot() {
+		t.Fatal("acquire after release should succeed")
+	}
+}
+
+// TestService_CacheSlotUnlimited verifies a nil semaphore disables the limit.
+func TestService_CacheSlotUnlimited(t *testing.T) {
+	s := &Service{cacheSemaphore: nil}
+	for i := 0; i < 100; i++ {
+		if !s.acquireCacheSlot() {
+			t.Fatal("nil semaphore must always admit")
+		}
+	}
+	s.releaseCacheSlot() // must be a no-op, not panic
+}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -305,6 +305,17 @@ func (s *Service) fetchFullObjectToCache(
 	// Set up cache listener (streams to cache via pipe)
 	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster)
 
+	// The cache populate was declined (concurrent-cache-write limit saturated, or
+	// no listener). This is a background fetch whose only purpose is to populate
+	// the cache — no client is waiting on this broadcaster — so downloading and
+	// broadcasting the full object would add upstream and CPU load under the very
+	// pressure the limit is meant to relieve. Abort instead.
+	if cachePipeWriter == nil {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping background cache fetch - cache populate declined")
+		broadcaster.Complete(nil)
+		return nil
+	}
+
 	// If the original request was anonymous and succeeded, the object is publicly
 	// accessible. Tigris omits X-Amz-Acl for objects inheriting bucket-level access,
 	// so inject public-read to ensure the cached metadata allows anonymous reads.

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -59,6 +59,12 @@ const (
 	minCacheWriteThroughput = 5 * 1024 * 1024 // 5 MB/s
 )
 
+// errCachePopulateDeclined signals that a background cache populate was
+// deliberately skipped because the concurrent-cache-write limit was saturated.
+// It is distinct from a fetch failure so callers do not record it as either a
+// success or a failure.
+var errCachePopulateDeclined = errors.New("cache populate declined: concurrent write limit reached")
+
 // cacheWriteTimeoutForSize returns a timeout scaled to contentLength.
 // Returns at least cacheWriteTimeout (60s), scaling up for large objects.
 func cacheWriteTimeoutForSize(contentLength int64) time.Duration {
@@ -88,16 +94,22 @@ func (s *Service) setupCacheListener(
 	ctx context.Context,
 	bucket, key string,
 	broadcaster *broadcast.Broadcaster,
+	slotHeld bool,
 ) (*io.PipeWriter, chan error) {
 	// Bound concurrent cache-populate operations. When the limit is saturated,
 	// skip caching entirely: the object is still served/forwarded from upstream,
 	// we just don't populate the cache this time. This keeps the memory- and
 	// I/O-heavy write pipeline (pipe + goroutines + streaming RocksDB write) from
-	// growing without bound under load.
-	if !s.acquireCacheSlot() {
-		metrics.CachePopulateSkipped.Inc()
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache populate - concurrent write limit reached")
-		return nil, nil
+	// growing without bound under load. slotHeld is true when the caller has
+	// already reserved a slot (the background path reserves it before the upstream
+	// request); once past this point the slot is owned by this function and is
+	// released on the no-listener path below or by the populate goroutine.
+	if !slotHeld {
+		if !s.acquireCacheSlot() {
+			metrics.CachePopulateSkipped.Inc()
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache populate - concurrent write limit reached")
+			return nil, nil
+		}
 	}
 
 	// Record when this write started - used to check against tombstones
@@ -274,6 +286,23 @@ func (s *Service) fetchFullObjectToCache(
 	publicACL bool,
 	broadcaster *broadcast.Broadcaster,
 ) error {
+	// This is a background fetch whose only purpose is to populate the cache, so
+	// reserve a cache-populate slot up front. If the concurrent-write limit is
+	// saturated, skip the whole operation — including the upstream request —
+	// rather than fetch and then discard the result under the very pressure the
+	// limit is meant to relieve. errCachePopulateDeclined distinguishes this
+	// deliberate skip from a real fetch success/failure for the caller's metrics.
+	if !s.acquireCacheSlot() {
+		metrics.CachePopulateSkipped.Inc()
+		return errCachePopulateDeclined
+	}
+	slotOwned := true
+	defer func() {
+		if slotOwned {
+			s.releaseCacheSlot()
+		}
+	}()
+
 	// Execute full object request (no Range header)
 	resp, err := s.forwarder.DoFullObjectRequest(ctx, bucket, key, accessKey, secretKey)
 	if err != nil {
@@ -302,18 +331,15 @@ func (s *Service) fetchFullObjectToCache(
 		return nil
 	}
 
-	// Set up cache listener (streams to cache via pipe)
-	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster)
-
-	// The cache populate was declined (concurrent-cache-write limit saturated, or
-	// no listener). This is a background fetch whose only purpose is to populate
-	// the cache — no client is waiting on this broadcaster — so downloading and
-	// broadcasting the full object would add upstream and CPU load under the very
-	// pressure the limit is meant to relieve. Abort instead.
+	// Hand the reserved slot to the cache listener (streams to cache via pipe).
+	// Ownership of releasing the slot transfers to setupCacheListener, so drop
+	// our own release regardless of the result.
+	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster, true)
+	slotOwned = false
 	if cachePipeWriter == nil {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping background cache fetch - cache populate declined")
+		// No listener could be created; nothing to populate.
 		broadcaster.Complete(nil)
-		return nil
+		return errCachePopulateDeclined
 	}
 
 	// If the original request was anonymous and succeeded, the object is publicly
@@ -420,10 +446,15 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 
 		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, publicACL, broadcaster)
 
-		if err != nil {
+		switch {
+		case errors.Is(err, errCachePopulateDeclined):
+			// Deliberately skipped because the cache-write limit was saturated —
+			// not a fetch success or failure (already counted as a populate skip).
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background cache fetch skipped - concurrent write limit reached")
+		case err != nil:
 			log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Background cache fetch failed")
 			metrics.RecordBackgroundFetchFailed()
-		} else {
+		default:
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background cache fetch completed")
 			metrics.RecordBackgroundFetchSucceeded()
 		}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -89,11 +89,23 @@ func (s *Service) setupCacheListener(
 	bucket, key string,
 	broadcaster *broadcast.Broadcaster,
 ) (*io.PipeWriter, chan error) {
+	// Bound concurrent cache-populate operations. When the limit is saturated,
+	// skip caching entirely: the object is still served/forwarded from upstream,
+	// we just don't populate the cache this time. This keeps the memory- and
+	// I/O-heavy write pipeline (pipe + goroutines + streaming RocksDB write) from
+	// growing without bound under load.
+	if !s.acquireCacheSlot() {
+		metrics.CachePopulateSkipped.Inc()
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache populate - concurrent write limit reached")
+		return nil, nil
+	}
+
 	// Record when this write started - used to check against tombstones
 	writeStartTime := time.Now().UnixNano()
 
 	listener := broadcaster.Subscribe()
 	if listener == nil {
+		s.releaseCacheSlot()
 		return nil, nil
 	}
 
@@ -103,6 +115,7 @@ func (s *Service) setupCacheListener(
 
 	// Start goroutine to consume chunks, build metadata, and write to cache
 	go func() {
+		defer s.releaseCacheSlot()
 		defer close(errCh)
 
 		// Wait for headers to build metadata

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -314,7 +314,7 @@ func (s *Service) streamFromUpstream(
 	var cacheErrCh chan error
 
 	if shouldCache {
-		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster)
+		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false)
 	}
 
 	// If an anonymous GET succeeded and Tigris didn't set an explicit per-object ACL,

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -16,9 +16,6 @@ import (
 )
 
 const (
-	// maxConcurrentCacheWrites limits the number of concurrent background cache operations.
-	maxConcurrentCacheWrites = 100
-
 	// X-Cache header constants for indicating cache status.
 	XCacheHeader   = "X-Cache"
 	XCacheHit      = "HIT"
@@ -33,7 +30,7 @@ type Service struct {
 	forwarder              RequestForwarder
 	cache                  *cache.Cache
 	config                 *config.Config
-	cacheSemaphore         chan struct{}      // Limits concurrent cache writes
+	cacheSemaphore         chan struct{}      // Bounds concurrent cache-populate operations (nil = unlimited)
 	broadcastManager       *broadcast.Manager // For streaming request coalescing
 	activeBackgroundFetches sync.Map          // Dedup for background full-object fetches (range caching)
 }
@@ -45,13 +42,43 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		channelBuf = broadcast.DefaultChannelBuffer
 	}
 
+	var cacheSem chan struct{}
+	if cfg.Cache.MaxConcurrentWrites > 0 {
+		cacheSem = make(chan struct{}, cfg.Cache.MaxConcurrentWrites)
+	}
+
 	return &Service{
 		forwarder:        forwarder,
 		cache:            cache,
 		config:           cfg,
-		cacheSemaphore:   make(chan struct{}, maxConcurrentCacheWrites),
+		cacheSemaphore:   cacheSem,
 		broadcastManager: broadcast.NewManager(channelBuf),
 	}
+}
+
+// acquireCacheSlot tries to reserve a cache-populate slot without blocking. It
+// returns true (and must be paired with releaseCacheSlot) when a slot is
+// reserved, or when the limiter is disabled (nil semaphore). It returns false
+// when the concurrent-cache-write limit is saturated, in which case the caller
+// should skip caching rather than block or spawn unbounded work.
+func (s *Service) acquireCacheSlot() bool {
+	if s.cacheSemaphore == nil {
+		return true
+	}
+	select {
+	case s.cacheSemaphore <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// releaseCacheSlot releases a slot previously reserved by acquireCacheSlot.
+func (s *Service) releaseCacheSlot() {
+	if s.cacheSemaphore == nil {
+		return
+	}
+	<-s.cacheSemaphore
 }
 
 // HandlePutObject handles PUT requests for objects.

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -335,7 +335,7 @@ func NewTestEnvironmentWithCache() *TestEnvironment {
 	xCacheTracker := NewXCacheTracker()
 
 	// Create TAG server with X-Cache tracking middleware
-	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true, 0)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 	tagServer := httptest.NewServer(wrappedRouter)
 
@@ -403,7 +403,7 @@ func NewTestEnvironmentWithCacheHandler(upstreamHandler http.HandlerFunc) *TestE
 	service := proxy.NewService(forwarder, testCache, cfg)
 
 	xCacheTracker := NewXCacheTracker()
-	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true, 0)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 	tagServer := httptest.NewServer(wrappedRouter)
 
@@ -460,7 +460,7 @@ func newTestEnvironmentWithUpstream(upstream *httptest.Server, backend *s3mem.Ba
 	xCacheTracker := NewXCacheTracker()
 
 	// Create TAG server with X-Cache tracking middleware
-	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true, 0)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 
 	var tagServer *httptest.Server
@@ -1038,7 +1038,7 @@ func NewTestEnvironmentWithTransparentAuth(t *testing.T, upstreamHandler http.Ha
 	service := proxy.NewService(forwarder, testCache, cfg)
 
 	xCacheTracker := NewXCacheTracker()
-	server := handlers.NewServer(service, "127.0.0.1", 0, true)
+	server := handlers.NewServer(service, "127.0.0.1", 0, true, 0)
 	wrappedRouter := xCacheTrackingMiddleware(xCacheTracker)(server.Router())
 	tagServer := httptest.NewServer(wrappedRouter)
 


### PR DESCRIPTION
## Problem

Under load — especially with a degraded cache ring — TAG's S3 ingress had **no working concurrency limit**. Every request spawned handlers that block on disk reads and cgo RocksDB calls (each pinning an OS thread), and cache populates spawned unbounded streaming-write pipelines, until the process hit Go's 10k-thread cap (`fatal error: thread exhaustion`) or OOM'd. The one existing limiter, `proxy.Service.cacheSemaphore`, was created but **never acquired** — it bounded nothing.

This is the TAG-side keystone for ocache issue #162 (thread exhaustion / admission control). TAG embeds ocache in-process (`embedded.New`), so its request load never traverses ocache's gRPC interceptors — admission must live here, at the S3 edge.

## Changes

**1. Global ingress admission middleware** (`handlers`) — a counting semaphore bounds concurrently-served S3 requests; when full, sheds with **`503 SlowDown`** so overload becomes backpressure instead of unbounded goroutine/thread/memory growth. Only exact `/health` and `/metrics` (and `/debug/pprof/` when pprof is enabled) are exempt, so S3 objects in a bucket named `health`/`metrics`/`debug` cannot bypass admission. Configurable via `server.max_inflight_requests` (0/unset = default 1024; negative disables).

**2. Wire the dead cache-populate limiter** (`proxy`) — `cacheSemaphore` is now acquired in `setupCacheListener`. When the concurrent-cache-write limit is saturated, TAG **skips caching** (still serves/forwards from upstream) rather than spawn unbounded populate work. Configurable via `cache.max_concurrent_writes` (0/unset = default 100; negative disables).

**3. Remove the whole-object-buffering footgun** (`cache`) — audited the GET path for 256MB+ (SlateDB SST) safety. It already streams: hits via `GetBodyStream` (buffering only objects `<= 64KB`, streaming the rest via `io.Pipe`), ranges via `GetRangeStream`, populate via `PutWithMetaStreamTombstoneAware`. Removed the unused `GetWithMeta`, which read whole bodies into a `bytes.Buffer` (a latent OOM path for large objects).

New metrics: `tag_inflight_requests`, `tag_admission_shed_total`, `tag_cache_populate_skipped_total`. Unit tests for admission (shed/exempt/bucket-not-exempt/unlimited) and the cache-slot limiter. Full `make test` passes.

## Out of scope (ocache-side, separate PRs)
Bounding the internal peer-forward fan-out and setting `grpc.MaxConcurrentStreams` on ocache's inter-node surface (issue #162 Part B), which requires an ocache release TAG then bumps to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path behavior under overload (503 shedding and degraded cache fill) and raises default concurrent cache writes from 100 to 256; operational endpoints remain reachable but mis-tuned limits could increase client-visible SlowDown or reduce cache warmth.
> 
> **Overview**
> Adds **overload protection** at the S3 edge and on the cache-populate path so load turns into **503 SlowDown** and skipped writes instead of unbounded goroutines, threads, and memory.
> 
> **Ingress admission** (`handlers`): middleware limits concurrently served S3 requests via `server.max_inflight_requests` (default 1024; negative disables). Saturated requests get S3 **SlowDown**; `/health`, `/metrics`, and registered `/debug/pprof/*` routes stay exempt using **mux path templates** so S3 keys like `/debug/pprof/...` cannot bypass the limit. Metrics: `tag_inflight_requests`, `tag_admission_shed_total`.
> 
> **Cache-write limiter** (`proxy`): `cache.max_concurrent_writes` (default **256**, was a fixed 100 slot that was never acquired) now gates `setupCacheListener` and background `fetchFullObjectToCache`; when full, responses still stream from upstream but caching is skipped (`tag_cache_populate_skipped_total`). Background fetches reserve a slot before upstream and treat saturation as `errCachePopulateDeclined` (not a fetch failure).
> 
> **Config/docs**: YAML and env vars `TAG_MAX_INFLIGHT_REQUESTS`, `TAG_CACHE_MAX_CONCURRENT_WRITES`; `NewServer` takes `maxInflight`.
> 
> **Cleanup**: removes unused `cache.GetWithMeta` (whole-body buffer read) and related tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde1385ad72e41a7d7293a5dea2a112d4e5ea371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->