### PR TITLE
fix: correct product name to Tigris Acceleration Gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway)
+# TAG (Tigris Acceleration Gateway)
 
 High-performance S3-compatible caching proxy for Tigris object storage with embedded distributed cache.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TAG
 
-Thanks for your interest in contributing to TAG (Tigris Access Gateway)! This
+Thanks for your interest in contributing to TAG (Tigris Acceleration Gateway)! This
 document covers how to get set up, our conventions, and the contribution
 process.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway) Makefile
+# TAG (Tigris Acceleration Gateway) Makefile
 
 # Variables
 BINARY_NAME := tag
@@ -262,7 +262,7 @@ clean-all: clean rocksdb-static-clean
 # Help target
 .PHONY: help
 help:
-	@echo "TAG (Tigris Access Gateway) Makefile targets:"
+	@echo "TAG (Tigris Acceleration Gateway) Makefile targets:"
 	@echo ""
 	@echo "Build targets:"
 	@echo "  all             - Build the binary (default)"

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-TAG (Tigris Access Gateway)
+TAG (Tigris Acceleration Gateway)
 Copyright 2026 Tigris Data, Inc.
 
 This product includes software developed at Tigris Data, Inc.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway)
+# TAG (Tigris Acceleration Gateway)
 
 TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigris.dev) object storage. It provides transparent caching with request coalescing to reduce upstream load and improve latency for frequently accessed objects.
 

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for TAG (Tigris Access Gateway).
+// Package main is the entry point for TAG (Tigris Acceleration Gateway).
 package main
 
 import (
@@ -49,7 +49,7 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: tag [options]\n\n")
-		fmt.Fprintf(os.Stderr, "TAG (Tigris Access Gateway) - S3-compatible caching proxy for Tigris\n\n")
+		fmt.Fprintf(os.Stderr, "TAG (Tigris Acceleration Gateway) - S3-compatible caching proxy for Tigris\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		fmt.Fprintf(os.Stderr, "  --version              Print version information and exit\n")
 		fmt.Fprintf(os.Stderr, "  --config PATH          Path to YAML configuration file\n")
@@ -65,7 +65,7 @@ func main() {
 
 	// Handle --version before any config loading
 	if *showVersion {
-		fmt.Printf("TAG (Tigris Access Gateway)\n")
+		fmt.Printf("TAG (Tigris Acceleration Gateway)\n")
 		fmt.Printf("  Version:    %s\n", Version)
 		fmt.Printf("  Build Time: %s\n", BuildTime)
 		fmt.Printf("  Git Commit: %s\n", GitCommit)
@@ -169,7 +169,7 @@ func main() {
 			Str("level", cfg.Log.Level).
 			Str("format", cfg.Log.Format),
 		).
-		Msg("Starting TAG (Tigris Access Gateway)")
+		Msg("Starting TAG (Tigris Acceleration Gateway)")
 
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/tag/main_test.go
+++ b/cmd/tag/main_test.go
@@ -31,7 +31,7 @@ func TestVersionFlag(t *testing.T) {
 
 	output := string(out)
 	for _, expected := range []string{
-		"TAG (Tigris Access Gateway)",
+		"TAG (Tigris Acceleration Gateway)",
 		"Version:",
 		"Build Time:",
 		"Git Commit:",

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -1,4 +1,4 @@
-# Docker Compose for TAG (Tigris Access Gateway) — released image
+# Docker Compose for TAG (Tigris Acceleration Gateway) — released image
 #
 # Pulls the published tigrisdata/tag image instead of building from source.
 # For the build-from-source variant, use docker-compose.yml.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Docker Compose for TAG (Tigris Access Gateway)
+# Docker Compose for TAG (Tigris Acceleration Gateway)
 #
 # TAG uses embedded OCache - no separate cache server needed.
 #

--- a/docs/CLA.md
+++ b/docs/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement
 
-Thank you for your interest in contributing to TAG (Tigris Access Gateway),
+Thank you for your interest in contributing to TAG (Tigris Acceleration Gateway),
 a project of Tigris Data, Inc. ("Tigris"). This Contributor License Agreement
 ("Agreement") documents the rights granted by contributors to Tigris. This is a
 legally binding document, so please read it carefully before agreeing to it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # TAG Architecture
 
-This document describes the architecture of TAG (Tigris Access Gateway), a high-performance S3-compatible caching proxy with an embedded distributed cache.
+This document describes the architecture of TAG (Tigris Acceleration Gateway), a high-performance S3-compatible caching proxy with an embedded distributed cache.
 
 ## System Overview
 


### PR DESCRIPTION
The canonical product name is **Tigris Acceleration Gateway** (as used on tigrisdata.com/docs). The repo said "Tigris **Access** Gateway" in several places — this corrects all of them. The `TAG` acronym is unchanged.

## Changed (11 files)
- Docs/meta: `README.md`, `NOTICE`, `CONTRIBUTING.md`, `docs/CLA.md`, `docs/architecture.md`, `CLAUDE.md`
- Build: `Makefile` (header + help target), `docker/docker-compose.yml`, `deploy/docker/docker-compose.release.yml` (comments)
- Code: `cmd/tag/main.go` — package comment, `--version`, `--help`, and startup-log strings; `cmd/tag/main_test.go` — the version-flag assertion (updates in lockstep)

## Verification
- `git grep "Access Gateway"` → none remaining.
- `make build` → `./tag --version` prints `TAG (Tigris Acceleration Gateway)`.
- `go test ./cmd/...` passes (the version-flag test asserts the new string). Note the test runs the pre-built binary, so it requires `make build` first — CI's `test` target depends on `build`, so it's covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only rename with no runtime, config, or API behavior changes.
> 
> **Overview**
> Replaces **Tigris Access Gateway** with the canonical **Tigris Acceleration Gateway** everywhere the full product name appears; the **TAG** acronym is unchanged.
> 
> User-facing strings in `cmd/tag` (`--version`, `--help`, startup log) and `TestVersionFlag` are updated together. Docs and legal/meta text (`README`, `NOTICE`, `CONTRIBUTING`, `CLA`, `architecture`), plus Makefile and Docker Compose comments, get the same wording fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f59dc7ac542e789ba978f94324ce28d5a5b4cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->