### PR TITLE
fix: run go vet with CGO env so make vet/lint/check work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ test-integration-coverage: rocksdb-static
 .PHONY: lint
 lint:
 	@echo "Running go vet..."
-	go vet ./...
+	$(CGO_ENV) go vet $(BUILD_TAGS) ./...
 	@echo "Running gofmt check..."
 	@gofmt -l -d $$(find . -name '*.go')
 	@echo "Running go mod tidy..."
@@ -226,7 +226,7 @@ lint-fix:
 
 .PHONY: vet
 vet:
-	go vet ./...
+	$(CGO_ENV) go vet $(BUILD_TAGS) ./...
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ test-integration-coverage: rocksdb-static
 
 # Code quality targets
 .PHONY: lint
-lint:
+lint: rocksdb-static
 	@echo "Running go vet..."
 	$(CGO_ENV) go vet $(BUILD_TAGS) ./...
 	@echo "Running gofmt check..."
@@ -225,7 +225,7 @@ lint-fix:
 	go mod tidy
 
 .PHONY: vet
-vet:
+vet: rocksdb-static
 	$(CGO_ENV) go vet $(BUILD_TAGS) ./...
 
 .PHONY: fmt

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -32,7 +32,7 @@ type Cache struct {
 // This allows tests to use an in-memory cache implementation like cacheclient.NewMemoryCache().
 func NewCacheWithClient(client cacheclient.CacheClient, cfg *config.CacheConfig) *Cache {
 	ttl := int64(config.DefaultCacheTTL.Seconds())
-	enabled := true    // Default to enabled
+	enabled := true // Default to enabled
 	if cfg != nil {
 		if cfg.TTL > 0 {
 			ttl = int64(cfg.TTL.Seconds())

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	// X-Cache header constants for indicating cache status.
-	XCacheHeader   = "X-Cache"
-	XCacheHit      = "HIT"
-	XCacheMiss     = "MISS"
+	XCacheHeader      = "X-Cache"
+	XCacheHit         = "HIT"
+	XCacheMiss        = "MISS"
 	XCacheBypass      = "BYPASS"      // Cache-Control: no-store bypassed cache
 	XCacheDisabled    = "DISABLED"    // Cache is disabled
 	XCacheRevalidated = "REVALIDATED" // Object revalidated with upstream
@@ -27,12 +27,12 @@ const (
 
 // Service provides the core caching proxy logic.
 type Service struct {
-	forwarder              RequestForwarder
-	cache                  *cache.Cache
-	config                 *config.Config
-	cacheSemaphore         chan struct{}      // Bounds concurrent cache-populate operations (nil = unlimited)
-	broadcastManager       *broadcast.Manager // For streaming request coalescing
-	activeBackgroundFetches sync.Map          // Dedup for background full-object fetches (range caching)
+	forwarder               RequestForwarder
+	cache                   *cache.Cache
+	config                  *config.Config
+	cacheSemaphore          chan struct{}      // Bounds concurrent cache-populate operations (nil = unlimited)
+	broadcastManager        *broadcast.Manager // For streaming request coalescing
+	activeBackgroundFetches sync.Map           // Dedup for background full-object fetches (range caching)
 }
 
 // NewService creates a new proxy service.


### PR DESCRIPTION
## Problem

The `vet` and `lint` Makefile targets ran `go vet ./...` **without** the CGO flags that the RocksDB cgo dependency (`grocksdb`) requires. So `make vet`, `make lint`, and `make check` all failed locally with:

```
fatal error: 'rocksdb/c.h' file not found
```

This has been a recurring papercut — `make check`/`make lint` were effectively unusable for contributors, and it's why CONTRIBUTING had to point at `make lint-ci` + `make test` instead.

## Fix

- **Makefile** — prefix both `go vet` calls (in the `vet` and `lint` targets) with `$(CGO_ENV)` and `$(BUILD_TAGS)`, matching what `build` and `test` already use.
- **Formatting** — `gofmt` `cache/cache.go` and `proxy/service.go` (pre-existing drift on `main`). `make lint`/`make lint-ci` run `gofmt -l -d`, which exits non-zero on diffs, so these two files were also blocking those targets. Pure formatting (comment spacing, const-block alignment) — no logic changes.

## Verification

- ✅ `make vet` — passes (CGO command now runs)
- ✅ `make lint` — passes
- ✅ `make lint-ci` — passes (what CI runs)
- ✅ `make check` — passes → "All checks passed!"

## Note

CI (`make lint-ci`) runs `gofmt -l -d`, but its only hard-enforced gate is the `go mod tidy` diff — the gofmt drift slipped through because those two files happened not to be re-checked. With this PR the tree is gofmt-clean again. A follow-up could make `lint-ci` fail on gofmt drift (e.g. `test -z "$(gofmt -l ...)"`) if you want that enforced, but that's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile and gofmt-only edits; no runtime, auth, or cache logic changes.
> 
> **Overview**
> **`make vet` and `make lint` now vet the tree the same way as `build` and `test`** — both targets depend on `rocksdb-static` and invoke `$(CGO_ENV) go vet $(BUILD_TAGS) ./...`, so local `go vet` no longer fails on missing `rocksdb/c.h` when CGO packages are analyzed.
> 
> **Formatting only** in `cache/cache.go` and `proxy/service.go` (comment spacing and struct/const alignment) so `gofmt -l -d` in `lint` / `lint-ci` stops failing on drift; no behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a03d0de7d5d69b55704966690a5febeb6b3249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->