### PR TITLE
docs: add Performance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ When multiple concurrent requests arrive for the same uncached object:
 
 See [docs/architecture.md](docs/architecture.md) for detailed architecture documentation.
 
+## Performance
+
+A single TAG node saturates a 100 Gbps NIC at **~85+ Gbps** for objects 1 MiB and larger, serves **~75K ops/sec** for small objects at sub-millisecond p50, and holds low single-digit-millisecond TTFB — all while using around **12% of available CPU**.
+
+| Object size | OPS (64 threads) | Throughput | TTFB p50 |
+| ----------- | ---------------- | ---------- | -------- |
+| 1 KiB       | ~75,700          | 74 MiB/s   | < 1 ms   |
+| 100 KiB     | ~33,300          | 3.2 GiB/s  | 1 ms     |
+| 1 MiB       | ~11,000          | 10.7 GiB/s | 1 ms     |
+| 4 MiB       | ~2,800           | 10.8 GiB/s | 1 ms     |
+
+Measured with [warp](https://github.com/minio/warp) against a single `i3en.24xlarge` node over a 100 Gbps link. See [docs/benchmarks.md](docs/benchmarks.md) for the full methodology, go-ycsb results, and limitations.
+
 ## Metrics
 
 TAG exposes Prometheus metrics at `/metrics` including request counts, latencies, cache hit/miss rates, and broadcast statistics.


### PR DESCRIPTION
Surfaces benchmark highlights in the README (where people evaluating TAG actually look) instead of moving `docs/benchmarks.md` to the repo root — keeps the "all docs under `docs/`" structure intact while making the performance story prominent.

## Change
Adds a **Performance** section after Architecture with:
- A one-line headline (saturates 100 Gbps NIC at ~85+ Gbps for 1 MiB+, ~75K ops/sec for small objects, low-single-digit-ms TTFB, ~12% CPU).
- A compact 64-thread table (OPS / throughput / TTFB across 1 KiB–4 MiB).
- A link to [docs/benchmarks.md](docs/benchmarks.md) for full methodology, go-ycsb results, and limitations.

All figures are taken directly from `docs/benchmarks.md` (the 64-thread warp rows + the existing summary), so nothing new is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, configuration, or deployment impact.
> 
> **Overview**
> Adds a **Performance** section to the README (after Architecture) so evaluators see throughput and latency numbers without digging into `docs/` first.
> 
> The section includes a headline summary (100 Gbps saturation, ~75K ops/sec for small objects, TTFB, ~12% CPU), a 64-thread warp table for 1 KiB–4 MiB (OPS, throughput, TTFB p50), and a pointer to `docs/benchmarks.md` for methodology and limitations. Figures are aligned with the existing benchmarks doc; no runtime or config behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf169ccc9d52fc705884952309e6d26113fabe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->