### PR TITLE
chore: drop GOPRIVATE/private-module setup now that ocache is public

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,7 +9,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   warp-benchmarks:
@@ -22,10 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,9 +11,6 @@ on:
         description: "Release version tag (e.g., v1.0.0)"
         required: true
 
-env:
-  GOPRIVATE: github.com/tigrisdata
-
 jobs:
   build-and-push:
     runs-on: namespace-profile-ubuntu-2404
@@ -26,10 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   test:
@@ -45,10 +44,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/s3-tests-cluster.yaml
+++ b/.github/workflows/s3-tests-cluster.yaml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   s3-compat-tests:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/s3-tests.yaml
+++ b/.github/workflows/s3-tests.yaml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   s3-compat-tests:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   test:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,7 @@ TESTRUN="TestBroadcast" make test-proxy
 
 ## Developer Setup
 
-This project depends on private Go modules under `github.com/tigrisdata`. Configure Go to bypass the public module proxy (one-time setup per machine):
-
-```bash
-go env -w GOPRIVATE=github.com/tigrisdata
-```
-
-This covers all private repos under the `tigrisdata` org (e.g., `ocache`). Without this, `go mod tidy` and `go get` will fail with 404 errors from the Go module proxy. If you see such errors, check that `GOPRIVATE` is set: `go env GOPRIVATE`.
+All dependencies are public, including the Tigris `ocache` modules (`github.com/tigrisdata/ocache/*`). No `GOPRIVATE` or Git URL rewriting is required — `make build`, `go mod tidy`, and `go get` work with a stock Go toolchain.
 
 ## Core Architecture
 

--- a/README.md
+++ b/README.md
@@ -171,17 +171,7 @@ See [docs/security.md](docs/security.md) for authentication, access control, and
 - Go 1.24 or later
 - Tigris account with access credentials (for running TAG and integration tests)
 
-TAG depends on Tigris Go modules. Configure Go and Git to access them:
-
-```bash
-# Tell Go to fetch tigrisdata repos directly (not via proxy)
-export GOPRIVATE=github.com/tigrisdata
-
-# Configure Git to use SSH for tigrisdata repos
-git config --global url."git@github.com:tigrisdata/".insteadOf "https://github.com/tigrisdata/"
-```
-
-Add the `GOPRIVATE` export to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`) for persistence.
+All dependencies, including the Tigris [`ocache`](https://github.com/tigrisdata/ocache) modules, are public and fetched normally by the Go toolchain — no extra configuration required.
 
 ### Build
 

--- a/docs/s3-compatibility-testing.md
+++ b/docs/s3-compatibility-testing.md
@@ -30,7 +30,7 @@ The S3 compatibility tests validate that TAG correctly implements the S3 API by 
 
 ## Running Tests Locally (Recommended)
 
-The recommended approach runs TAG on your host machine with its embedded cache. This avoids needing a GitHub token for private module access.
+The recommended approach runs TAG on your host machine with its embedded cache.
 
 ```bash
 # 1. Set credentials


### PR DESCRIPTION
`github.com/tigrisdata/ocache` — TAG's **only** `tigrisdata` dependency (confirmed via `go list -m all`: everything else is public third-party) — is now a public repo. This removes the private-module workarounds that are no longer needed.

## Changes

- **CI (6 workflows: benchmark, docker, release, s3-tests, s3-tests-cluster, test)** — remove the `GOPRIVATE: github.com/tigrisdata` env var and the `Configure git for private modules` token-rewrite step. Modules now resolve through the default Go proxy. `GH_BOT_ACCESS_TOKEN` is retained where it's still used for other purposes (`gh release download` in docker/t3-upload, and checkout/publish in release).
- **README** — replace the `GOPRIVATE` + SSH-rewrite "Prerequisites" block in Contributing with a one-line note that all deps (including `ocache`) are public and need no configuration. External contributors can now `make build` with a stock toolchain.
- **CLAUDE.md** — same update to the Developer Setup section.
- **docs/s3-compatibility-testing.md** — drop the stale "avoids needing a GitHub token for private module access" note.

## Verification

- ✅ All six workflow YAMLs parse (yq); the empty `env:` block left in `docker.yaml` was removed.
- ✅ `GH_BOT_ACCESS_TOKEN` still present only where legitimately used (release/gh-download steps).
- ✅ Repo-wide sweep: the sole remaining `GOPRIVATE` mention is the CLAUDE.md line stating it is *not* required.

## Note

With `GOPRIVATE` gone, CI fetches `ocache` via `proxy.golang.org` instead of direct git. Versions are pinned in `go.sum`; the proxy fetches public modules on demand, so the first post-merge CI run may prime the proxy cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation-only changes; no application or security logic. Risk is limited to CI module fetch behavior (public proxy vs direct git).
> 
> **Overview**
> Removes **private Go module** workarounds now that `github.com/tigrisdata/ocache` is public.
> 
> **CI:** Six workflows (`benchmark`, `docker`, `release`, `s3-tests`, `s3-tests-cluster`, `test`) no longer set `GOPRIVATE` or run the **Configure git for private modules** step that rewrote `https://github.com/` with `GH_BOT_ACCESS_TOKEN`. `go mod download` relies on the default module proxy instead. `GH_BOT_ACCESS_TOKEN` stays where still needed (e.g. `gh release download` in docker, semantic-release in release).
> 
> **Docs:** `README` Contributing, `CLAUDE.md` Developer Setup, and `docs/s3-compatibility-testing.md` now state that all deps (including `ocache`) are public and need no `GOPRIVATE` or SSH/Git URL rewriting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad38ce8d2a5e1fd124bb35e4184d11513df2c59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->