### PR TITLE
fix: reject meta/body length mismatch when serving small objects from cache

### DIFF
--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -239,7 +239,13 @@ func (s *Service) serveFromCache(
 		bodyBuf.Reset()
 
 		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
-		if bodyErr == nil && bodyBuf.Len() > 0 {
+		// Serve only if the body length matches the metadata's Content-Length.
+		// Meta and body are separate cache entries with no atomicity between
+		// them, so a concurrent overwrite/delete of a hot key can pair one
+		// version's metadata with another version's body. Serving that pair
+		// emits a wrong Content-Length (truncated or over-read response), so
+		// treat any mismatch as a cache miss and fall through to upstream.
+		if bodyErr == nil && int64(bodyBuf.Len()) == meta.ContentLength {
 			metrics.RecordCacheHit()
 			meta.WriteHeaders(w)
 			w.Header().Set(XCacheHeader, XCacheHit)
@@ -250,12 +256,18 @@ func (s *Service) serveFromCache(
 			putBuffer(bodyBuf)
 			return nil
 		}
+		bodyLen := bodyBuf.Len()
 		putBuffer(bodyBuf)
-		// Body unavailable — return error (caller may fall through to upstream)
+		// Body unavailable or inconsistent — return error (caller may fall
+		// through to upstream)
 		if bodyErr != nil {
 			return fmt.Errorf("cache body read failed: %w", bodyErr)
 		}
-		return fmt.Errorf("cache body empty for %s/%s", bucket, key)
+		if bodyLen == 0 {
+			return fmt.Errorf("cache body empty for %s/%s", bucket, key)
+		}
+		return fmt.Errorf("cache body length mismatch for %s/%s: meta says %d, body is %d",
+			bucket, key, meta.ContentLength, bodyLen)
 	}
 
 	// Large objects: stream via pipe

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -350,7 +350,18 @@ func (s *Service) handleRevalidation206Range(
 	return copyErr
 }
 
-// serveStaleFromCache serves stale content from cache, handling both full and range requests.
+// serveStaleFromCache serves stale content from cache when upstream is
+// unreachable (or returned an unexpected status), handling both full and range
+// requests.
+//
+// Fail-closed by design: if the cached pair is unavailable or inconsistent
+// (e.g. a torn meta/body from a concurrent rewrite, detected by the length
+// guard in serveFromCache), this returns an error and commits no response, so
+// the handler surfaces a 5xx rather than emitting a wrong-length or
+// version-skewed body during an outage. We deliberately prefer failing over
+// serving corruption; the availability cost is limited to the rare
+// torn-pair-during-outage window, which the ETag-versioned-body root fix
+// (issue #92 follow-up) removes entirely.
 func (s *Service) serveStaleFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -360,10 +371,17 @@ func (s *Service) serveStaleFromCache(
 	rangeHeader string,
 	start time.Time,
 ) error {
+	var err error
 	if rangeHeader != "" {
-		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		err = s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+	} else {
+		err = s.serveFromCache(ctx, w, bucket, key, meta, start)
 	}
-	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+	if err != nil {
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).
+			Msg("Stale cache serve failed during upstream outage; failing closed")
+	}
+	return err
 }
 
 // revalidateAndServeHead sends a conditional HEAD to upstream for a HEAD request.

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -507,6 +507,111 @@ func TestServeFromCache_SmallObject(t *testing.T) {
 	}
 }
 
+func TestServeFromCache_LengthMismatch_ReturnsError(t *testing.T) {
+	// A concurrent overwrite of a hot key can pair one version's metadata with
+	// another version's body (meta and body are separate cache entries).
+	// serveFromCache must detect the mismatch and return an error instead of
+	// serving a truncated/over-read response with the wrong Content-Length.
+	mock := &mockForwarder{}
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	// Cache a consistent meta+body pair, then overwrite the body key with a
+	// different-length payload to simulate a concurrent rewrite of the object.
+	body := []byte("original body v1")
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ContentType:   "text/plain",
+		ContentLength: int64(len(body)),
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, body, 0)
+	_ = memCache.Put(ctx, cache.MakeBodyKey(bucket, key), []byte("v2"), 60)
+
+	w := httptest.NewRecorder()
+	err := svc.serveFromCache(ctx, w, bucket, key, meta, time.Now())
+	if err == nil {
+		t.Fatal("serveFromCache() error = nil, want length-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "length mismatch") {
+		t.Errorf("error = %q, want it to mention length mismatch", err.Error())
+	}
+	// No response must be committed so the caller can fall through to upstream.
+	if w.Body.Len() != 0 {
+		t.Errorf("body length = %d, want 0 (nothing written on mismatch)", w.Body.Len())
+	}
+	if got := w.Header().Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length = %q, want unset on mismatch", got)
+	}
+}
+
+func TestRevalidation304_CacheBodyLengthMismatch_FallsThrough(t *testing.T) {
+	// Setup: mock upstream returns 304, but the cached body no longer matches
+	// the cached metadata (concurrent rewrite). Forward should be called as
+	// fallback to serve fresh content instead of a truncated body.
+	freshBody := "fresh from upstream"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+		forwardFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(freshBody))
+			return nil
+		},
+	}
+
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0)
+
+	// Overwrite only the body key with a shorter payload to simulate a
+	// concurrent rewrite racing this read.
+	_ = memCache.Put(ctx, cache.MakeBodyKey(bucket, key), []byte("short"), 60)
+
+	// Execute revalidation — should fall through to Forward
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now())
+	if err != nil {
+		t.Fatalf("revalidateAndServe() error = %v (expected fallback to upstream)", err)
+	}
+
+	// Verify: fresh response from upstream, not the mismatched cached pair
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
+		t.Errorf("X-Cache = %q, want %q (upstream fallback)", got, XCacheMiss)
+	}
+	if w.Body.String() != freshBody {
+		t.Errorf("body = %q, want %q", w.Body.String(), freshBody)
+	}
+}
+
 func TestRevalidationRange304_ServesCachedRange(t *testing.T) {
 	// Setup: mock upstream returns 304 Not Modified (object unchanged)
 	mock := &mockForwarder{

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -551,6 +551,42 @@ func TestServeFromCache_LengthMismatch_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestServeStaleFromCache_LengthMismatch_FailsClosed(t *testing.T) {
+	// When upstream is unreachable, revalidateAndServe falls back to
+	// serveStaleFromCache. A torn meta/body pair (concurrent rewrite) must fail
+	// closed — return an error and commit no response — rather than serve a
+	// wrong-length body during the outage.
+	mock := &mockForwarder{}
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	body := []byte("original body v1")
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ContentType:   "text/plain",
+		ContentLength: int64(len(body)),
+		StatusCode:    http.StatusOK,
+	}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, body, 0)
+	_ = memCache.Put(ctx, cache.MakeBodyKey(bucket, key), []byte("v2"), 60)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
+	err := svc.serveStaleFromCache(ctx, w, r, bucket, key, meta, "", time.Now())
+	if err == nil {
+		t.Fatal("serveStaleFromCache() error = nil, want fail-closed on torn pair during outage")
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body length = %d, want 0 (nothing served on mismatch)", w.Body.Len())
+	}
+}
+
 func TestRevalidation304_CacheBodyLengthMismatch_FallsThrough(t *testing.T) {
 	// Setup: mock upstream returns 304, but the cached body no longer matches
 	// the cached metadata (concurrent rewrite). Forward should be called as


### PR DESCRIPTION
Fixes the client-visible truncation / wrong-`Content-Length` / empty-body symptom in #92.

## Root cause (full analysis in the issue)

TAG stores each cached object as two independent entries — `meta|bucket|key` and `body|bucket|key` — with no atomicity or version linkage, and reads them separately (`GetMeta()` then `GetBodyStream()`). For a hot key that is rewritten constantly (Parseable's `manifest.json`, `.schema`, ingestor state), a reader can pair **version-N metadata with version-N+1 (or deleted) body**:

1. **Truncation / wrong length** — `serveFromCache` buffered the small body and emitted `Content-Length` from the (stale) metadata without comparing it to the actual buffered body → response declares 100 bytes but carries 50 (the `request or response body errors`).
2. **Empty body / `cache body unavailable: EOF`** — a reader that got meta just before invalidation deletes the body finds it gone.

## The fix

In the small-object path, `serveFromCache` now serves from cache **only when the buffered body length matches `meta.ContentLength`**. Any mismatch (or unavailable body) is treated as a cache miss; both call sites (cache-hit GET and 304 revalidation) fall through to upstream, and the miss path re-caches — so a torn meta/body pair self-heals.

- `proxy/revalidation.go` — length-match guard + clearer mismatch error.
- `proxy/revalidation_test.go` — unit test for mismatch (nothing written to the response) and an end-to-end 304-revalidation test with a concurrently overwritten body key.

## Scope / caveat

This eliminates races 1 and 2 (the reported symptom). It does **not** fully restore read-after-write: race 3 (a GET racing an in-flight PUT can refetch and re-cache the pre-PUT object) remains, and is addressed by the planned follow-up — **ETag-versioned body keys** + **post-PUT re-invalidation** (see the issue). An optional `cache.skip_patterns` operator escape hatch is also proposed there.

## Verification
- ✅ `make test` (all unit packages) passes, including the two new regression tests.
- ✅ `make test-race` clean across all packages (this is a concurrency fix).

Addresses #92 (symptom fix). The issue stays open for the root-cause follow-up (ETag-versioned body keys + post-PUT re-invalidation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GET/revalidation and stale-serving paths for cached objects; intentional fail-closed behavior during outages when meta/body are inconsistent.
> 
> **Overview**
> Fixes client-visible **wrong `Content-Length`**, truncation, and empty-body errors when cached metadata and body come from different versions of the same hot key (#92).
> 
> For **small objects**, `serveFromCache` now serves from cache only when the buffered body length equals `meta.ContentLength`. Any read error, empty body, or length mismatch is treated like a cache miss: callers can fall through to upstream (e.g. after a **304** revalidation) without committing a bad response.
> 
> **Stale fallback** during upstream failure is **fail-closed** for inconsistent pairs: `serveStaleFromCache` propagates the error and logs a warning instead of serving a skewed body, so clients may see **5xx** in the rare torn-pair-during-outage case rather than corrupt data. Large-object streaming is unchanged.
> 
> Regression tests cover mismatch detection (no response written), stale fail-closed, and **304 → upstream `Forward`** when meta and body disagree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54fd609bad78fb13e199f55c64982dc864aa88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->