### PR TITLE
feat: publish native install assets to the release bucket

### DIFF
--- a/.github/workflows/t3-upload-release.yaml
+++ b/.github/workflows/t3-upload-release.yaml
@@ -111,6 +111,48 @@ jobs:
 
           echo "Versioned upload complete"
 
+      - name: Stage native install assets
+        id: native
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+
+          # Take the native assets from the exact release tag so they match the
+          # uploaded binary. Older releases predating deploy/native/ are skipped.
+          git fetch --tags --force
+          if ! git cat-file -e "${VERSION}:deploy/native/config.yaml" 2>/dev/null; then
+            echo "Native assets not present at ${VERSION}; skipping native upload"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git checkout "${VERSION}" -- deploy/native/config.yaml deploy/native/install.sh deploy/native/run.sh
+
+          # Produce two flavors: version-pinned (for /<version>/) and latest (for
+          # /latest/), by rewriting each script's default TAG_VERSION. This makes
+          # `curl .../<dir>/install.sh | bash` install the matching version.
+          mkdir -p native/versioned native/latest
+          cp deploy/native/config.yaml native/versioned/config.yaml
+          cp deploy/native/config.yaml native/latest/config.yaml
+          for f in install.sh run.sh; do
+            sed -E "s|TAG_VERSION:-[^}]*|TAG_VERSION:-${VERSION}|" "deploy/native/$f" > "native/versioned/$f"
+            sed -E "s|TAG_VERSION:-[^}]*|TAG_VERSION:-latest|"     "deploy/native/$f" > "native/latest/$f"
+          done
+          echo "present=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload native install assets to T3 (versioned directory)
+        if: steps.native.outputs.present == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          aws s3 cp native/versioned/config.yaml "s3://$S3_BUCKET/$VERSION/config.yaml" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/yaml"
+          aws s3 cp native/versioned/install.sh "s3://$S3_BUCKET/$VERSION/install.sh" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          aws s3 cp native/versioned/run.sh "s3://$S3_BUCKET/$VERSION/run.sh" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          echo "Native assets uploaded to $VERSION/"
+
       - name: Update latest directory
         # Only update 'latest' when triggered by release workflow, not manual dispatch
         if: github.event_name == 'workflow_run'
@@ -129,6 +171,16 @@ jobs:
               --endpoint-url "$S3_ENDPOINT" \
               --content-type "application/octet-stream"
           done
+
+          if [ "${{ steps.native.outputs.present }}" = "true" ]; then
+            echo "Updating latest/ native assets..."
+            aws s3 cp native/latest/config.yaml "s3://$S3_BUCKET/latest/config.yaml" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/yaml"
+            aws s3 cp native/latest/install.sh "s3://$S3_BUCKET/latest/install.sh" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+            aws s3 cp native/latest/run.sh "s3://$S3_BUCKET/latest/run.sh" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          fi
 
           echo "Latest directory updated"
 

--- a/.github/workflows/t3-upload-release.yaml
+++ b/.github/workflows/t3-upload-release.yaml
@@ -119,8 +119,15 @@ jobs:
           # Take the native assets from the exact release tag so they match the
           # uploaded binary. Older releases predating deploy/native/ are skipped.
           git fetch --tags --force
-          if ! git cat-file -e "${VERSION}:deploy/native/config.yaml" 2>/dev/null; then
-            echo "Native assets not present at ${VERSION}; skipping native upload"
+          missing=false
+          for asset in config.yaml install.sh run.sh; do
+            if ! git cat-file -e "${VERSION}:deploy/native/${asset}" 2>/dev/null; then
+              echo "deploy/native/${asset} not present at ${VERSION}"
+              missing=true
+            fi
+          done
+          if [ "$missing" = "true" ]; then
+            echo "Native assets incomplete at ${VERSION}; skipping native upload"
             echo "present=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ TAG can be deployed to Kubernetes, Docker, or standalone mode. Deployment manife
   # A specific release
   curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
   ```
+
 - **TLS/HTTPS** — see [docs/tls.md](docs/tls.md).
 - **Benchmarks** — see [docs/benchmarks.md](docs/benchmarks.md).
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ TAG can be deployed to Kubernetes, Docker, or standalone mode. Deployment manife
 
 - **Kubernetes** — Kustomize manifests in [`deploy/kubernetes/`](deploy/kubernetes/); see [docs/deploy.md](docs/deploy.md).
 - **Docker** — released-image Compose files in [`deploy/docker/`](deploy/docker/) for pulling a published `tigrisdata/tag` image; see [docs/docker.md](docs/docker.md). For local development against source, use the build-from-source Compose files in [`docker/`](docker/).
-- **Native binary** — install/run scripts in [`deploy/native/`](deploy/native/).
+- **Native binary** — install/run scripts in [`deploy/native/`](deploy/native/). Each release also publishes these scripts and a matching `config.yaml` next to the binaries, so you can install without cloning the repo:
+
+  ```bash
+  # Latest release
+  curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
+
+  # A specific release
+  curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
+  ```
 - **TLS/HTTPS** — see [docs/tls.md](docs/tls.md).
 - **Benchmarks** — see [docs/benchmarks.md](docs/benchmarks.md).
 

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -56,11 +56,9 @@ chmod +x "${DEST}" 2>/dev/null || sudo chmod +x "${DEST}"
 # Install default configuration file
 CONFIG_DIR="/etc/tag"
 CONFIG_FILE="${CONFIG_DIR}/config.yaml"
-# Pin the config to the same release as the binary so native installs are
-# reproducible. Fall back to main only for versions predating the config's move
-# into this repo (e.g. <= v1.9.4, whose git tag has no deploy/native/config.yaml).
-CONFIG_URL="https://raw.githubusercontent.com/tigrisdata/tag/refs/tags/${TAG_VERSION}/deploy/native/config.yaml"
-CONFIG_FALLBACK_URL="https://raw.githubusercontent.com/tigrisdata/tag/main/deploy/native/config.yaml"
+# Config ships in the same versioned release directory as the binary, so it is
+# always matched to the installed version and needs no GitHub access.
+CONFIG_URL="${TAG_RELEASES_URL}/${TAG_VERSION}/config.yaml"
 
 if [ ! -d "${CONFIG_DIR}" ]; then
     echo "Creating ${CONFIG_DIR} (may require sudo)..."
@@ -73,13 +71,9 @@ if [ ! -f "${CONFIG_FILE}" ]; then
     if curl -fsSL "${CONFIG_URL}" -o "${TMPCONFIG}"; then
         cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
         chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
-    elif curl -fsSL "${CONFIG_FALLBACK_URL}" -o "${TMPCONFIG}"; then
-        echo "Warning: no config for ${TAG_VERSION}; using the config from main," \
-             "which may not match this release."
-        cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
-        chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
     else
-        echo "Warning: Could not download default config, skipping"
+        echo "Warning: no config found at ${CONFIG_URL}; skipping." \
+             "TAG can also be configured entirely via environment variables."
     fi
 else
     echo "Config already exists at ${CONFIG_FILE}, skipping"


### PR DESCRIPTION
## Context

Native installs fetched `config.yaml` from `raw.githubusercontent.com`, which coupled installs to GitHub (rate limits, only works while the repo is public) and pulled config from a ref *separate* from the versioned binary. The binaries already live in the `tag-releases` bucket (`t3.storage.dev`), uploaded per-version and to `latest/` by the `Upload Release to T3` workflow. This publishes the native assets to that same bucket so installs are reproducible and GitHub-free.

## Changes

- **`.github/workflows/t3-upload-release.yaml`** — after the binary upload, take `config.yaml`, `install.sh`, `run.sh` **from the exact release tag** (so they match the binary) and upload them to `s3://tag-releases/<version>/`, plus `s3://tag-releases/latest/` on release. Each uploaded script's default `TAG_VERSION` is rewritten to the release version (or `latest` for the `latest/` copies), so `curl .../<dir>/install.sh | bash` installs the matching version. Releases predating `deploy/native/` are detected and skipped.
- **`deploy/native/install.sh`** — fetch config from `${TAG_RELEASES_URL}/${TAG_VERSION}/config.yaml` (same base URL and version as the binary) instead of `raw.githubusercontent.com`. On a miss, warn and note that TAG can be configured entirely via env vars. This retires the GitHub-raw config path (and the tag-ref/`main` fallback added earlier).
- **`README.md`** — document the one-liner bootstrap:
  ```bash
  curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
  curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
  ```

## Resulting bucket layout

```
s3://tag-releases/<version>/   tag-linux-amd64  tag-linux-arm64  tag-darwin-arm64
                               config.yaml  install.sh  run.sh   <-- new
s3://tag-releases/latest/      (same set, scripts default to 'latest')
```

## Verification

- ✅ `bash -n deploy/native/install.sh`.
- ✅ `sed` version-rewrite simulated against the real scripts — only the `TAG_VERSION` definition line changes; version-pinned and `latest` flavors both correct.
- ✅ Workflow YAML parses (yq, 11 steps).

## Notes

- The bucket-published `install.sh` for a version always has a sibling `config.yaml` in the same dir, so the bootstrap path has no version-skew.
- Transitional: a direct `deploy/native/install.sh` run from a clone with the current default (`v1.9.4`) will 404 on `/v1.9.4/config.yaml` (that version predates this upload) and skip config with a warning — resolves once the next release publishes native assets. The recommended bootstrap path works fully from the first post-merge release.
- Depends on the release AWS creds already used by this workflow; no new secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release CI uploads, install scripting, and README; no runtime application logic or auth paths.
> 
> **Overview**
> **Release uploads** now ship `config.yaml`, `install.sh`, and `run.sh` alongside binaries in `tag-releases` under `/<version>/` and (on release) `/latest/`. The workflow checks out those files from the release tag, rewrites each script’s default `TAG_VERSION` for version-pinned vs `latest` copies, and skips native upload when older tags lack `deploy/native/`.
> 
> **Native install** no longer pulls config from GitHub: `install.sh` downloads `config.yaml` from the same T3 URL/version as the binary and drops the tag/`main` fallback; a miss only warns and notes env-based config.
> 
> **Docs** add `curl …/latest/install.sh | bash` and version-pinned one-liners for repo-free installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c024dcd134a13e8c35842400fab1c3b1dbb3a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->