### PR TITLE
Release

### DIFF
--- a/.github/workflows/t3-upload-release.yaml
+++ b/.github/workflows/t3-upload-release.yaml
@@ -37,8 +37,15 @@ jobs:
           WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
-            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
-            echo "Using manual version: $INPUT_VERSION"
+            # Normalize to the v-prefixed tag so the S3 directory, gh release
+            # lookups, and the native-asset git ref all reference the same tag
+            # (release tags are always vX.Y.Z). Entering "1.10.0" -> "v1.10.0".
+            case "$INPUT_VERSION" in
+              v*) VERSION="$INPUT_VERSION" ;;
+              *)  VERSION="v$INPUT_VERSION" ;;
+            esac
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Using manual version: $VERSION"
           else
             # Get the tag pointing to the workflow_run commit SHA
             git fetch --tags

--- a/.github/workflows/t3-upload-release.yaml
+++ b/.github/workflows/t3-upload-release.yaml
@@ -111,6 +111,55 @@ jobs:
 
           echo "Versioned upload complete"
 
+      - name: Stage native install assets
+        id: native
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+
+          # Take the native assets from the exact release tag so they match the
+          # uploaded binary. Older releases predating deploy/native/ are skipped.
+          git fetch --tags --force
+          missing=false
+          for asset in config.yaml install.sh run.sh; do
+            if ! git cat-file -e "${VERSION}:deploy/native/${asset}" 2>/dev/null; then
+              echo "deploy/native/${asset} not present at ${VERSION}"
+              missing=true
+            fi
+          done
+          if [ "$missing" = "true" ]; then
+            echo "Native assets incomplete at ${VERSION}; skipping native upload"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git checkout "${VERSION}" -- deploy/native/config.yaml deploy/native/install.sh deploy/native/run.sh
+
+          # Produce two flavors: version-pinned (for /<version>/) and latest (for
+          # /latest/), by rewriting each script's default TAG_VERSION. This makes
+          # `curl .../<dir>/install.sh | bash` install the matching version.
+          mkdir -p native/versioned native/latest
+          cp deploy/native/config.yaml native/versioned/config.yaml
+          cp deploy/native/config.yaml native/latest/config.yaml
+          for f in install.sh run.sh; do
+            sed -E "s|TAG_VERSION:-[^}]*|TAG_VERSION:-${VERSION}|" "deploy/native/$f" > "native/versioned/$f"
+            sed -E "s|TAG_VERSION:-[^}]*|TAG_VERSION:-latest|"     "deploy/native/$f" > "native/latest/$f"
+          done
+          echo "present=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload native install assets to T3 (versioned directory)
+        if: steps.native.outputs.present == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          aws s3 cp native/versioned/config.yaml "s3://$S3_BUCKET/$VERSION/config.yaml" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/yaml"
+          aws s3 cp native/versioned/install.sh "s3://$S3_BUCKET/$VERSION/install.sh" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          aws s3 cp native/versioned/run.sh "s3://$S3_BUCKET/$VERSION/run.sh" \
+            --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          echo "Native assets uploaded to $VERSION/"
+
       - name: Update latest directory
         # Only update 'latest' when triggered by release workflow, not manual dispatch
         if: github.event_name == 'workflow_run'
@@ -129,6 +178,16 @@ jobs:
               --endpoint-url "$S3_ENDPOINT" \
               --content-type "application/octet-stream"
           done
+
+          if [ "${{ steps.native.outputs.present }}" = "true" ]; then
+            echo "Updating latest/ native assets..."
+            aws s3 cp native/latest/config.yaml "s3://$S3_BUCKET/latest/config.yaml" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/yaml"
+            aws s3 cp native/latest/install.sh "s3://$S3_BUCKET/latest/install.sh" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+            aws s3 cp native/latest/run.sh "s3://$S3_BUCKET/latest/run.sh" \
+              --endpoint-url "$S3_ENDPOINT" --content-type "text/x-shellscript"
+          fi
 
           echo "Latest directory updated"
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,13 @@ See [docs/security.md](docs/security.md) for authentication, access control, and
 
 ## Deployment
 
-TAG can be deployed to Kubernetes, Docker, or standalone mode.
+TAG can be deployed to Kubernetes, Docker, or standalone mode. Deployment manifests and scripts live under [`deploy/`](deploy/):
 
-See [tigrisdata/tag-deploy](https://github.com/tigrisdata/tag-deploy) for complete deployment guide and manifests.
+- **Kubernetes** — Kustomize manifests in [`deploy/kubernetes/`](deploy/kubernetes/); see [docs/deploy.md](docs/deploy.md).
+- **Docker** — released-image Compose files in [`deploy/docker/`](deploy/docker/) for pulling a published `tigrisdata/tag` image; see [docs/docker.md](docs/docker.md). For local development against source, use the build-from-source Compose files in [`docker/`](docker/).
+- **Native binary** — install/run scripts in [`deploy/native/`](deploy/native/).
+- **TLS/HTTPS** — see [docs/tls.md](docs/tls.md).
+- **Benchmarks** — see [docs/benchmarks.md](docs/benchmarks.md).
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,16 @@ TAG can be deployed to Kubernetes, Docker, or standalone mode. Deployment manife
 
 - **Kubernetes** — Kustomize manifests in [`deploy/kubernetes/`](deploy/kubernetes/); see [docs/deploy.md](docs/deploy.md).
 - **Docker** — released-image Compose files in [`deploy/docker/`](deploy/docker/) for pulling a published `tigrisdata/tag` image; see [docs/docker.md](docs/docker.md). For local development against source, use the build-from-source Compose files in [`docker/`](docker/).
-- **Native binary** — install/run scripts in [`deploy/native/`](deploy/native/).
+- **Native binary** — install/run scripts in [`deploy/native/`](deploy/native/). Each release also publishes these scripts and a matching `config.yaml` next to the binaries, so you can install without cloning the repo:
+
+  ```bash
+  # Latest release
+  curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
+
+  # A specific release
+  curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
+  ```
+
 - **TLS/HTTPS** — see [docs/tls.md](docs/tls.md).
 - **Benchmarks** — see [docs/benchmarks.md](docs/benchmarks.md).
 

--- a/deploy/docker/docker-compose-cluster.release.yml
+++ b/deploy/docker/docker-compose-cluster.release.yml
@@ -1,0 +1,116 @@
+# Docker Compose for TAG Cluster — released image
+#
+# Pulls the published tigrisdata/tag image instead of building from source.
+# For the build-from-source variant, use docker-compose-cluster.yml.
+#
+# TAG uses embedded OCache - each TAG node has its own embedded cache that
+# forms a distributed cluster via gossip protocol and gRPC for routing.
+#
+# Usage:
+#   export AWS_ACCESS_KEY_ID=<your-key>
+#   export AWS_SECRET_ACCESS_KEY=<your-secret>
+#   docker compose -f docker-compose-cluster.release.yml up -d
+#
+# Defaults to the latest published image. For reproducible deployments, pin a
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.9.4) in your .env.
+# All nodes share this variable, so the cluster stays on a single version.
+
+x-tag-common: &tag-common
+  image: tigrisdata/tag:${TAG_VERSION:-latest}
+  user: root
+  restart: unless-stopped
+  networks:
+    - tag-cluster
+
+x-tag-healthcheck: &tag-healthcheck
+  test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+  interval: 5s
+  timeout: 3s
+  retries: 10
+  # Longer start_period to accommodate warm-cache boot on a populated cache volume.
+  start_period: 60s
+
+services:
+  # TAG Node 1 (with embedded cache)
+  tag-1:
+    <<: *tag-common
+    container_name: tag-1
+    hostname: tag-1
+    ports:
+      - "8081:8080"
+      - "9001:9000"  # gRPC for cache routing
+      - "7001:7000"  # Cluster gossip
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_CACHE_NODE_ID=tag-1
+      - TAG_CACHE_DISK_PATH=/data/cache
+      - TAG_CACHE_CLUSTER_ADDR=:7000
+      - TAG_CACHE_GRPC_ADDR=:9000
+      - TAG_CACHE_ADVERTISE_ADDR=tag-1:9000
+      - TAG_CACHE_SEED_NODES=tag-1:7000,tag-2:7000,tag-3:7000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    volumes:
+      - tag-1-cache:/data/cache
+    healthcheck: *tag-healthcheck
+
+  # TAG Node 2 (with embedded cache)
+  tag-2:
+    <<: *tag-common
+    container_name: tag-2
+    hostname: tag-2
+    ports:
+      - "8082:8080"
+      - "9002:9000"  # gRPC for cache routing
+      - "7002:7000"  # Cluster gossip
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_CACHE_NODE_ID=tag-2
+      - TAG_CACHE_DISK_PATH=/data/cache
+      - TAG_CACHE_CLUSTER_ADDR=:7000
+      - TAG_CACHE_GRPC_ADDR=:9000
+      - TAG_CACHE_ADVERTISE_ADDR=tag-2:9000
+      - TAG_CACHE_SEED_NODES=tag-1:7000,tag-2:7000,tag-3:7000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    volumes:
+      - tag-2-cache:/data/cache
+    healthcheck: *tag-healthcheck
+    depends_on:
+      - tag-1
+
+  # TAG Node 3 (with embedded cache)
+  tag-3:
+    <<: *tag-common
+    container_name: tag-3
+    hostname: tag-3
+    ports:
+      - "8083:8080"
+      - "9003:9000"  # gRPC for cache routing
+      - "7003:7000"  # Cluster gossip
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_CACHE_NODE_ID=tag-3
+      - TAG_CACHE_DISK_PATH=/data/cache
+      - TAG_CACHE_CLUSTER_ADDR=:7000
+      - TAG_CACHE_GRPC_ADDR=:9000
+      - TAG_CACHE_ADVERTISE_ADDR=tag-3:9000
+      - TAG_CACHE_SEED_NODES=tag-1:7000,tag-2:7000,tag-3:7000
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    volumes:
+      - tag-3-cache:/data/cache
+    healthcheck: *tag-healthcheck
+    depends_on:
+      - tag-2
+
+networks:
+  tag-cluster:
+
+volumes:
+  tag-1-cache:
+  tag-2-cache:
+  tag-3-cache:

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -1,0 +1,47 @@
+# Docker Compose for TAG (Tigris Access Gateway) — released image
+#
+# Pulls the published tigrisdata/tag image instead of building from source.
+# For the build-from-source variant, use docker-compose.yml.
+#
+# TAG uses embedded OCache - no separate cache server needed.
+#
+# Usage:
+#   export AWS_ACCESS_KEY_ID=<your-key>
+#   export AWS_SECRET_ACCESS_KEY=<your-secret>
+#   docker compose -f docker-compose.release.yml up -d
+#
+# Defaults to the latest published image. For reproducible deployments, pin a
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.9.4) in your .env.
+
+services:
+  tag:
+    image: tigrisdata/tag:${TAG_VERSION:-latest}
+    container_name: tag
+    user: root
+    ports:
+      - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_UPSTREAM_ENDPOINT=${TAG_UPSTREAM_ENDPOINT:-https://t3.storage.dev}
+      - TAG_CACHE_NODE_ID=tag-standalone
+      - TAG_CACHE_DISK_PATH=/data/cache
+      - TAG_LOG_LEVEL=${TAG_LOG_LEVEL:-info}
+    volumes:
+      - tag-cache:/data/cache
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      # Longer start_period to accommodate warm-cache boot on a populated cache volume.
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - tag-network
+
+networks:
+  tag-network:
+
+volumes:
+  tag-cache:

--- a/deploy/kubernetes/base/hpa.yaml
+++ b/deploy/kubernetes/base/hpa.yaml
@@ -1,0 +1,43 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tag
+  labels:
+    app: tag
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: tag
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 4
+          periodSeconds: 15
+      selectPolicy: Max

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - service-headless.yaml
+  - hpa.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: tag
+    includeSelectors: true
+
+images:
+  - name: tigrisdata/tag
+    newTag: v1.9.4

--- a/deploy/kubernetes/base/service-headless.yaml
+++ b/deploy/kubernetes/base/service-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tag-headless
+  labels:
+    app: tag
+spec:
+  clusterIP: None
+  selector:
+    app: tag
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    - name: grpc
+      port: 9000
+      targetPort: 9000
+    - name: cluster
+      port: 7000
+      targetPort: 7000

--- a/deploy/kubernetes/base/service.yaml
+++ b/deploy/kubernetes/base/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tag
+  labels:
+    app: tag
+  annotations:
+    # For AWS NLB
+    # service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    # For GCP
+    # cloud.google.com/neg: '{"ingress": true}'
+spec:
+  type: LoadBalancer
+  selector:
+    app: tag
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tag
+  labels:
+    app: tag
+spec:
+  serviceName: tag-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tag
+  template:
+    metadata:
+      labels:
+        app: tag
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: tag
+          image: tigrisdata/tag:v1.9.4
+          imagePullPolicy: Always
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tag-credentials
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tag-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: TAG_CACHE_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TAG_CACHE_DISK_PATH
+              value: "/data/cache"
+            - name: TAG_CACHE_CLUSTER_ADDR
+              value: ":7000"
+            - name: TAG_CACHE_GRPC_ADDR
+              value: ":9000"
+            - name: TAG_CACHE_ADVERTISE_ADDR
+              value: "$(POD_NAME).tag-headless:9000"
+            - name: TAG_CACHE_SEED_NODES
+              value: "tag-headless:7000"
+            - name: TAG_CACHE_MAX_DISK_USAGE
+              value: "429496729600"
+            - name: TAG_LOG_LEVEL
+              value: "info"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9000
+              protocol: TCP
+            - name: cluster
+              containerPort: 7000
+              protocol: TCP
+          volumeMounts:
+            - name: cache-data
+              mountPath: /data/cache
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          # Gate liveness/readiness until the process is actually serving. On a
+          # warm-cache boot the on-disk store is opened before the HTTP server
+          # starts listening, and on a large cache that can take longer than the
+          # liveness failureThreshold window -- without a startupProbe, k8s
+          # liveness-kills the pod mid-boot and crashloops it. The boot budget is
+          # failureThreshold x periodSeconds (here 10m); scale it up for larger
+          # on-disk caches.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: tag
+                topologyKey: kubernetes.io/hostname
+      # fsGroup makes the kubelet chown the cache PVC to GID 1000 on mount, so the
+      # container (UID 1000, readOnlyRootFilesystem) can write to /data/cache on
+      # storage classes that provision new volumes as root:root.
+      securityContext:
+        fsGroup: 1000
+  volumeClaimTemplates:
+    - metadata:
+        name: cache-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 400Gi

--- a/deploy/native/config.yaml
+++ b/deploy/native/config.yaml
@@ -1,0 +1,71 @@
+# Default TAG configuration
+# Installed to /etc/tag/config.yaml by install.sh
+#
+# Override any setting via environment variables (see docs/configuration.md).
+# Environment variables take precedence over this file.
+
+# Server configuration
+server:
+  # HTTP port for the S3 API
+  # Default: 8080
+  http_port: 8080
+
+  # IP address to bind to
+  # Default: "0.0.0.0" (all interfaces)
+  bind_ip: "0.0.0.0"
+
+  # Path to TLS certificate file (PEM format)
+  # When both tls_cert_file and tls_key_file are set, TAG serves HTTPS
+  # Default: "" (TLS disabled, serves HTTP)
+  tls_cert_file: ""
+
+  # Path to TLS private key file (PEM format)
+  # Must be set together with tls_cert_file
+  # Default: "" (TLS disabled, serves HTTP)
+  tls_key_file: ""
+
+# Cache configuration
+cache:
+  # Enable caching (set to false for pass-through mode)
+  # Default: true
+  enabled: true
+
+  # Default TTL for cached objects
+  # Default: 24h (24 hours)
+  ttl: 24h
+
+  # Maximum object size to cache (in bytes)
+  # Objects larger than this are not cached
+  # Default: 1073741824 (1GB)
+  size_threshold: 1073741824
+
+  # Path to cache data directory
+  # /var/tmp/tag works on both macOS and Linux without root
+  disk_path: "/var/tmp/tag"
+
+  # Max disk usage in bytes (0 = unlimited)
+  # Default: 0
+  max_disk_usage_bytes: 0
+
+  # Unique node identifier for cluster mode
+  # Required for multi-node deployments
+  node_id: "tag-node-1"
+
+  # Address for memberlist gossip protocol
+  # Default: :7000
+  # port 7000 conflicts on macOS with AirPlay Receiver, so we use 17000 by default
+  cluster_addr: ":17000"
+
+  # Address for gRPC server (cache cluster routing)
+  # Default: :9000
+  grpc_addr: ":19000"
+
+# Logging configuration
+log:
+  # Log level: debug, info, warn, error
+  # Default: "info"
+  level: "info"
+
+  # Log format: json (structured) or console (human-readable)
+  # Default: "json"
+  format: "json"

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Install TAG binary for the current platform
+#
+
+set -euo pipefail
+
+TAG_VERSION="${TAG_VERSION:-v1.9.4}"
+TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS and architecture
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "${ARCH}" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+esac
+
+BINARY_NAME="tag-${OS}-${ARCH}"
+DOWNLOAD_URL="${TAG_RELEASES_URL}/${TAG_VERSION}/${BINARY_NAME}"
+DEST="${INSTALL_DIR}/tag"
+
+echo "Installing TAG ${TAG_VERSION} (${OS}/${ARCH})..."
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "Error: curl is required but not installed"
+    exit 1
+fi
+
+# Create install directory if it doesn't exist
+if [ ! -d "${INSTALL_DIR}" ]; then
+    echo "Creating ${INSTALL_DIR} (may require sudo)..."
+    mkdir -p "${INSTALL_DIR}" 2>/dev/null || sudo mkdir -p "${INSTALL_DIR}"
+fi
+
+# Download binary to a temporary file first, then move to destination
+echo "Downloading from ${DOWNLOAD_URL}..."
+TMPFILE="$(mktemp)"
+TMPCONFIG=""
+trap 'rm -f "${TMPFILE}" "${TMPCONFIG}"' EXIT
+
+if ! curl -fsSL "${DOWNLOAD_URL}" -o "${TMPFILE}"; then
+    echo "Error: Failed to download TAG from ${DOWNLOAD_URL}"
+    exit 1
+fi
+
+# Move to destination, using sudo only if needed for permissions
+if ! mv "${TMPFILE}" "${DEST}" 2>/dev/null; then
+    sudo mv "${TMPFILE}" "${DEST}"
+fi
+
+chmod +x "${DEST}" 2>/dev/null || sudo chmod +x "${DEST}"
+
+# Install default configuration file
+CONFIG_DIR="/etc/tag"
+CONFIG_FILE="${CONFIG_DIR}/config.yaml"
+# Pin the config to the same release as the binary so native installs are
+# reproducible. Fall back to main only for versions predating the config's move
+# into this repo (e.g. <= v1.9.4, whose git tag has no deploy/native/config.yaml).
+CONFIG_URL="https://raw.githubusercontent.com/tigrisdata/tag/refs/tags/${TAG_VERSION}/deploy/native/config.yaml"
+CONFIG_FALLBACK_URL="https://raw.githubusercontent.com/tigrisdata/tag/main/deploy/native/config.yaml"
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+    echo "Creating ${CONFIG_DIR} (may require sudo)..."
+    mkdir -p "${CONFIG_DIR}" 2>/dev/null || sudo mkdir -p "${CONFIG_DIR}"
+fi
+
+if [ ! -f "${CONFIG_FILE}" ]; then
+    echo "Installing default config to ${CONFIG_FILE}..."
+    TMPCONFIG="$(mktemp)"
+    if curl -fsSL "${CONFIG_URL}" -o "${TMPCONFIG}"; then
+        cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
+        chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
+    elif curl -fsSL "${CONFIG_FALLBACK_URL}" -o "${TMPCONFIG}"; then
+        echo "Warning: no config for ${TAG_VERSION}; using the config from main," \
+             "which may not match this release."
+        cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
+        chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
+    else
+        echo "Warning: Could not download default config, skipping"
+    fi
+else
+    echo "Config already exists at ${CONFIG_FILE}, skipping"
+fi
+
+echo "TAG ${TAG_VERSION} installed to ${DEST}"
+echo ""
+echo "Quick start:"
+echo "  export AWS_ACCESS_KEY_ID=your_access_key"
+echo "  export AWS_SECRET_ACCESS_KEY=your_secret_key"
+echo "  tag --config /etc/tag/config.yaml"
+echo ""
+echo "Verify with:"
+echo "  tag --version"

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -56,11 +56,9 @@ chmod +x "${DEST}" 2>/dev/null || sudo chmod +x "${DEST}"
 # Install default configuration file
 CONFIG_DIR="/etc/tag"
 CONFIG_FILE="${CONFIG_DIR}/config.yaml"
-# Pin the config to the same release as the binary so native installs are
-# reproducible. Fall back to main only for versions predating the config's move
-# into this repo (e.g. <= v1.9.4, whose git tag has no deploy/native/config.yaml).
-CONFIG_URL="https://raw.githubusercontent.com/tigrisdata/tag/refs/tags/${TAG_VERSION}/deploy/native/config.yaml"
-CONFIG_FALLBACK_URL="https://raw.githubusercontent.com/tigrisdata/tag/main/deploy/native/config.yaml"
+# Config ships in the same versioned release directory as the binary, so it is
+# always matched to the installed version and needs no GitHub access.
+CONFIG_URL="${TAG_RELEASES_URL}/${TAG_VERSION}/config.yaml"
 
 if [ ! -d "${CONFIG_DIR}" ]; then
     echo "Creating ${CONFIG_DIR} (may require sudo)..."
@@ -73,13 +71,9 @@ if [ ! -f "${CONFIG_FILE}" ]; then
     if curl -fsSL "${CONFIG_URL}" -o "${TMPCONFIG}"; then
         cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
         chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
-    elif curl -fsSL "${CONFIG_FALLBACK_URL}" -o "${TMPCONFIG}"; then
-        echo "Warning: no config for ${TAG_VERSION}; using the config from main," \
-             "which may not match this release."
-        cp "${TMPCONFIG}" "${CONFIG_FILE}" 2>/dev/null || sudo cp "${TMPCONFIG}" "${CONFIG_FILE}"
-        chmod 644 "${CONFIG_FILE}" 2>/dev/null || sudo chmod 644 "${CONFIG_FILE}"
     else
-        echo "Warning: Could not download default config, skipping"
+        echo "Warning: no config found at ${CONFIG_URL}; skipping." \
+             "TAG can also be configured entirely via environment variables."
     fi
 else
     echo "Config already exists at ${CONFIG_FILE}, skipping"

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -22,9 +22,30 @@ CACHE_DATA_DIR="${TAG_DATA_DIR}/cache-data"
 # Ports
 TAG_PORT="${TAG_PORT:-8080}"
 
+# Config file passed to the binary when it exists; install.sh writes this path.
+# Set to an empty string to run with built-in defaults and env overrides only.
+TAG_CONFIG_FILE="${TAG_CONFIG_FILE-/etc/tag/config.yaml}"
+
+# True when the config file enables TLS (both tls_cert_file and tls_key_file set
+# to a non-empty value). Mirrors the binary, which serves HTTPS only when both
+# are set, so the health probe picks the right scheme even when TLS is configured
+# via the file rather than TAG_TLS_CERT_FILE / TAG_TLS_KEY_FILE.
+config_enables_tls() {
+    local file="$1"
+    [ -n "${file}" ] && [ -f "${file}" ] || return 1
+    local cert key
+    cert=$(sed -n 's/^[[:space:]]*tls_cert_file:[[:space:]]*//p' "${file}" \
+        | sed 's/#.*$//; s/["'\'']//g; s/[[:space:]]*$//' | tail -n1)
+    key=$(sed -n 's/^[[:space:]]*tls_key_file:[[:space:]]*//p' "${file}" \
+        | sed 's/#.*$//; s/["'\'']//g; s/[[:space:]]*$//' | tail -n1)
+    [ -n "${cert}" ] && [ -n "${key}" ]
+}
+
 # Health-check scheme follows TLS config: TAG serves HTTPS when both a cert and a
-# key are set, so probe over HTTPS (and skip cert verification for self-signed).
-if [ -n "${TAG_TLS_CERT_FILE:-}" ] && [ -n "${TAG_TLS_KEY_FILE:-}" ]; then
+# key are set (via env vars or the config file), so probe over HTTPS (and skip
+# cert verification for self-signed).
+if { [ -n "${TAG_TLS_CERT_FILE:-}" ] && [ -n "${TAG_TLS_KEY_FILE:-}" ]; } \
+    || config_enables_tls "${TAG_CONFIG_FILE}"; then
     TAG_HEALTH_SCHEME="https"
     TAG_HEALTH_CURL_OPTS="-k"
 else
@@ -94,7 +115,9 @@ download_binary() {
     local url="$3"
     local dest="${BIN_DIR}/${name}-${version}"
 
-    if [ -x "${dest}" ]; then
+    # "latest" is a moving tag, so a cached .bin/<name>-latest can be stale after
+    # a new release. Re-download it every start; only cache pinned versions.
+    if [ -x "${dest}" ] && [ "${version}" != "latest" ]; then
         echo "${name} ${version} already downloaded"
         return 0
     fi
@@ -102,13 +125,20 @@ download_binary() {
     echo "Downloading ${name} ${version} for ${OS}-${ARCH}..."
     mkdir -p "${BIN_DIR}"
 
+    # Download to a temp file in the same dir and atomically rename on success, so
+    # a failed/partial download never truncates a previously working binary (which
+    # would block offline starts, esp. for the always-refreshed "latest").
     local download_url="${url}/${version}/${name}-${OS}-${ARCH}"
-    if ! curl -fsSL "${download_url}" -o "${dest}"; then
+    local tmp
+    tmp="$(mktemp "${BIN_DIR}/.${name}-${version}.XXXXXX")"
+    if ! curl -fsSL "${download_url}" -o "${tmp}"; then
+        rm -f "${tmp}"
         echo "Error: Failed to download ${name} from ${download_url}"
         exit 1
     fi
 
-    chmod +x "${dest}"
+    chmod +x "${tmp}"
+    mv -f "${tmp}" "${dest}"
     echo "${name} ${version} downloaded successfully"
 }
 
@@ -210,6 +240,14 @@ cmd_start() {
 
     local tag_bin="${BIN_DIR}/tag-${TAG_VERSION}"
 
+    # Pass the installed config file to the binary when present, so edits to
+    # /etc/tag/config.yaml (TLS, upstream, cache) actually take effect.
+    local config_args=()
+    if [ -n "${TAG_CONFIG_FILE}" ] && [ -f "${TAG_CONFIG_FILE}" ]; then
+        config_args=(--config "${TAG_CONFIG_FILE}")
+        echo "Using config file: ${TAG_CONFIG_FILE}"
+    fi
+
     # Start TAG with embedded cache
     echo "Starting TAG with embedded cache..."
     TAG_HTTP_PORT="${TAG_PORT}" \
@@ -221,7 +259,7 @@ cmd_start() {
     TAG_LOG_LEVEL="${TAG_LOG_LEVEL}" \
     TAG_PPROF_ENABLED="${TAG_PPROF_ENABLED}" \
     TAG_MAX_IDLE_CONNS_PER_HOST="${TAG_MAX_IDLE_CONNS_PER_HOST}" \
-    "${tag_bin}" \
+    "${tag_bin}" ${config_args[@]+"${config_args[@]}"} \
         > "${LOG_DIR}/tag.log" 2>&1 &
     local tag_pid=$!
     echo "${tag_pid}" > "${TAG_PID_FILE}"
@@ -322,6 +360,7 @@ cmd_help() {
     echo "  TAG_MAX_IDLE_CONNS_PER_HOST  Max idle connections per host (default: ${TAG_MAX_IDLE_CONNS_PER_HOST})"
     echo "  TAG_PORT               TAG HTTP port (default: ${TAG_PORT})"
     echo "  TAG_START_TIMEOUT      Seconds to wait for /health on start (default: ${TAG_START_TIMEOUT})"
+    echo "  TAG_CONFIG_FILE        Config file passed to tag if it exists; empty to disable (default: ${TAG_CONFIG_FILE})"
     echo "  TAG_CACHE_MAX_DISK_USAGE  Max cache disk usage in bytes (default: ${TAG_CACHE_MAX_DISK_USAGE})"
     echo "  TAG_CACHE_CLUSTER_ADDR Cluster gossip address (default: ${TAG_CACHE_CLUSTER_ADDR})"
     echo "  TAG_CACHE_GRPC_ADDR    gRPC server address (default: ${TAG_CACHE_GRPC_ADDR})"

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -1,0 +1,360 @@
+#!/bin/bash
+#
+# Native runner for TAG with embedded cache
+# Downloads pre-built binary from Tigris and runs it as a native process
+#
+
+set -euo pipefail
+
+# Configuration (can be overridden via environment variables)
+TAG_VERSION="${TAG_VERSION:-v1.9.4}"
+
+# Directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="${BIN_DIR:-${SCRIPT_DIR}/.bin}"
+DATA_DIR="${DATA_DIR:-/tmp/native-data}"
+# Well-defined subdirectory containing all runtime data - safe to delete on cleanup
+TAG_DATA_DIR="${DATA_DIR}/tag-data"
+LOG_DIR="${TAG_DATA_DIR}/logs"
+PID_DIR="${TAG_DATA_DIR}/pids"
+CACHE_DATA_DIR="${TAG_DATA_DIR}/cache-data"
+
+# Ports
+TAG_PORT="${TAG_PORT:-8080}"
+
+# Health-check scheme follows TLS config: TAG serves HTTPS when both a cert and a
+# key are set, so probe over HTTPS (and skip cert verification for self-signed).
+if [ -n "${TAG_TLS_CERT_FILE:-}" ] && [ -n "${TAG_TLS_KEY_FILE:-}" ]; then
+    TAG_HEALTH_SCHEME="https"
+    TAG_HEALTH_CURL_OPTS="-k"
+else
+    TAG_HEALTH_SCHEME="http"
+    TAG_HEALTH_CURL_OPTS=""
+fi
+
+# Cache settings
+TAG_CACHE_MAX_DISK_USAGE="${TAG_CACHE_MAX_DISK_USAGE:-429496729600}"  # 400GB
+# Use port 17000 instead of 7000 to avoid conflict with macOS Control Center
+TAG_CACHE_CLUSTER_ADDR="${TAG_CACHE_CLUSTER_ADDR:-:17000}"
+TAG_CACHE_GRPC_ADDR="${TAG_CACHE_GRPC_ADDR:-:19000}"
+
+# TAG settings
+TAG_LOG_LEVEL="${TAG_LOG_LEVEL:-info}"
+TAG_PPROF_ENABLED="${TAG_PPROF_ENABLED:-false}"
+TAG_MAX_IDLE_CONNS_PER_HOST="${TAG_MAX_IDLE_CONNS_PER_HOST:-100}"
+
+# Seconds to wait for /health during start. Warm-cache boots open the on-disk
+# store before the HTTP server listens, which on a large cache can take minutes
+# (cf. the Kubernetes startupProbe budget); scale this up for larger caches. The
+# wait exits as soon as /health responds, so this only bounds a failed start.
+TAG_START_TIMEOUT="${TAG_START_TIMEOUT:-600}"
+
+# Release URLs
+TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
+
+# PID files
+TAG_PID_FILE="${PID_DIR}/tag.pid"
+
+# Check required dependencies
+check_dependencies() {
+    local missing=()
+
+    if ! command -v lsof >/dev/null 2>&1; then
+        missing+=("lsof")
+    fi
+
+    if ! command -v curl >/dev/null 2>&1; then
+        missing+=("curl")
+    fi
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "Error: Required dependencies not installed: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Detect OS and architecture
+detect_platform() {
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m)"
+
+    # Convert architecture names
+    case "${ARCH}" in
+        x86_64)  ARCH="amd64" ;;
+        aarch64) ARCH="arm64" ;;
+    esac
+
+    echo "Detected platform: ${OS}-${ARCH}"
+}
+
+# Download a binary if it doesn't exist
+download_binary() {
+    local name="$1"
+    local version="$2"
+    local url="$3"
+    local dest="${BIN_DIR}/${name}-${version}"
+
+    if [ -x "${dest}" ]; then
+        echo "${name} ${version} already downloaded"
+        return 0
+    fi
+
+    echo "Downloading ${name} ${version} for ${OS}-${ARCH}..."
+    mkdir -p "${BIN_DIR}"
+
+    local download_url="${url}/${version}/${name}-${OS}-${ARCH}"
+    if ! curl -fsSL "${download_url}" -o "${dest}"; then
+        echo "Error: Failed to download ${name} from ${download_url}"
+        exit 1
+    fi
+
+    chmod +x "${dest}"
+    echo "${name} ${version} downloaded successfully"
+}
+
+# Kill processes on a specific port (graceful shutdown)
+kill_port() {
+    local port="$1"
+    local pids
+    pids=$(lsof -ti:"${port}" 2>/dev/null || true)
+    if [ -n "${pids}" ]; then
+        echo "Stopping processes on port ${port}..."
+        # Send SIGTERM first for graceful shutdown
+        echo "${pids}" | xargs kill -TERM 2>/dev/null || true
+        sleep 2
+        # Force kill if still running
+        pids=$(lsof -ti:"${port}" 2>/dev/null || true)
+        if [ -n "${pids}" ]; then
+            echo "Force killing processes on port ${port}..."
+            echo "${pids}" | xargs kill -9 2>/dev/null || true
+        fi
+    fi
+}
+
+# Kill process by PID file (graceful shutdown)
+kill_pid_file() {
+    local pid_file="$1"
+    local name="$2"
+
+    if [ -f "${pid_file}" ]; then
+        local pid
+        pid=$(cat "${pid_file}")
+        if kill -0 "${pid}" 2>/dev/null; then
+            echo "Stopping ${name} (PID: ${pid})..."
+            kill -TERM "${pid}" 2>/dev/null || true
+            sleep 2
+            if kill -0 "${pid}" 2>/dev/null; then
+                echo "Force killing ${name}..."
+                kill -9 "${pid}" 2>/dev/null || true
+            fi
+        fi
+        rm -f "${pid_file}"
+    fi
+}
+
+# Wait for a health endpoint to become available
+wait_for_health() {
+    local name="$1"
+    local url="$2"
+    local timeout="${3:-30}"
+
+    echo "Waiting for ${name} to be ready..."
+    local count=0
+    while ! curl -sf ${TAG_HEALTH_CURL_OPTS} "${url}" > /dev/null 2>&1; do
+        sleep 1
+        count=$((count + 1))
+        if [ ${count} -ge ${timeout} ]; then
+            echo "Error: ${name} failed to start within ${timeout} seconds"
+            return 1
+        fi
+    done
+    echo "${name} is ready"
+}
+
+# Check if a service is running on a port
+check_port() {
+    local port="$1"
+    lsof -ti:"${port}" > /dev/null 2>&1
+}
+
+# Start services
+cmd_start() {
+    echo "Starting TAG (native mode with embedded cache)..."
+
+    # Check dependencies
+    check_dependencies
+
+    # Check AWS credentials
+    if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+        echo "Error: AWS credentials not set."
+        echo "  export AWS_ACCESS_KEY_ID=<your-key>"
+        echo "  export AWS_SECRET_ACCESS_KEY=<your-secret>"
+        exit 1
+    fi
+
+    # Detect platform
+    detect_platform
+
+    # Stop any existing processes
+    kill_pid_file "${TAG_PID_FILE}" "TAG"
+    kill_port "${TAG_PORT}"
+    sleep 1
+
+    # Download binary
+    download_binary "tag" "${TAG_VERSION}" "${TAG_RELEASES_URL}"
+
+    # Create directories (all under TAG_DATA_DIR)
+    mkdir -p "${LOG_DIR}"
+    mkdir -p "${PID_DIR}"
+    mkdir -p "${CACHE_DATA_DIR}"
+
+    local tag_bin="${BIN_DIR}/tag-${TAG_VERSION}"
+
+    # Start TAG with embedded cache
+    echo "Starting TAG with embedded cache..."
+    TAG_HTTP_PORT="${TAG_PORT}" \
+    TAG_CACHE_NODE_ID="tag-native" \
+    TAG_CACHE_DISK_PATH="${CACHE_DATA_DIR}" \
+    TAG_CACHE_MAX_DISK_USAGE="${TAG_CACHE_MAX_DISK_USAGE}" \
+    TAG_CACHE_CLUSTER_ADDR="${TAG_CACHE_CLUSTER_ADDR}" \
+    TAG_CACHE_GRPC_ADDR="${TAG_CACHE_GRPC_ADDR}" \
+    TAG_LOG_LEVEL="${TAG_LOG_LEVEL}" \
+    TAG_PPROF_ENABLED="${TAG_PPROF_ENABLED}" \
+    TAG_MAX_IDLE_CONNS_PER_HOST="${TAG_MAX_IDLE_CONNS_PER_HOST}" \
+    "${tag_bin}" \
+        > "${LOG_DIR}/tag.log" 2>&1 &
+    local tag_pid=$!
+    echo "${tag_pid}" > "${TAG_PID_FILE}"
+
+    if ! wait_for_health "TAG" "${TAG_HEALTH_SCHEME}://localhost:${TAG_PORT}/health" "${TAG_START_TIMEOUT}"; then
+        echo "TAG logs:"
+        tail -20 "${LOG_DIR}/tag.log"
+        exit 1
+    fi
+
+    echo ""
+    echo "TAG started successfully with embedded cache!"
+    echo "  TAG:   ${TAG_HEALTH_SCHEME}://localhost:${TAG_PORT}"
+    echo "  Cache: ${CACHE_DATA_DIR}"
+    echo ""
+    echo "Logs: ${LOG_DIR}"
+}
+
+# Stop services
+cmd_stop() {
+    echo "Stopping TAG..."
+
+    # Try PID file first, then fall back to port-based killing
+    kill_pid_file "${TAG_PID_FILE}" "TAG"
+    kill_port "${TAG_PORT}"
+
+    echo "TAG stopped"
+
+    if [ "${1:-}" = "--clean" ]; then
+        echo "Cleaning up tag data..."
+
+        # Delete the well-defined tag-data subdirectory (contains logs, pids, cache-data)
+        # This is safe because we created it with a known name
+        if [ -d "${TAG_DATA_DIR}" ]; then
+            rm -rf "${TAG_DATA_DIR}"
+            echo "Tag data directory removed: ${TAG_DATA_DIR}"
+        else
+            echo "Tag data directory does not exist, nothing to clean"
+        fi
+    fi
+}
+
+# Check status of services
+cmd_status() {
+    echo "Service Status:"
+    echo ""
+
+    # TAG status
+    local tag_pid=""
+    if [ -f "${TAG_PID_FILE}" ]; then
+        tag_pid=$(cat "${TAG_PID_FILE}")
+    fi
+
+    if check_port "${TAG_PORT}"; then
+        echo "  TAG (port ${TAG_PORT}): RUNNING${tag_pid:+ (PID: ${tag_pid})}"
+        if curl -sf ${TAG_HEALTH_CURL_OPTS} "${TAG_HEALTH_SCHEME}://localhost:${TAG_PORT}/health" > /dev/null 2>&1; then
+            echo "    Health: OK"
+        else
+            echo "    Health: UNHEALTHY"
+        fi
+        echo "    Cache:  ${CACHE_DATA_DIR}"
+    else
+        echo "  TAG (port ${TAG_PORT}): STOPPED"
+    fi
+}
+
+# Show logs
+cmd_logs() {
+    local lines="${1:-50}"
+
+    if [ -f "${LOG_DIR}/tag.log" ]; then
+        echo "=== TAG Logs ==="
+        tail -"${lines}" "${LOG_DIR}/tag.log"
+    else
+        echo "No TAG logs found"
+    fi
+}
+
+# Show usage
+cmd_help() {
+    echo "Native runner for TAG with embedded cache"
+    echo ""
+    echo "Usage: $0 <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  start           Start TAG service"
+    echo "  stop [--clean]  Stop service (--clean removes all tag data)"
+    echo "  status          Check status of service"
+    echo "  logs [lines]    Show logs (default: 50 lines)"
+    echo "  help            Show this help message"
+    echo ""
+    echo "Environment Variables:"
+    echo "  AWS_ACCESS_KEY_ID      AWS access key (required)"
+    echo "  AWS_SECRET_ACCESS_KEY  AWS secret key (required)"
+    echo "  TAG_VERSION            TAG version (default: ${TAG_VERSION})"
+    echo "  TAG_LOG_LEVEL          Log level: debug, info, warn, error (default: ${TAG_LOG_LEVEL})"
+    echo "  TAG_PPROF_ENABLED      Enable pprof profiling: true, false (default: ${TAG_PPROF_ENABLED})"
+    echo "  TAG_MAX_IDLE_CONNS_PER_HOST  Max idle connections per host (default: ${TAG_MAX_IDLE_CONNS_PER_HOST})"
+    echo "  TAG_PORT               TAG HTTP port (default: ${TAG_PORT})"
+    echo "  TAG_START_TIMEOUT      Seconds to wait for /health on start (default: ${TAG_START_TIMEOUT})"
+    echo "  TAG_CACHE_MAX_DISK_USAGE  Max cache disk usage in bytes (default: ${TAG_CACHE_MAX_DISK_USAGE})"
+    echo "  TAG_CACHE_CLUSTER_ADDR Cluster gossip address (default: ${TAG_CACHE_CLUSTER_ADDR})"
+    echo "  TAG_CACHE_GRPC_ADDR    gRPC server address (default: ${TAG_CACHE_GRPC_ADDR})"
+    echo "  BIN_DIR                Binary download directory (default: ${BIN_DIR})"
+    echo "  DATA_DIR               Data directory (default: ${DATA_DIR})"
+    echo ""
+    echo "Examples:"
+    echo "  export AWS_ACCESS_KEY_ID=<key>"
+    echo "  export AWS_SECRET_ACCESS_KEY=<secret>"
+    echo "  $0 start"
+    echo "  $0 status"
+    echo "  $0 logs 100"
+    echo "  $0 stop --clean"
+}
+
+# Main entry point
+main() {
+    local command="${1:-help}"
+    shift || true
+
+    case "${command}" in
+        start)  cmd_start "$@" ;;
+        stop)   cmd_stop "$@" ;;
+        status) cmd_status "$@" ;;
+        logs)   cmd_logs "$@" ;;
+        help)   cmd_help ;;
+        *)
+            echo "Unknown command: ${command}"
+            echo ""
+            cmd_help
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,62 @@
+# TAG Benchmarks
+
+Benchmark results for a single TAG instance serving cached object reads. A single TAG node saturates a 100 Gbps NIC at ~85+ Gbps for objects 1 MiB and larger, delivers ~75K ops/sec for small objects, and maintains low single-digit millisecond TTFB — all while using around 12% of available CPU.
+
+## Test Environment
+
+Benchmarks were run on Amazon EC2 using [go-ycsb](https://github.com/pingcap/go-ycsb) and [warp](https://github.com/minio/warp).
+
+| Role             | Instance      | vCPUs | Memory  | Storage   | Network  |
+| ---------------- | ------------- | ----- | ------- | --------- | -------- |
+| Benchmark client | c6in.16xlarge | 64    | 128 GiB | -         | 100 Gbps |
+| TAG server       | i3en.24xlarge | 96    | 768 GiB | 60 TB SSD | 100 Gbps |
+
+TAG was run as a single instance via `deploy/native/run.sh`. During the benchmarks, TAG CPU usage stayed under 1200% and memory usage remained around 24 GB, leaving significant headroom on the server.
+
+## Results — warp
+
+Benchmarks were run using [warp](https://github.com/minio/warp) on the same test environment. Each test ran GET operations for ~30 minutes.
+
+| Object Size | Threads | OPS    | Throughput | p50 (ms) | p99 (ms) | TTFB p50 (ms) |
+| ----------- | ------- | ------ | ---------- | -------- | -------- | ------------- |
+| 1 KiB       | 16      | 38,724 | 37.8 MiB/s | 0.3      | 6.5      | < 1           |
+| 1 KiB       | 32      | 58,535 | 57.2 MiB/s | 0.3      | 2.0      | < 1           |
+| 1 KiB       | 64      | 75,717 | 73.9 MiB/s | 0.4      | 3.2      | < 1           |
+| 100 KiB     | 16      | 19,543 | 1.9 GiB/s  | 0.6      | 10.7     | < 1           |
+| 100 KiB     | 32      | 28,594 | 2.7 GiB/s  | 0.7      | 5.1      | 1             |
+| 100 KiB     | 64      | 33,350 | 3.2 GiB/s  | 1.3      | 5.8      | 1             |
+| 1 MiB       | 16      | 7,224  | 7.1 GiB/s  | 5.8      | 20.2     | 4             |
+| 1 MiB       | 32      | 10,313 | 10.1 GiB/s | 2.9      | 12.7     | 1             |
+| 1 MiB       | 64      | 10,955 | 10.7 GiB/s | 5.3      | 17.5     | 1             |
+| 4 MiB       | 16      | 1,984  | 7.8 GiB/s  | 13.2     | 59.7     | 6             |
+| 4 MiB       | 32      | 2,686  | 10.5 GiB/s | 10.3     | 38.1     | 1             |
+| 4 MiB       | 64      | 2,775  | 10.8 GiB/s | 18.6     | 102.3    | 1             |
+
+## Results — go-ycsb
+
+Benchmarks were run using [go-ycsb](https://github.com/pingcap/go-ycsb) on the same test environment.
+
+| Object Size | Threads | OPS    | p50 (us) | p99 (us) |
+| ----------- | ------- | ------ | -------- | -------- |
+| 1 KB        | 16      | 34,117 | 380      | 1,024    |
+| 1 KB        | 32      | 47,743 | 484      | 2,275    |
+| 1 KB        | 64      | 55,231 | 744      | 4,443    |
+| 100 KB      | 16      | 7,906  | 1,842    | 4,015    |
+| 100 KB      | 32      | 8,697  | 3,389    | 9,775    |
+| 100 KB      | 64      | 9,726  | 4,411    | 25,999   |
+| 1 MB        | 16      | 2,981  | 4,891    | 8,431    |
+| 1 MB        | 32      | 4,816  | 6,523    | 11,223   |
+| 1 MB        | 64      | 6,255  | 9,655    | 19,727   |
+
+## Key Observations
+
+- **1 KiB objects**: ~75K ops/sec at 64 threads with sub-millisecond p50.
+- **100 KiB objects**: ~3.2 GiB/s at 64 threads (~26 Gbps).
+- **1 MiB objects**: ~10.7 GiB/s (~86 Gbps) at 64 threads, saturating the 100 Gbps EC2 network link at 32+ threads.
+- **4 MiB objects**: ~10.5 GiB/s (~84 Gbps) at 32 threads, saturating the 100 Gbps EC2 network link.
+- TTFB remains sub-millisecond for small objects (1 KiB, 100 KiB) and stays in the low single-digit milliseconds for objects up to 4 MiB.
+- Throughput scales with thread count for small objects and saturates the 100 Gbps NIC at ~85 Gbps for 1 MiB+ objects.
+
+## Limitations
+
+For 1 MiB+ objects, throughput is NIC-bound at ~85 Gbps — the practical maximum on a 100 Gbps EC2 link. For smaller objects (1 KiB, 100 KiB), throughput is client-bound; multiple benchmark clients would be needed to determine TAG's actual ceiling. A single go-ycsb instance does not scale well past ~20 Gbps and struggles with object sizes above 1 MB.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,31 +4,31 @@ TAG can be configured via a YAML configuration file and/or environment variables
 
 ## Environment Variables
 
-| Variable                      | Description                                                                     | Default                  |
-| ----------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
-| `AWS_ACCESS_KEY_ID`           | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
-| `AWS_SECRET_ACCESS_KEY`       | S3 secret key for authentication                                                | (required)               |
-| `TAG_UPSTREAM_ENDPOINT`       | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
-| `TAG_MAX_IDLE_CONNS_PER_HOST` | HTTP connection pool size per upstream host                                     | `100`                    |
-| `TAG_CACHE_TTL`               | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
-| `TAG_CACHE_DISABLED`          | Disable caching (`true` or `1`)                                                 | `false`                  |
-| `TAG_CACHE_DISK_PATH`         | Path to cache data directory                                                    | `/var/cache/tag`         |
-| `TAG_CACHE_MAX_DISK_USAGE`    | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
-| `TAG_CACHE_NODE_ID`           | Unique node identifier for cluster mode                                         | (none)                   |
-| `TAG_CACHE_CLUSTER_ADDR`      | Address for memberlist gossip                                                   | `:7000`                  |
-| `TAG_CACHE_GRPC_ADDR`         | Address for gRPC server                                                         | `:9000`                  |
-| `TAG_CACHE_ADVERTISE_ADDR`    | Address advertised to other nodes                                               | (defaults to GRPC addr)  |
-| `TAG_CACHE_SEED_NODES`        | Comma-separated seed nodes for cluster discovery                                | (none)                   |
-| `TAG_CACHE_DELETE_BATCH_SIZE` | File deletions processed per deletion-queue batch                               | `1000`                   |
-| `TAG_CACHE_RECOVERY_WORKERS`  | Parallel workers for startup file recovery                                      | `16`                     |
-| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                    | `256`                    |
-| `TAG_MAX_INFLIGHT_REQUESTS`   | Max concurrently-served S3 requests before shedding with 503 SlowDown           | `1024`                   |
-| `TAG_LOG_LEVEL`               | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
-| `TAG_LOG_FORMAT`              | Log format: `json` or `console`                                                 | `json`                   |
-| `TAG_TRANSPARENT_PROXY`       | Disable transparent proxy mode (`false` or `0`)                                 | `true`                   |
-| `TAG_TLS_CERT_FILE`           | Path to TLS certificate file (PEM format)                                       | (none)                   |
-| `TAG_TLS_KEY_FILE`            | Path to TLS private key file (PEM format)                                       | (none)                   |
-| `TAG_PPROF_ENABLED`           | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
+| Variable                          | Description                                                                     | Default                  |
+| --------------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`               | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
+| `AWS_SECRET_ACCESS_KEY`           | S3 secret key for authentication                                                | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`           | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
+| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
+| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
+| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |
+| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                    | `/var/cache/tag`         |
+| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
+| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
+| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes                                               | (defaults to GRPC addr)  |
+| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery                                | (none)                   |
+| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                               | `1000`                   |
+| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                      | `16`                     |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                        | `256`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrently-served S3 requests before shedding with 503 SlowDown           | `1024`                   |
+| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
+| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                 | `json`                   |
+| `TAG_TRANSPARENT_PROXY`           | Disable transparent proxy mode (`false` or `0`)                                 | `true`                   |
+| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                                       | (none)                   |
+| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                                       | (none)                   |
+| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
 
 ## Configuration File
 
@@ -185,14 +185,14 @@ log:
 
 Controls the HTTP server settings.
 
-| Field           | Type   | Default     | Description                        |
-| --------------- | ------ | ----------- | ---------------------------------- |
-| `http_port`     | int    | `8080`      | Port for the S3 API                |
-| `bind_ip`       | string | `"0.0.0.0"` | IP address to bind to              |
-| `pprof_enabled` | bool   | `false`     | Enable pprof profiling endpoints   |
-| `tls_cert_file` | string | `""`        | Path to TLS certificate file (PEM) |
-| `tls_key_file`  | string | `""`        | Path to TLS private key file (PEM) |
-| `max_inflight_requests` | int | `1024` | Max concurrently-served S3 requests before shedding with 503 SlowDown (`0`/unset = default, negative = disabled). `/health`, `/metrics`, `/debug/pprof/*` are exempt. |
+| Field                   | Type   | Default     | Description                                                                                                                                                           |
+| ----------------------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http_port`             | int    | `8080`      | Port for the S3 API                                                                                                                                                   |
+| `bind_ip`               | string | `"0.0.0.0"` | IP address to bind to                                                                                                                                                 |
+| `pprof_enabled`         | bool   | `false`     | Enable pprof profiling endpoints                                                                                                                                      |
+| `tls_cert_file`         | string | `""`        | Path to TLS certificate file (PEM)                                                                                                                                    |
+| `tls_key_file`          | string | `""`        | Path to TLS private key file (PEM)                                                                                                                                    |
+| `max_inflight_requests` | int    | `1024`      | Max concurrently-served S3 requests before shedding with 503 SlowDown (`0`/unset = default, negative = disabled). `/health`, `/metrics`, `/debug/pprof/*` are exempt. |
 
 ### Upstream
 
@@ -248,21 +248,21 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 
 Controls the embedded cache behavior. TAG uses an embedded OCache instance with RocksDB storage.
 
-| Field                  | Type     | Default          | Description                                       |
-| ---------------------- | -------- | ---------------- | ------------------------------------------------- |
-| `enabled`              | bool     | `true`           | Enable caching                                    |
-| `ttl`                  | duration | `24h`            | Default TTL for cached objects                    |
-| `size_threshold`       | int64    | `1073741824`     | Max object size to cache (bytes)                  |
-| `disk_path`            | string   | `/var/cache/tag` | Path to cache data directory                      |
-| `max_disk_usage_bytes` | int64    | `0`              | Max disk usage (0 = unlimited)                    |
-| `node_id`              | string   | `""`             | Unique node identifier for cluster mode           |
-| `cluster_addr`         | string   | `:7000`          | Address for memberlist gossip                     |
-| `grpc_addr`            | string   | `:9000`          | Address for gRPC server                           |
-| `advertise_addr`       | string   | `""`             | Address advertised to other nodes                 |
-| `seed_nodes`           | []string | `[]`             | Seed nodes for cluster discovery                  |
-| `delete_batch_size`    | int      | `1000`           | File deletions processed per deletion-queue batch |
-| `recovery_workers`     | int      | `16`             | Parallel workers for startup file recovery        |
-| `max_concurrent_writes` | int     | `256`            | Max concurrent cache-populate operations (`0`/unset = default, negative = disabled) |
+| Field                   | Type     | Default          | Description                                                                         |
+| ----------------------- | -------- | ---------------- | ----------------------------------------------------------------------------------- |
+| `enabled`               | bool     | `true`           | Enable caching                                                                      |
+| `ttl`                   | duration | `24h`            | Default TTL for cached objects                                                      |
+| `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
+| `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
+| `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
+| `node_id`               | string   | `""`             | Unique node identifier for cluster mode                                             |
+| `cluster_addr`          | string   | `:7000`          | Address for memberlist gossip                                                       |
+| `grpc_addr`             | string   | `:9000`          | Address for gRPC server                                                             |
+| `advertise_addr`        | string   | `""`             | Address advertised to other nodes                                                   |
+| `seed_nodes`            | []string | `[]`             | Seed nodes for cluster discovery                                                    |
+| `delete_batch_size`     | int      | `1000`           | File deletions processed per deletion-queue batch                                   |
+| `recovery_workers`      | int      | `16`             | Parallel workers for startup file recovery                                          |
+| `max_concurrent_writes` | int      | `256`            | Max concurrent cache-populate operations (`0`/unset = default, negative = disabled) |
 
 **TTL Format:**
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,136 @@
+# Kubernetes Deployment
+
+Deploy TAG as a StatefulSet with an embedded distributed cache cluster. For running locally, see the [README](../README.md). For all configuration options, see the [Configuration Reference](configuration.md).
+
+## Prerequisites
+
+- A running Kubernetes cluster
+- `kubectl` configured to access the cluster
+- Tigris access key and secret key with read access to all buckets that will be accessed through TAG
+
+## Deploy
+
+### 1. Create a namespace
+
+```bash
+kubectl create namespace tag
+```
+
+### 2. Create the credentials secret
+
+```bash
+kubectl create secret generic tag-credentials \
+  --namespace tag \
+  --from-literal=AWS_ACCESS_KEY_ID=your_access_key \
+  --from-literal=AWS_SECRET_ACCESS_KEY=your_secret_key
+```
+
+### 3. Apply the manifests
+
+```bash
+kubectl apply -k deploy/kubernetes/base/ -n tag
+```
+
+This deploys a 3-replica StatefulSet with:
+- Embedded cache on each pod (400 GiB PVC per pod)
+- Gossip-based cluster discovery via a headless service
+- A LoadBalancer service for external access on port 8080
+- Horizontal Pod Autoscaler (3-10 replicas)
+
+### 4. Verify the deployment
+
+```bash
+# Check pod status
+kubectl get pods -n tag
+
+# Check health
+kubectl exec -n tag tag-0 -- curl -s http://localhost:8080/health
+```
+
+## Kubernetes Manifests
+
+The `deploy/kubernetes/base/` directory uses Kustomize:
+
+| File | Description |
+|------|-------------|
+| `kustomization.yaml` | Kustomize configuration with image tag |
+| `statefulset.yaml` | TAG StatefulSet (3 replicas, embedded cache) |
+| `service.yaml` | LoadBalancer Service for external access |
+| `service-headless.yaml` | Headless Service for cluster discovery |
+| `hpa.yaml` | Horizontal Pod Autoscaler |
+
+To customize the image version or other settings, create an overlay:
+
+```yaml
+# deploy/kubernetes/overlays/production/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+images:
+  - name: tigrisdata/tag
+    newTag: v1.9.3
+```
+
+## Production Considerations
+
+### High Availability
+
+- The StatefulSet deploys 3 replicas by default with pod anti-affinity to distribute across nodes.
+- Each TAG pod has its own local cache, so losing a pod only affects cache hit ratio temporarily.
+- Health checks (readiness and liveness probes) ensure automatic recovery.
+
+### Scaling
+
+**Horizontal:** The HPA scales from 3 to 10 replicas based on CPU (70%) and memory (80%) utilization. New nodes join the cache cluster automatically. Scaling down may temporarily reduce cache hit ratio.
+
+**Vertical:** Adjust resource requests/limits in the StatefulSet. The default is 2-4 CPUs and 4-8 GiB memory per pod. SSD storage is recommended for cache performance. If you change the PVC volume size, also update `TAG_CACHE_MAX_DISK_USAGE` in the StatefulSet to match (value is in bytes).
+
+### Health Checks
+
+TAG exposes a health endpoint:
+
+```
+GET /health
+```
+
+Returns `200 OK` when healthy. The StatefulSet configures both readiness and liveness probes against this endpoint.
+
+### Monitoring
+
+TAG exposes Prometheus metrics at `/metrics`. The StatefulSet includes Prometheus annotations for automatic scraping.
+
+Key metrics:
+- `tag_requests_total{status="error"}` - error rate
+- `tag_cache_hits_total / (tag_cache_hits_total + tag_cache_misses_total)` - cache hit ratio
+- `tag_upstream_request_duration_seconds` - upstream latency
+
+## Troubleshooting
+
+### No cache hits
+
+- Check TAG logs for cache initialization errors: `kubectl logs -n tag tag-0`
+- Verify the cache PVC is bound: `kubectl get pvc -n tag`
+- Ensure the disk path is writable
+
+### Authentication failures
+
+- Verify the credentials secret exists: `kubectl get secret -n tag tag-credentials`
+- Check that credentials have read access to the target buckets
+- Review signature logs at debug level: set `TAG_LOG_LEVEL=debug` in the StatefulSet
+
+### High latency
+
+- Check upstream endpoint latency
+- Monitor cache hit ratio via Prometheus metrics
+- Review disk I/O performance on the storage class
+
+### Debug mode
+
+Enable debug logging by updating the StatefulSet:
+
+```yaml
+env:
+  - name: TAG_LOG_LEVEL
+    value: "debug"
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,104 @@
+# Docker
+
+Run TAG using Docker Compose. For all configuration options, see the [Configuration Reference](configuration.md).
+
+## Build-from-source vs. released image
+
+Two sets of Compose files ship in this repo:
+
+- **`docker/docker-compose.yml`** / **`docker/docker-compose-cluster.yml`** — package a locally built binary into the image via the local `Dockerfile`. Use these for local development against source. The `Dockerfile` does not compile TAG; it copies a pre-built **Linux** binary from `docker/bin/<arch>/tag` (`<arch>` is `amd64` or `arm64`), so you must stage that binary before building — see [Building the local image](#building-the-local-image) below.
+- **`deploy/docker/docker-compose.release.yml`** / **`deploy/docker/docker-compose-cluster.release.yml`** — pull the published `tigrisdata/tag` image. Use these to run a released version without building anything, e.g. `docker-compose -f docker-compose.release.yml up -d`.
+
+The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.9.4`) in your `.env`.
+
+### Building the local image
+
+The `docker/` Compose files expect a Linux binary staged at `docker/bin/<arch>/tag`. Build (or cross-compile) it first, then bring the stack up:
+
+```bash
+# From the repo root — produce a linux/amd64 binary and stage it for the build
+mkdir -p docker/bin/amd64
+GOOS=linux GOARCH=amd64 make build   # or: go build -o docker/bin/amd64/tag ./cmd/tag
+cp tag docker/bin/amd64/tag           # if 'make build' wrote ./tag
+
+cd docker
+docker-compose up -d
+```
+
+If you just want to run TAG without a local toolchain, use the released-image files under `deploy/docker/` instead.
+
+## Prerequisites
+
+Create a `.env` file in the directory of the Compose files you run (`docker/` for build-from-source, `deploy/docker/` for the released image) with your Tigris credentials:
+
+```bash
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+```
+
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials with read-only access to all buckets accessed through TAG (required). Clients use their own credentials directly.
+
+## Single Node
+
+```bash
+cd docker
+docker-compose up -d
+```
+
+TAG will be available at `http://localhost:8080`.
+
+```bash
+# View logs
+docker-compose logs -f tag
+
+# Stop
+docker-compose down
+```
+
+## Cluster Mode
+
+Run 3 TAG nodes with an embedded distributed cache cluster:
+
+```bash
+cd docker
+docker-compose -f docker-compose-cluster.yml up -d
+```
+
+TAG endpoints:
+
+- `http://localhost:8081` (tag-1)
+- `http://localhost:8082` (tag-2)
+- `http://localhost:8083` (tag-3)
+
+Each node discovers the others via gossip and shares cached objects across the cluster.
+
+```bash
+# View logs
+docker-compose -f docker-compose-cluster.yml logs -f
+
+# Stop and remove volumes
+docker-compose -f docker-compose-cluster.yml down -v
+```
+
+## Environment Variables
+
+You can add optional environment variables to the `.env` file:
+
+```bash
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+TAG_LOG_LEVEL=info
+```
+
+See the full [Configuration Reference](configuration.md) for all options.
+
+## Test
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# Download an object using AWS CLI
+aws s3 cp s3://your-bucket/your-key ./local-file \
+  --endpoint-url http://localhost:8080
+```

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,126 @@
+# TLS/HTTPS
+
+TAG supports TLS encryption for serving requests over HTTPS. TLS is disabled by default and must be explicitly configured. For all configuration options, see the [Configuration Reference](configuration.md).
+
+## Configuration
+
+TLS requires both a certificate file and a private key file. Both must be provided together; setting only one will cause a validation error at startup.
+
+### Environment Variables
+
+```bash
+export TAG_TLS_CERT_FILE=/path/to/cert.pem
+export TAG_TLS_KEY_FILE=/path/to/key.pem
+```
+
+### Configuration File
+
+```yaml
+server:
+  tls_cert_file: /path/to/cert.pem
+  tls_key_file: /path/to/key.pem
+```
+
+The certificate file should contain the full chain: the server certificate followed by any intermediate certificates.
+
+When TLS is enabled, TAG serves all requests over HTTPS. The startup logs will indicate the protocol in use.
+
+## Generate Self-Signed Certificates
+
+For testing and development, generate a self-signed certificate:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
+  -days 365 -nodes -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+```
+
+> **Note:** Self-signed certificates are suitable for development only. Use certificates from a trusted CA for production deployments.
+
+## Docker
+
+Mount the certificate and key files into the container and set the environment variables:
+
+```yaml
+services:
+  tag:
+    image: tigrisdata/tag:v1.9.4
+    ports:
+      - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - TAG_TLS_CERT_FILE=/etc/tag/tls/cert.pem
+      - TAG_TLS_KEY_FILE=/etc/tag/tls/key.pem
+    volumes:
+      - ./certs/cert.pem:/etc/tag/tls/cert.pem:ro
+      - ./certs/key.pem:/etc/tag/tls/key.pem:ro
+```
+
+Test the connection:
+
+```bash
+curl -k https://localhost:8080/health
+```
+
+## Kubernetes
+
+Store the TLS certificate and key in a Kubernetes Secret:
+
+```bash
+kubectl create secret tls tag-tls \
+  --namespace tag \
+  --cert=cert.pem \
+  --key=key.pem
+```
+
+Add the TLS configuration to the StatefulSet:
+
+```yaml
+containers:
+  - name: tag
+    env:
+      - name: TAG_TLS_CERT_FILE
+        value: "/etc/tag/tls/tls.crt"
+      - name: TAG_TLS_KEY_FILE
+        value: "/etc/tag/tls/tls.key"
+    volumeMounts:
+      - name: tls-certs
+        mountPath: /etc/tag/tls
+        readOnly: true
+volumes:
+  - name: tls-certs
+    secret:
+      secretName: tag-tls
+```
+
+When using TLS in Kubernetes, update the health check probes to use HTTPS:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+    scheme: HTTPS
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+    scheme: HTTPS
+```
+
+## Native Binary
+
+Set the environment variables before starting TAG:
+
+```bash
+export TAG_TLS_CERT_FILE=/path/to/cert.pem
+export TAG_TLS_KEY_FILE=/path/to/key.pem
+./deploy/native/run.sh start
+```
+
+When TLS is enabled, test with:
+
+```bash
+curl -k https://localhost:8080/health
+```

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -6,13 +6,13 @@ TAG instance (which proxies to Tigris) and exercise:
 
 All operations run at concurrency 64.
 
-| Operation | warp command                  | Object size                    |
-| --------- | ----------------------------- | ------------------------------ |
-| GET       | `warp get`                    | 4 MiB                          |
+| Operation | warp command                  | Object size                                  |
+| --------- | ----------------------------- | -------------------------------------------- |
+| GET       | `warp get`                    | 4 MiB                                        |
 | GET RANGE | `warp get --range-size=64KiB` | 256 MiB object, 64 KiB ranges (SlateDB-like) |
-| PUT       | `warp put`                    | 4 MiB                          |
-| HEAD      | `warp stat`                   | 4 MiB                          |
-| LIST V2   | `warp list`                   | 4 MiB                          |
+| PUT       | `warp put`                    | 4 MiB                                        |
+| HEAD      | `warp stat`                   | 4 MiB                                        |
+| LIST V2   | `warp list`                   | 4 MiB                                        |
 
 This is a **smoke benchmark**: the run fails if any operation errors. It does not
 enforce performance thresholds — it captures numbers for inspection.
@@ -49,12 +49,12 @@ shape the GET RANGE case to the SlateDB-fronting pattern (small ranges from
 large objects); object sizes stay modest so bandwidth against real upstream
 stays bounded. Override for heavier local runs:
 
-| Var                                                              | Default                 | Meaning                                          |
-| ---------------------------------------------------------------- | ----------------------- | ------------------------------------------------ |
-| `WARP_VERSION`                                                   | `v1.5.0`                | warp version installed via `go install`          |
-| `WARP_HOST`                                                      | `localhost:8080`        | TAG host:port                                    |
-| `WARP_BUCKET`                                                    | `tag-warp-benchmark`    | bucket for benchmark data (cleared each run)     |
-| `WARP_REGION`                                                    | `auto`                  | SigV4 region (must match TAG's region)           |
+| Var                                                              | Default                  | Meaning                                          |
+| ---------------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| `WARP_VERSION`                                                   | `v1.5.0`                 | warp version installed via `go install`          |
+| `WARP_HOST`                                                      | `localhost:8080`         | TAG host:port                                    |
+| `WARP_BUCKET`                                                    | `tag-warp-benchmark`     | bucket for benchmark data (cleared each run)     |
+| `WARP_REGION`                                                    | `auto`                   | SigV4 region (must match TAG's region)           |
 | `WARP_DURATION`                                                  | `30s`                    | duration per operation                           |
 | `WARP_CONCURRENT`                                                | `64`                     | concurrent operations                            |
 | `WARP_OBJ_SIZE` / `WARP_OBJECTS`                                 | `4MiB` / `100`           | size / count for 4 MiB ops                       |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Release workflow and published install scripts affect how operators deploy TAG; mistakes could break installs or upload wrong versions, but application runtime/auth code is unchanged.
> 
> **Overview**
> Brings **deployment into this repo** under `deploy/` (Kubernetes Kustomize base, Docker Compose for published images, native `install.sh` / `run.sh` / `config.yaml`) and **rewrites the README deployment section** to point at those paths plus new docs instead of the external `tag-deploy` repo. Users can install without cloning via `curl …/latest/install.sh | bash` (documented with versioned URLs).
> 
> The **T3 release upload workflow** now normalizes manual dispatch versions to `vX.Y.Z`, checks out `deploy/native/*` at the release tag, uploads `config.yaml` and shell scripts beside binaries (skipping older tags missing those files), and rewrites default `TAG_VERSION` in scripts for versioned vs `latest/` prefixes when updating `latest/`.
> 
> Adds **docs** for Kubernetes (`deploy.md`), released-image Docker (`docker.md`), TLS (`tls.md`), and published benchmark numbers (`benchmarks.md`). Remaining diff is minor doc table formatting in `configuration.md` and the warp benchmark README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2840326709d2795cc6f7e9aaf8e45ecceca8e7f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->