### PR TITLE
test(bench): SlateDB-shaped range reads + higher concurrency in warp defaults

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -4,13 +4,15 @@ Throughput/latency benchmarks for TAG's core S3 operations using
 [MinIO `warp`](https://github.com/minio/warp). They run `warp` against a local
 TAG instance (which proxies to Tigris) and exercise:
 
-| Operation | warp command                 | Object size                  |
-| --------- | ---------------------------- | ---------------------------- |
-| GET       | `warp get`                   | 4 MiB                        |
-| GET RANGE | `warp get --range-size=4MiB` | 100 MiB object, 4 MiB ranges |
-| PUT       | `warp put`                   | 4 MiB                        |
-| HEAD      | `warp stat`                  | 4 MiB                        |
-| LIST V2   | `warp list`                  | 4 MiB                        |
+All operations run at concurrency 64.
+
+| Operation | warp command                  | Object size                    |
+| --------- | ----------------------------- | ------------------------------ |
+| GET       | `warp get`                    | 4 MiB                          |
+| GET RANGE | `warp get --range-size=64KiB` | 256 MiB object, 64 KiB ranges (SlateDB-like) |
+| PUT       | `warp put`                    | 4 MiB                          |
+| HEAD      | `warp stat`                   | 4 MiB                          |
+| LIST V2   | `warp list`                   | 4 MiB                          |
 
 This is a **smoke benchmark**: the run fails if any operation errors. It does not
 enforce performance thresholds — it captures numbers for inspection.
@@ -42,7 +44,10 @@ In CI the `results/` directory is uploaded as the `benchmark-results` artifact.
 
 ## Tuning
 
-`run-warp.sh` reads env vars (CI defaults are intentionally small):
+`run-warp.sh` reads env vars. Defaults run at moderate concurrency (64) and
+shape the GET RANGE case to the SlateDB-fronting pattern (small ranges from
+large objects); object sizes stay modest so bandwidth against real upstream
+stays bounded. Override for heavier local runs:
 
 | Var                                                              | Default                 | Meaning                                          |
 | ---------------------------------------------------------------- | ----------------------- | ------------------------------------------------ |
@@ -50,10 +55,10 @@ In CI the `results/` directory is uploaded as the `benchmark-results` artifact.
 | `WARP_HOST`                                                      | `localhost:8080`        | TAG host:port                                    |
 | `WARP_BUCKET`                                                    | `tag-warp-benchmark`    | bucket for benchmark data (cleared each run)     |
 | `WARP_REGION`                                                    | `auto`                  | SigV4 region (must match TAG's region)           |
-| `WARP_DURATION`                                                  | `30s`                   | duration per operation                           |
-| `WARP_CONCURRENT`                                                | `4`                     | concurrent operations                            |
-| `WARP_OBJ_SIZE` / `WARP_OBJECTS`                                 | `4MiB` / `100`          | size / count for 4 MiB ops                       |
-| `WARP_RANGE_OBJ_SIZE` / `WARP_RANGE_SIZE` / `WARP_RANGE_OBJECTS` | `100MiB` / `4MiB` / `8` | GET RANGE large object size / range size / count |
+| `WARP_DURATION`                                                  | `30s`                    | duration per operation                           |
+| `WARP_CONCURRENT`                                                | `64`                     | concurrent operations                            |
+| `WARP_OBJ_SIZE` / `WARP_OBJECTS`                                 | `4MiB` / `100`           | size / count for 4 MiB ops                       |
+| `WARP_RANGE_OBJ_SIZE` / `WARP_RANGE_SIZE` / `WARP_RANGE_OBJECTS` | `256MiB` / `64KiB` / `8` | GET RANGE large object size / range size / count |
 
 Example, a heavier local run:
 

--- a/tests/benchmark/run-warp.sh
+++ b/tests/benchmark/run-warp.sh
@@ -65,11 +65,19 @@ HOST="${WARP_HOST:-localhost:${TAG_HTTP_PORT:-8080}}"
 BUCKET="${WARP_BUCKET:-tag-warp-benchmark}"
 REGION="${WARP_REGION:-auto}"
 DURATION="${WARP_DURATION:-30s}"
-CONCURRENT="${WARP_CONCURRENT:-4}"
+# Concurrency is duration-bounded (more in-flight, not longer runtime). 64 gives
+# realistic contention through the ingress-admission and cache-populate paths
+# while staying well under their limits (default 1024 / 256), so results measure
+# throughput cleanly without triggering 503 shedding.
+CONCURRENT="${WARP_CONCURRENT:-64}"
 OBJ_SIZE="${WARP_OBJ_SIZE:-4MiB}"
 OBJECTS="${WARP_OBJECTS:-100}"
-RANGE_OBJ_SIZE="${WARP_RANGE_OBJ_SIZE:-100MiB}"
-RANGE_SIZE="${WARP_RANGE_SIZE:-4MiB}"
+# GET RANGE mirrors the SlateDB-fronting workload: small block-sized reads at
+# random offsets from large (SST-sized) objects. Reading only KiBs per request
+# keeps bandwidth low even at high concurrency while exercising TAG's
+# serve-a-small-range-from-a-large-cached-object path (SectionReader seek).
+RANGE_OBJ_SIZE="${WARP_RANGE_OBJ_SIZE:-256MiB}"
+RANGE_SIZE="${WARP_RANGE_SIZE:-64KiB}"
 RANGE_OBJECTS="${WARP_RANGE_OBJECTS:-8}"
 
 # Flags shared by every operation. TAG is plain HTTP locally, so no --tls.
@@ -112,8 +120,9 @@ run_op() {
     fi
 }
 
-# Core operations. All use 4MiB objects except GET RANGE, which reads 4MiB
-# ranges from 100MiB objects (--range-size implies ranged GETs).
+# Core operations. All use 4MiB objects except GET RANGE, which reads small
+# (64KiB) ranges from large 256MiB objects — the SlateDB read pattern — where
+# --range-size implies ranged GETs.
 run_op "get"       get    --obj.size="$OBJ_SIZE"       --objects="$OBJECTS"
 run_op "get-range" get    --obj.size="$RANGE_OBJ_SIZE" --objects="$RANGE_OBJECTS" --range-size="$RANGE_SIZE"
 run_op "put"       put    --obj.size="$OBJ_SIZE"


### PR DESCRIPTION
Retunes the existing Warp Benchmarks job (no new job) to be more representative of the production workload and to actually exercise the concurrency-bounding code merged in #72.

## Changes (`tests/benchmark/run-warp.sh` defaults)
- **Concurrency 4 → 64.** Duration-bounded, so ~no extra runtime. Adds realistic contention through the ingress-admission and cache-populate paths; stays well under their limits (1024 / 256) so throughput is measured cleanly without triggering 503 shedding. (At concurrency 4 those paths were dormant, so the benchmark couldn't see #72 at all.)
- **GET RANGE → SlateDB pattern: 64 KiB ranges from 256 MiB objects** (was 4 MiB ranges from 100 MiB). SlateDB fronts large SSTs and reads small blocks at random offsets — this exercises TAG's serve-a-small-range-from-a-large-cached-object path (`GetRangeStream` → `SectionReader` seek). Only KiBs are read per request, so bandwidth stays low even at high concurrency.

Small-object GET/PUT/HEAD/LIST stay at 4 MiB to keep upstream bandwidth bounded. All values remain env-overridable; README updated.

**Note:** the first run after this merges is a new baseline — not comparable to the concurrency-4 history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only default and documentation changes; no production TAG code paths modified.
> 
> **Overview**
> Retunes **Warp smoke benchmark defaults** in `run-warp.sh` and documents them in `tests/benchmark/README.md` so nightly/local runs better match production and stress concurrency paths from #72.
> 
> **Concurrency** default rises **4 → 64** (still duration-bounded). The script comments explain this is meant to drive realistic load through ingress-admission and cache-populate without hitting 503 shedding limits.
> 
> **GET RANGE** defaults change from **4 MiB ranges on 100 MiB objects** to **64 KiB ranges on 256 MiB objects** (SlateDB/SST-style small reads from large objects). GET/PUT/HEAD/LIST stay at 4 MiB; all knobs remain env-overridable.
> 
> **Baseline note:** metrics after merge are not comparable to the old concurrency-4 history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a7199be550cc386727c575a19088beb622146e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->