### PR TITLE
chore: bump pinned versions to v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.11.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.9.4
+    newTag: v1.11.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.9.4
+          image: tigrisdata/tag:v1.11.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.9.3
+    newTag: v1.11.0
 ```
 
 ## Production Considerations

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.9.4
+    image: tigrisdata/tag:v1.11.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Updates hardcoded release versions after cutting **v1.11.0**.

## Changes
| File | From → To | Why |
|---|---|---|
| `deploy/kubernetes/base/kustomization.yaml` | `newTag: v1.9.4 → v1.11.0` | `kubectl apply -k` now deploys the current release |
| `deploy/kubernetes/base/statefulset.yaml` | `image: …:v1.9.4 → v1.11.0` | pod image matches |
| `README.md` | install example `v1.10.0 → v1.11.0` | |
| `docs/tls.md` | Docker image example `v1.9.4 → v1.11.0` | |
| `docs/deploy.md` | overlay example `newTag: v1.9.3 → v1.11.0` | |

The k8s manifests were two releases behind (would have deployed **v1.9.4**). Released-image Compose files are untouched — they already track `${TAG_VERSION:-latest}`.

## Verification
- ✅ `kubectl kustomize deploy/kubernetes/base` renders `image: tigrisdata/tag:v1.11.0`
- ✅ No `v1.9.x` / `v1.10.x` pins remain in `deploy/kubernetes`, README, or the two docs

## Note
Keeping the manual per-release bump for now (per discussion). A future option is to have the release workflow `sed` the k8s image tag automatically, like it already does for the native scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and deployment pin updates only; no application or runtime logic changes.
> 
> **Overview**
> Aligns documentation and Kubernetes defaults with the **v1.11.0** release so copy-paste installs and `kubectl apply -k deploy/kubernetes/base` no longer pull older images.
> 
> **Kubernetes** — `deploy/kubernetes/base/kustomization.yaml` `newTag` and `statefulset.yaml` container image move from **v1.9.4** to **v1.11.0** (manifests were two releases behind).
> 
> **Docs / README** — Install curl example (**v1.10.0** → **v1.11.0**), TLS Docker sample image (**v1.9.4** → **v1.11.0**), and deploy overlay example `newTag` (**v1.9.3** → **v1.11.0**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dea65faa462e7e5e2d49d6c4e1399eae42c9714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->