### PR TITLE
feat: allow any S3-compatible endpoint in signing mode

### DIFF
--- a/.claude/rules/transparent-proxy.md
+++ b/.claude/rules/transparent-proxy.md
@@ -14,7 +14,7 @@
 - Transparent mode is default (`TAG_TRANSPARENT_PROXY` / `upstream.transparent_proxy`)
 - `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials with read-only access for all buckets (background cache fetches). Missing in transparent mode = fatal startup error.
 - Local auth enabled implicitly when transparent proxy is active
-- Endpoint validation: only `localhost`, `*.tigris.dev`, `*.storage.dev` allowed. Startup fatal on mismatch.
+- Endpoint validation: enforced only in transparent proxy mode (proxy HMAC headers are Tigris-specific) — only `localhost`, `*.tigris.dev`, `*.storage.dev` allowed, startup fatal on mismatch. Signing mode re-signs with standard SigV4 and permits any S3-compatible endpoint (`config.IsTigrisEndpoint` gates this; non-Tigris signing endpoints log a startup warning).
 
 ## Proxy Headers
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,7 +9,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   warp-benchmarks:
@@ -22,10 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,9 +11,6 @@ on:
         description: "Release version tag (e.g., v1.0.0)"
         required: true
 
-env:
-  GOPRIVATE: github.com/tigrisdata
-
 jobs:
   build-and-push:
     runs-on: namespace-profile-ubuntu-2404
@@ -26,10 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   test:
@@ -45,10 +44,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/s3-tests-cluster.yaml
+++ b/.github/workflows/s3-tests-cluster.yaml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   s3-compat-tests:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/s3-tests.yaml
+++ b/.github/workflows/s3-tests.yaml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   s3-compat-tests:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   GO_VERSION: "1.24.2"
-  GOPRIVATE: github.com/tigrisdata
 
 jobs:
   test:
@@ -32,10 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure git for private modules
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,7 @@ TESTRUN="TestBroadcast" make test-proxy
 
 ## Developer Setup
 
-This project depends on private Go modules under `github.com/tigrisdata`. Configure Go to bypass the public module proxy (one-time setup per machine):
-
-```bash
-go env -w GOPRIVATE=github.com/tigrisdata
-```
-
-This covers all private repos under the `tigrisdata` org (e.g., `ocache`). Without this, `go mod tidy` and `go get` will fail with 404 errors from the Go module proxy. If you see such errors, check that `GOPRIVATE` is set: `go env GOPRIVATE`.
+All dependencies are public, including the Tigris `ocache` modules (`github.com/tigrisdata/ocache/*`). No `GOPRIVATE` or Git URL rewriting is required — `make build`, `go mod tidy`, and `go get` work with a stock Go toolchain.
 
 ## Core Architecture
 

--- a/README.md
+++ b/README.md
@@ -171,17 +171,7 @@ See [docs/security.md](docs/security.md) for authentication, access control, and
 - Go 1.24 or later
 - Tigris account with access credentials (for running TAG and integration tests)
 
-TAG depends on Tigris Go modules. Configure Go and Git to access them:
-
-```bash
-# Tell Go to fetch tigrisdata repos directly (not via proxy)
-export GOPRIVATE=github.com/tigrisdata
-
-# Configure Git to use SSH for tigrisdata repos
-git config --global url."git@github.com:tigrisdata/".insteadOf "https://github.com/tigrisdata/"
-```
-
-Add the `GOPRIVATE` export to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`) for persistence.
+All dependencies, including the Tigris [`ocache`](https://github.com/tigrisdata/ocache) modules, are public and fetched normally by the Go toolchain — no extra configuration required.
 
 ### Build
 

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -193,6 +193,12 @@ func main() {
 		}
 		proxySigner = auth.NewProxySigner(accessKey, secretKey)
 		log.Info().Msg("Transparent proxy mode enabled")
+	} else {
+		log.Info().Str("endpoint", cfg.Upstream.Endpoint).Msg("Signing mode enabled")
+		if !config.IsTigrisEndpoint(cfg.Upstream.Endpoint) {
+			log.Warn().Str("endpoint", cfg.Upstream.Endpoint).
+				Msg("Running against a non-Tigris S3 endpoint; transparent-proxy features are unavailable and third-party backends are community-supported")
+		}
 	}
 
 	if credStore.Count() == 0 && !cfg.Upstream.IsTransparentProxy() {

--- a/config/config.go
+++ b/config/config.go
@@ -442,14 +442,8 @@ func applyEnvOverrides(cfg *Config) {
 
 // validate checks that the final configuration is valid.
 func validate(cfg *Config) error {
-	// The upstream-endpoint allowlist is enforced only in transparent proxy
-	// mode, where the X-Tigris-Proxy-* identity headers are meaningful only to
-	// Tigris. Signing mode re-signs with standard SigV4 and works against any
-	// S3-compatible service, so any endpoint is permitted there.
-	if cfg.Upstream.IsTransparentProxy() {
-		if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint); err != nil {
-			return err
-		}
+	if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint, cfg.Upstream.IsTransparentProxy()); err != nil {
+		return err
 	}
 	if err := validateTLS(&cfg.Server); err != nil {
 		return err
@@ -488,16 +482,27 @@ func IsTigrisEndpoint(endpoint string) bool {
 	return strings.HasSuffix(host, ".tigris.dev") || strings.HasSuffix(host, ".storage.dev")
 }
 
-// validateUpstreamEndpoint ensures the upstream endpoint is an allowed Tigris
-// domain or localhost. Enforced only in transparent proxy mode (see validate).
-func validateUpstreamEndpoint(endpoint string) error {
-	if _, err := url.Parse(endpoint); err != nil {
+// validateUpstreamEndpoint ensures the upstream endpoint is a well-formed
+// absolute http(s) URL with a host (checked in every mode, since the signing
+// path builds upstream requests from it). In transparent proxy mode it must
+// additionally be a Tigris domain or localhost, because the X-Tigris-Proxy-*
+// identity headers are meaningful only to Tigris; signing mode permits any
+// S3-compatible host.
+func validateUpstreamEndpoint(endpoint string, transparent bool) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
 		return fmt.Errorf("invalid upstream endpoint %q: %w", endpoint, err)
 	}
-	if IsTigrisEndpoint(endpoint) {
-		return nil
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("upstream endpoint %q must be an absolute http:// or https:// URL", endpoint)
 	}
-	return fmt.Errorf("upstream endpoint %q is not allowed in transparent proxy mode: host must be localhost, *.tigris.dev, or *.storage.dev (use signing mode for other S3-compatible services)", endpoint)
+	if u.Hostname() == "" {
+		return fmt.Errorf("upstream endpoint %q must include a host", endpoint)
+	}
+	if transparent && !IsTigrisEndpoint(endpoint) {
+		return fmt.Errorf("upstream endpoint %q is not allowed in transparent proxy mode: host must be localhost, *.tigris.dev, or *.storage.dev (use signing mode for other S3-compatible services)", endpoint)
+	}
+	return nil
 }
 
 // splitEndpoints splits a comma-separated string into a slice of endpoints.

--- a/config/config.go
+++ b/config/config.go
@@ -442,8 +442,14 @@ func applyEnvOverrides(cfg *Config) {
 
 // validate checks that the final configuration is valid.
 func validate(cfg *Config) error {
-	if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint); err != nil {
-		return err
+	// The upstream-endpoint allowlist is enforced only in transparent proxy
+	// mode, where the X-Tigris-Proxy-* identity headers are meaningful only to
+	// Tigris. Signing mode re-signs with standard SigV4 and works against any
+	// S3-compatible service, so any endpoint is permitted there.
+	if cfg.Upstream.IsTransparentProxy() {
+		if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint); err != nil {
+			return err
+		}
 	}
 	if err := validateTLS(&cfg.Server); err != nil {
 		return err
@@ -465,22 +471,33 @@ func validateTLS(server *ServerConfig) error {
 	return nil
 }
 
-// validateUpstreamEndpoint ensures the upstream endpoint is an allowed Tigris domain or localhost.
-func validateUpstreamEndpoint(endpoint string) error {
+// IsTigrisEndpoint reports whether the endpoint host is localhost or a Tigris
+// domain (*.tigris.dev, *.storage.dev). Transparent proxy mode requires a Tigris
+// endpoint; signing mode works with any S3-compatible endpoint. Returns false if
+// the endpoint cannot be parsed.
+func IsTigrisEndpoint(endpoint string) bool {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("invalid upstream endpoint %q: %w", endpoint, err)
+		return false
 	}
 
 	host := u.Hostname() // strips port if present
 	if host == "localhost" {
-		return nil
+		return true
 	}
-	if strings.HasSuffix(host, ".tigris.dev") || strings.HasSuffix(host, ".storage.dev") {
-		return nil
-	}
+	return strings.HasSuffix(host, ".tigris.dev") || strings.HasSuffix(host, ".storage.dev")
+}
 
-	return fmt.Errorf("upstream endpoint %q is not allowed: host must be localhost, *.tigris.dev, or *.storage.dev", endpoint)
+// validateUpstreamEndpoint ensures the upstream endpoint is an allowed Tigris
+// domain or localhost. Enforced only in transparent proxy mode (see validate).
+func validateUpstreamEndpoint(endpoint string) error {
+	if _, err := url.Parse(endpoint); err != nil {
+		return fmt.Errorf("invalid upstream endpoint %q: %w", endpoint, err)
+	}
+	if IsTigrisEndpoint(endpoint) {
+		return nil
+	}
+	return fmt.Errorf("upstream endpoint %q is not allowed in transparent proxy mode: host must be localhost, *.tigris.dev, or *.storage.dev (use signing mode for other S3-compatible services)", endpoint)
 }
 
 // splitEndpoints splits a comma-separated string into a slice of endpoints.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -542,6 +542,74 @@ upstream:
 	}
 }
 
+func TestIsTigrisEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     bool
+	}{
+		{"tigris.dev domain", "https://fly.storage.tigris.dev", true},
+		{"storage.dev domain", "https://t3.storage.dev", true},
+		{"localhost", "http://localhost:8080", true},
+		{"localhost no port", "http://localhost", true},
+		{"third-party s3", "https://s3.amazonaws.com", false},
+		{"minio", "http://minio.internal:9000", false},
+		{"not a suffix match", "https://nottrigris.dev", false},
+		{"lookalike host", "https://evil.tigris.dev.attacker.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTigrisEndpoint(tt.endpoint); got != tt.want {
+				t.Errorf("IsTigrisEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+// Signing mode re-signs with standard SigV4 and works against any S3-compatible
+// service, so the Tigris endpoint allowlist must not be enforced there.
+func TestLoad_SigningModeAllowsNonTigrisEndpoint(t *testing.T) {
+	content := `
+upstream:
+  transparent_proxy: false
+  endpoint: "https://s3.amazonaws.com"
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() should allow a non-Tigris endpoint in signing mode, got error: %v", err)
+	}
+	if cfg.Upstream.IsTransparentProxy() {
+		t.Error("expected signing mode (transparent proxy disabled)")
+	}
+	if cfg.Upstream.Endpoint != "https://s3.amazonaws.com" {
+		t.Errorf("Upstream.Endpoint = %q, want https://s3.amazonaws.com", cfg.Upstream.Endpoint)
+	}
+}
+
+// Transparent proxy mode still requires a Tigris endpoint, since the
+// X-Tigris-Proxy-* identity headers are only meaningful to Tigris.
+func TestLoad_TransparentModeRejectsNonTigrisEndpoint(t *testing.T) {
+	content := `
+upstream:
+  transparent_proxy: true
+  endpoint: "https://s3.amazonaws.com"
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	if _, err := Load(tmpFile); err == nil {
+		t.Error("Load() should reject a non-Tigris endpoint in transparent proxy mode")
+	}
+}
+
 func TestCacheDefaultValues(t *testing.T) {
 	cfg := NewDefault()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -503,24 +503,36 @@ func TestTransparentProxy_DisabledByEnv_NumericZero(t *testing.T) {
 
 func TestValidateUpstreamEndpoint(t *testing.T) {
 	tests := []struct {
-		name     string
-		endpoint string
-		wantErr  bool
+		name        string
+		endpoint    string
+		transparent bool
+		wantErr     bool
 	}{
-		{"tigris.dev domain", "https://fly.storage.tigris.dev", false},
-		{"storage.dev domain", "https://t3.storage.dev", false},
-		{"localhost", "http://localhost:8080", false},
-		{"localhost no port", "http://localhost", false},
-		{"disallowed domain", "https://evil.example.com", true},
-		{"subdomain of tigris.dev", "https://sub.tigris.dev", false},
-		{"not a suffix match", "https://nottrigris.dev", true},
+		// Transparent mode: Tigris allowlist enforced.
+		{"tigris.dev domain", "https://fly.storage.tigris.dev", true, false},
+		{"storage.dev domain", "https://t3.storage.dev", true, false},
+		{"localhost", "http://localhost:8080", true, false},
+		{"localhost no port", "http://localhost", true, false},
+		{"disallowed domain", "https://evil.example.com", true, true},
+		{"subdomain of tigris.dev", "https://sub.tigris.dev", true, false},
+		{"not a suffix match", "https://nottrigris.dev", true, true},
+		// Signing mode: any well-formed http(s) URL is allowed.
+		{"third-party s3 signing", "https://s3.amazonaws.com", false, false},
+		{"minio signing", "http://minio.internal:9000", false, false},
+		{"tigris signing", "https://t3.storage.dev", false, false},
+		// Well-formedness is enforced in both modes.
+		{"hostless signing", "s3.amazonaws.com", false, true},
+		{"hostless transparent", "s3.amazonaws.com", true, true},
+		{"host:port without scheme", "host:9000", false, true},
+		{"empty endpoint", "", false, true},
+		{"non-http scheme", "ftp://example.com", false, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateUpstreamEndpoint(tt.endpoint)
+			err := validateUpstreamEndpoint(tt.endpoint, tt.transparent)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("validateUpstreamEndpoint(%q) error = %v, wantErr %v", tt.endpoint, err, tt.wantErr)
+				t.Errorf("validateUpstreamEndpoint(%q, transparent=%v) error = %v, wantErr %v", tt.endpoint, tt.transparent, err, tt.wantErr)
 			}
 		})
 	}
@@ -607,6 +619,24 @@ upstream:
 
 	if _, err := Load(tmpFile); err == nil {
 		t.Error("Load() should reject a non-Tigris endpoint in transparent proxy mode")
+	}
+}
+
+// Even in signing mode a hostless/malformed endpoint must fail at startup rather
+// than passing and breaking every proxied request when the upstream URL is built.
+func TestLoad_SigningModeRejectsHostlessEndpoint(t *testing.T) {
+	content := `
+upstream:
+  transparent_proxy: false
+  endpoint: "s3.amazonaws.com"
+`
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	if _, err := Load(tmpFile); err == nil {
+		t.Error("Load() should reject a hostless endpoint (no scheme/host) even in signing mode")
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,7 +219,7 @@ This restriction exists because transparent mode adds `X-Tigris-Proxy-*` identit
 
 When `transparent_proxy` is `true` (default), TAG forwards client requests to Tigris as-is, preserving the original Authorization header and adding proxy headers so Tigris validates the signature against the original host. No local credential store is needed. This mode works only with Tigris.
 
-When `transparent_proxy` is `false`, TAG validates incoming request signatures against its local credential store and re-signs requests for the upstream endpoint (signing mode). This is useful when TAG needs to perform credential translation.
+When `transparent_proxy` is `false` (signing mode), TAG validates incoming request signatures against its local credential store, then re-signs each request for the upstream endpoint with the same credentials. The store is populated from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, so clients must authenticate with those credentials and TAG re-signs upstream with them. See [Credential Handling by Mode](security.md#credential-handling-by-mode) in the security docs.
 
 **Using TAG with other S3-compatible services:**
 
@@ -241,7 +241,7 @@ Notes:
 - Set `region` to match the backend. The default `auto` is Tigris-specific; region-sensitive services such as AWS S3 return signature errors unless the region matches the endpoint (e.g., `us-east-1` for `s3.us-east-1.amazonaws.com`).
 - Transparent proxy mode and its zero-config, no-double-auth experience are Tigris-only. Third-party backends are supported on a best-effort, community-supported basis.
 - TAG logs a warning at startup when signing mode runs against a non-Tigris endpoint.
-- Configure the upstream credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) for the backend TAG signs requests to.
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are the credentials for the backend TAG signs requests to; clients must present these same credentials, and they need permissions covering whatever operations clients perform (read-only is insufficient if clients write).
 - `upstream.endpoint` is trusted operator configuration and TAG only ever forwards to that single host (never a client-chosen one) — see [Endpoint Validation](security.md#endpoint-validation) in the security docs.
 
 **TLS / HTTPS:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,10 +229,16 @@ Signing mode re-signs requests with standard AWS SigV4, so it works against any 
 upstream:
   transparent_proxy: false
   endpoint: "https://s3.us-east-1.amazonaws.com"
+  # Set the backend's region; the default "auto" only works with Tigris. AWS and
+  # other region-sensitive services reject signatures whose credential scope
+  # region does not match the endpoint.
+  region: "us-east-1"
 ```
 
 Notes:
 
+- The `endpoint` must be an absolute `http://` or `https://` URL with a host; TAG refuses to start otherwise (in any mode).
+- Set `region` to match the backend. The default `auto` is Tigris-specific; region-sensitive services such as AWS S3 return signature errors unless the region matches the endpoint (e.g., `us-east-1` for `s3.us-east-1.amazonaws.com`).
 - Transparent proxy mode and its zero-config, no-double-auth experience are Tigris-only. Third-party backends are supported on a best-effort, community-supported basis.
 - TAG logs a warning at startup when signing mode runs against a non-Tigris endpoint.
 - Configure the upstream credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) for the backend TAG signs requests to.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ Notes:
 - Transparent proxy mode and its zero-config, no-double-auth experience are Tigris-only. Third-party backends are supported on a best-effort, community-supported basis.
 - TAG logs a warning at startup when signing mode runs against a non-Tigris endpoint.
 - Configure the upstream credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) for the backend TAG signs requests to.
+- `upstream.endpoint` is trusted operator configuration and TAG only ever forwards to that single host (never a client-chosen one) — see [Endpoint Validation](security.md#endpoint-validation) in the security docs.
 
 **TLS / HTTPS:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,19 +207,35 @@ Configures the connection to upstream Tigris storage.
 
 **Endpoint Validation:**
 
-The upstream endpoint must be one of the following allowed hosts:
+In **transparent proxy mode** (the default), the upstream endpoint must be one of the following allowed hosts, and TAG will refuse to start otherwise:
 
 - `localhost` (for local development)
 - `*.tigris.dev` (e.g., `fly.storage.tigris.dev`)
 - `*.storage.dev` (e.g., `t3.storage.dev`)
 
-TAG will refuse to start if the endpoint host does not match one of these patterns.
+This restriction exists because transparent mode adds `X-Tigris-Proxy-*` identity headers that are only meaningful to Tigris. In **signing mode** (`transparent_proxy: false`) the endpoint is not restricted — see below.
 
 **Transparent Proxy Mode:**
 
-When `transparent_proxy` is `true` (default), TAG forwards client requests to Tigris as-is, preserving the original Authorization header and adding proxy headers so Tigris validates the signature against the original host. No local credential store is needed.
+When `transparent_proxy` is `true` (default), TAG forwards client requests to Tigris as-is, preserving the original Authorization header and adding proxy headers so Tigris validates the signature against the original host. No local credential store is needed. This mode works only with Tigris.
 
 When `transparent_proxy` is `false`, TAG validates incoming request signatures against its local credential store and re-signs requests for the upstream endpoint (signing mode). This is useful when TAG needs to perform credential translation.
+
+**Using TAG with other S3-compatible services:**
+
+Signing mode re-signs requests with standard AWS SigV4, so it works against any S3-compatible endpoint (AWS S3, MinIO, Ceph, etc.), not just Tigris. To point TAG at a non-Tigris backend:
+
+```yaml
+upstream:
+  transparent_proxy: false
+  endpoint: "https://s3.us-east-1.amazonaws.com"
+```
+
+Notes:
+
+- Transparent proxy mode and its zero-config, no-double-auth experience are Tigris-only. Third-party backends are supported on a best-effort, community-supported basis.
+- TAG logs a warning at startup when signing mode runs against a non-Tigris endpoint.
+- Configure the upstream credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) for the backend TAG signs requests to.
 
 **TLS / HTTPS:**
 

--- a/docs/s3-compatibility-testing.md
+++ b/docs/s3-compatibility-testing.md
@@ -30,7 +30,7 @@ The S3 compatibility tests validate that TAG correctly implements the S3 API by 
 
 ## Running Tests Locally (Recommended)
 
-The recommended approach runs TAG on your host machine with its embedded cache. This avoids needing a GitHub token for private module access.
+The recommended approach runs TAG on your host machine with its embedded cache.
 
 ```bash
 # 1. Set credentials

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,9 +19,29 @@ Tigris independently validates both the client's SigV4 signature and TAG's proxy
 
 ### Signing Mode
 
-TAG validates incoming request signatures against a local credential store, then re-signs requests for the upstream endpoint using standard AWS SigV4. This mode is used when TAG needs to perform credential translation (e.g., clients use different credentials than the upstream account). Because it re-signs with standard SigV4, signing mode works against any S3-compatible service, not only Tigris (see [Endpoint Validation](#endpoint-validation)).
+In signing mode, TAG terminates the client signature and re-issues the upstream one itself:
+
+1. The client signs its request with its own SigV4 credentials.
+2. TAG looks up the secret for the client's access key in its **local credential store** and cryptographically validates the incoming signature.
+3. TAG re-signs the (possibly transformed) request for the upstream endpoint using standard AWS SigV4 with **the same access key and secret**, then streams it upstream.
+
+TAG re-signs rather than forwarding the original signature because it may transform the request — for example decoding AWS chunked transfer encoding to `UNSIGNED-PAYLOAD` — which would otherwise invalidate the client's signature. The upstream sees the **same identity** as the client; this is not identity translation.
+
+Because TAG must know the secret for every access key it serves, those credentials must be present in its local credential store. In production the store is populated only from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (a single pair), so **clients must authenticate with those same credentials**, and TAG re-signs upstream with them. If the store is empty, TAG rejects all requests.
+
+Because it re-signs with standard SigV4, signing mode works against any S3-compatible service, not only Tigris (see [Endpoint Validation](#endpoint-validation)).
 
 Set `TAG_TRANSPARENT_PROXY=false` or `upstream.transparent_proxy: false` in YAML to enable signing mode.
+
+### Credential Handling by Mode
+
+| Aspect | Transparent proxy (default) | Signing mode |
+| --- | --- | --- |
+| Upstream request signature | Client's original signature, forwarded unchanged | Re-signed by TAG with the client's own credentials |
+| Does TAG need client secret keys? | No — cache hits are validated locally using signing keys learned from Tigris | Yes — the secret for each client access key must be in TAG's local store |
+| Role of `AWS_*` credentials | TAG's own identity: signs `X-Tigris-Proxy-*` headers and background cache fetches (read-only) | The credential store's contents: clients present it and TAG re-signs every request (reads **and** writes) with it |
+| Client credentials | Any credentials in the same Tigris org; secrets never stored | Must match a credential in TAG's store (by default the `AWS_*` pair) |
+| Works with non-Tigris backends | No (Tigris only) | Yes (any S3-compatible service) |
 
 ## Local Authentication
 
@@ -169,22 +189,18 @@ Any other host causes a fatal startup error in transparent mode.
 
 ## Credential Requirements
 
-TAG requires its own Tigris credentials via environment variables:
+TAG loads credentials from environment variables at startup:
 
 ```bash
-export AWS_ACCESS_KEY_ID=<TAG's access key>
-export AWS_SECRET_ACCESS_KEY=<TAG's secret key>
+export AWS_ACCESS_KEY_ID=<access key>
+export AWS_SECRET_ACCESS_KEY=<secret key>
 ```
 
-These credentials must have **read-only access** to all buckets accessed through TAG. This is required for:
+How they are used, and what permissions they need, depends on the mode (see [Credential Handling by Mode](#credential-handling-by-mode)).
 
-- Signing proxy headers (transparent mode)
-- Background cache fetches (e.g., fetching full objects after a range request cache miss)
-- Re-signing requests for upstream (signing mode)
+**Transparent proxy mode:** these are TAG's *own* Tigris credentials, used only to sign the `X-Tigris-Proxy-*` identity headers and to perform background cache fetches (fetching full objects after a range-request cache miss). Because TAG never re-signs client requests in this mode, **read-only** access to the cached buckets is sufficient. TAG's access key must belong to the same Tigris organization as client access keys; clients use their own credentials directly and TAG does not store their secret keys.
 
-In transparent proxy mode, TAG's access key must belong to the same Tigris organization as client access keys. Clients use their own credentials directly — TAG does not need or store client secret keys.
-
-In signing mode, these are the credentials for the configured upstream — the Tigris account, or the third-party S3 account when running against another service. Set `upstream.region` to match that backend (the default `auto` is Tigris-specific); see the "Using TAG with other S3-compatible services" section in [configuration.md](configuration.md).
+**Signing mode:** this pair populates TAG's local credential store — clients must authenticate with it, and TAG re-signs *every* forwarded request with it. Its permissions must therefore cover whatever operations clients perform: **read-only is not sufficient if clients issue writes** (PUT/DELETE) — grant the access needed for those operations. Set `upstream.region` to match the backend (the default `auto` is Tigris-specific); see the "Using TAG with other S3-compatible services" section in [configuration.md](configuration.md).
 
 ## Error Mapping
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,7 +19,7 @@ Tigris independently validates both the client's SigV4 signature and TAG's proxy
 
 ### Signing Mode
 
-TAG validates incoming request signatures against a local credential store, then re-signs requests for the upstream Tigris endpoint. This mode is used when TAG needs to perform credential translation (e.g., clients use different credentials than the upstream Tigris account).
+TAG validates incoming request signatures against a local credential store, then re-signs requests for the upstream endpoint using standard AWS SigV4. This mode is used when TAG needs to perform credential translation (e.g., clients use different credentials than the upstream account). Because it re-signs with standard SigV4, signing mode works against any S3-compatible service, not only Tigris (see [Endpoint Validation](#endpoint-validation)).
 
 Set `TAG_TRANSPARENT_PROXY=false` or `upstream.transparent_proxy: false` in YAML to enable signing mode.
 
@@ -153,9 +153,9 @@ The `X-Tigris-Proxy-Signing-Keys` response header contains encrypted signing key
 
 ## Endpoint Validation
 
-TAG validates the upstream endpoint at startup to prevent misconfiguration and SSRF attacks.
+TAG validates the upstream endpoint at startup. In **every mode**, the endpoint must be a well-formed absolute `http://` or `https://` URL with a host; anything else (a hostless value like `s3.amazonaws.com`, a `host:port` string, a non-http scheme) is a fatal startup error.
 
-**Allowed hosts:**
+**Transparent proxy mode** additionally restricts the host to the Tigris allowlist below, because the `X-Tigris-Proxy-*` identity headers TAG adds are only meaningful to Tigris:
 
 | Pattern         | Example                          | Use Case                  |
 | --------------- | -------------------------------- | ------------------------- |
@@ -163,7 +163,9 @@ TAG validates the upstream endpoint at startup to prevent misconfiguration and S
 | `*.tigris.dev`  | `https://fly.storage.tigris.dev` | Tigris production domains |
 | `*.storage.dev` | `https://t3.storage.dev`         | Tigris storage domains    |
 
-Any other endpoint causes a fatal startup error. This prevents TAG from being used as an open proxy to arbitrary services.
+Any other host causes a fatal startup error in transparent mode.
+
+**Signing mode** (`transparent_proxy: false`) does not apply the Tigris allowlist — it re-signs with standard SigV4 and can front any S3-compatible service. The upstream is a single, operator-configured value; TAG forwards only to that endpoint and never lets clients choose the upstream, so this is not an open proxy. The SSRF surface is limited to operator misconfiguration of `upstream.endpoint`, so treat that value as trusted configuration and set it explicitly. TAG logs a warning at startup when signing mode targets a non-Tigris host; third-party backends are community-supported.
 
 ## Credential Requirements
 
@@ -181,6 +183,8 @@ These credentials must have **read-only access** to all buckets accessed through
 - Re-signing requests for upstream (signing mode)
 
 In transparent proxy mode, TAG's access key must belong to the same Tigris organization as client access keys. Clients use their own credentials directly — TAG does not need or store client secret keys.
+
+In signing mode, these are the credentials for the configured upstream — the Tigris account, or the third-party S3 account when running against another service. Set `upstream.region` to match that backend (the default `auto` is Tigris-specific); see the "Using TAG with other S3-compatible services" section in [configuration.md](configuration.md).
 
 ## Error Mapping
 


### PR DESCRIPTION
## Context

The upstream-endpoint allowlist (`localhost`, `*.tigris.dev`, `*.storage.dev`) was enforced **unconditionally** in `config.validate()`, so TAG refused to start against any non-Tigris backend — even in **signing mode**, which re-signs with standard AWS SigV4 and is vendor-neutral. The allowlist is only technically required in **transparent proxy mode**, where the `X-Tigris-Proxy-*` identity headers are meaningful only to Tigris.

This gates the check to transparent mode, letting people run TAG's caching proxy in front of any S3-compatible service (AWS S3, MinIO, Ceph, …) in signing mode, while keeping the premium transparent-proxy experience Tigris-only.

## Changes

- **`config`** — enforce `validateUpstreamEndpoint` only when `IsTransparentProxy()`; extract an exported `IsTigrisEndpoint(endpoint) bool` helper. Transparent mode is the default, so the strict check still applies unless signing mode is **explicitly** enabled — safe by default, never bypassed by accident.
- **`cmd/tag`** — log "Signing mode enabled" at startup, and warn when signing mode runs against a non-Tigris endpoint (transparent-proxy features unavailable; third-party backends community-supported).
- **Tests** — `IsTigrisEndpoint` cases (including a lookalike host `evil.tigris.dev.attacker.com`), signing mode allows a non-Tigris endpoint, transparent mode still rejects it.
- **Docs** — `docs/configuration.md`: clarify endpoint validation is transparent-mode-only and add a "Using TAG with other S3-compatible services" section. Updated the `transparent-proxy` rule note.

## Behavior

| Mode | Endpoint | Result |
|---|---|---|
| Transparent (default) | Tigris/localhost | ✅ starts |
| Transparent (default) | non-Tigris | ❌ fatal at startup (unchanged) |
| Signing (`transparent_proxy: false`) | Tigris | ✅ starts |
| Signing (`transparent_proxy: false`) | non-Tigris | ✅ starts + warning |

## Verification

- ✅ `go test ./config/...` (new + existing endpoint tests pass)
- ✅ `make build`; `go vet ./config/... ./cmd/...` clean

## Note

The endpoint check was the explicit gate. I reviewed the signing path for other hardcoded Tigris assumptions and didn't find startup-blocking ones (upstream creds and region come from config/env). Positioning is handled in docs: Tigris is first-class/optimized; third-party is best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upstream validation and expands signing-mode deployment to arbitrary operator-chosen hosts; default transparent mode behavior is unchanged, and forwarding remains to a single configured endpoint.
> 
> **Overview**
> **Signing mode** can now target any S3-compatible upstream (AWS, MinIO, etc.): the Tigris host allowlist applies only when **transparent proxy** is on (default unchanged). All modes still require a valid absolute `http://` or `https://` URL with a host.
> 
> `config` adds `IsTigrisEndpoint` and gates the allowlist on `IsTransparentProxy()`. Startup logs signing mode and warns on non-Tigris endpoints. Docs and security pages describe mode-specific credentials, endpoint rules, and third-party backends.
> 
> CI and contributor docs drop `GOPRIVATE` and private Git rewrite steps now that `ocache` is public.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e60455aa6063c96001f755761b0dacc780a1d293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->