### PR TITLE
fix: ETag-versioned cache body keys for read-after-write consistency

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -68,36 +68,12 @@ func (c *Cache) IsEnabled() bool {
 // IMPORTANT: Body is written BEFORE metadata to ensure metadata presence
 // guarantees body availability. This prevents race conditions where a reader
 // finds metadata but body hasn't been written yet.
-// currentBodyETag returns the ETag of the currently-cached metadata for the key
-// and whether such metadata exists. Used to locate a superseded body version for
-// eviction on overwrite.
-func (c *Cache) currentBodyETag(ctx context.Context, bucket, key string) (string, bool) {
-	m, ok, _ := c.GetMeta(ctx, bucket, key)
-	if !ok {
-		return "", false
-	}
-	return m.ETag, true
-}
-
-// evictSupersededBody deletes the body of a previously cached version once a new
-// version with a different ETag has been committed, bounding disk usage for keys
-// that are rewritten frequently. It runs after the new meta+body are live, so new
-// readers already resolve to the new version; an in-flight reader that resolved
-// the old meta reads its body via an atomic Get and therefore either completes
-// before this delete or cleanly misses and falls through to upstream.
-func (c *Cache) evictSupersededBody(ctx context.Context, bucket, key, prevETag string, hadPrev bool, newETag string) {
-	if !hadPrev {
-		return
-	}
-	prevBodyKey := MakeBodyKey(bucket, key, prevETag)
-	if prevBodyKey == MakeBodyKey(bucket, key, newETag) {
-		return // same ETag — body was overwritten in place, nothing to evict
-	}
-	if err := c.client.Delete(ctx, prevBodyKey); err != nil && !isNotFoundError(err) {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Failed to evict superseded body")
-	}
-}
-
+// Body lifecycle note: bodies are addressed by ETag and are never deleted
+// synchronously (not on overwrite, not on invalidation). Each version is an
+// immutable entry that ages out via TTL, so a reader that resolved a given
+// metadata version always finds its exact body — no delete-during-read can
+// truncate an in-flight response. Invalidation removes only the metadata (plus a
+// tombstone), which is enough to make subsequent reads miss and refetch.
 func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *CachedObjectMeta, body []byte, ttl int) error {
 	if !c.IsEnabled() {
 		return nil
@@ -106,10 +82,6 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 	if ttl == 0 {
 		ttl = int(c.defaultTTL)
 	}
-
-	// Capture the currently-cached version's ETag (if any) so we can evict its
-	// body after the new version is committed — see evictSupersededBody.
-	prevETag, hadPrev := c.currentBodyETag(ctx, bucket, key)
 
 	metaKey := MakeMetaKey(bucket, key)
 	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
@@ -135,8 +107,6 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 		_ = c.client.Delete(ctx, bodyKey)
 		return err
 	}
-
-	c.evictSupersededBody(ctx, bucket, key, prevETag, hadPrev, meta.ETag)
 
 	log.Debug().
 		Str("bucket", bucket).
@@ -169,8 +139,6 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	if ttl == 0 {
 		ttl = int(c.defaultTTL)
 	}
-
-	prevETag, hadPrev := c.currentBodyETag(ctx, bucket, key)
 
 	metaKey := MakeMetaKey(bucket, key)
 	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
@@ -209,8 +177,6 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		_ = c.client.Delete(ctx, bodyKey)
 		return err
 	}
-
-	c.evictSupersededBody(ctx, bucket, key, prevETag, hadPrev, meta.ETag)
 
 	log.Debug().
 		Str("bucket", bucket).
@@ -305,23 +271,17 @@ func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 
 	metaKey := MakeMetaKey(bucket, key)
 
-	// Resolve the current version's body key from meta before deleting meta, so
-	// we can reclaim the matching body. Older superseded body versions (if any)
-	// are orphaned and age out via TTL.
-	etag, _ := c.currentBodyETag(ctx, bucket, key)
-	bodyKey := MakeBodyKey(bucket, key, etag)
-
-	// Delete metadata (ignore not found)
+	// Delete only the metadata. That is sufficient to make subsequent reads miss
+	// (a read resolves the body from meta.ETag, so with meta gone there is no body
+	// lookup), and the tombstone above blocks any in-flight repopulation. The
+	// versioned body is intentionally left to age out via TTL rather than deleted
+	// synchronously — deleting it could truncate an in-flight reader still
+	// streaming that exact version.
 	if err := c.client.Delete(ctx, metaKey); err != nil && !isNotFoundError(err) {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta delete error")
 	}
 
-	// Delete body (ignore not found)
-	if err := c.client.Delete(ctx, bodyKey); err != nil && !isNotFoundError(err) {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body delete error")
-	}
-
-	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Deleted from cache (meta+body)")
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Invalidated cache metadata (body ages out via TTL)")
 	return nil
 }
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -167,14 +167,19 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 			Int64("tombstone_ts", tombTs).
 			Int64("write_start", writeStartTime).
 			Msg("Skipping meta write - tombstone detected after body stream")
-		_ = c.client.Delete(ctx, bodyKey) // Clean up orphaned body
+		// The just-written versioned body is left to age out via TTL rather than
+		// deleted synchronously: a concurrent populate of the same ETag could have
+		// a reader streaming this exact body key, and deleting it would truncate
+		// that reader. Without a visible meta entry the orphaned body is unreachable
+		// and harmless until it expires.
 		return nil
 	}
 
 	// Write metadata AFTER body (makes entry visible)
 	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
-		_ = c.client.Delete(ctx, bodyKey)
+		// Same rationale as the tombstone branch: leave the versioned body to TTL
+		// rather than risk truncating a concurrent same-version reader.
 		return err
 	}
 
@@ -236,24 +241,27 @@ func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w i
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key, etag)
-
-	// Stream body directly to writer - no intermediate buffer
-	err := c.client.GetStream(ctx, bodyKey, w)
-	if err != nil {
-		if isNotFoundError(err) {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
-			return ErrNotFound
+	// Try the versioned key first, then the legacy unversioned key. A NotFound
+	// from GetStream writes nothing to w, so falling through to the next candidate
+	// is safe.
+	var err error
+	for _, bodyKey := range bodyKeyCandidates(bucket, key, etag) {
+		err = c.client.GetStream(ctx, bodyKey, w)
+		if err == nil {
+			log.Debug().
+				Str("bucket", bucket).
+				Str("key", key).
+				Msg("Cache hit (body streamed)")
+			return nil
 		}
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
-		return err
+		if !isNotFoundError(err) {
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
+			return err
+		}
 	}
 
-	log.Debug().
-		Str("bucket", bucket).
-		Str("key", key).
-		Msg("Cache hit (body streamed)")
-	return nil
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
+	return ErrNotFound
 }
 
 // DeleteWithMeta removes both metadata and body from cache.
@@ -308,14 +316,14 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key, etag)
+	candidates := bodyKeyCandidates(bucket, key, etag)
 
 	// Handle ocache quirk: reading byte 0 alone requires reading 2 bytes
 	// and discarding the last byte
 	if start == 0 && end == 0 {
 		// Single byte at position 0 - need to read 2 bytes and discard last
 		var buf bytes.Buffer
-		err := c.client.GetRangeStream(ctx, bodyKey, 0, 1, &buf)
+		err := c.rangeFromCandidates(ctx, candidates, 0, 1, &buf)
 		if err != nil {
 			if isNotFoundError(err) {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (range)")
@@ -331,7 +339,7 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 	}
 
 	// ocache now uses inclusive end (same as HTTP Range semantics)
-	err := c.client.GetRangeStream(ctx, bodyKey, start, end, w)
+	err := c.rangeFromCandidates(ctx, candidates, start, end, w)
 	if err != nil {
 		if isNotFoundError(err) {
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (range)")
@@ -354,6 +362,25 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 		Int64("length", end-start+1).
 		Msg("Cache hit (range)")
 	return nil
+}
+
+// rangeFromCandidates reads the given byte range from the first body key that
+// exists, trying each candidate in order. A NotFound from the underlying range
+// read writes nothing to w, so falling through to the next candidate is safe.
+// It returns the underlying error from the last candidate when all miss (a
+// NotFound that the caller maps to ErrNotFound).
+func (c *Cache) rangeFromCandidates(ctx context.Context, candidates []string, start, end int64, w io.Writer) error {
+	var err error
+	for _, bodyKey := range candidates {
+		err = c.client.GetRangeStream(ctx, bodyKey, start, end, w)
+		if err == nil {
+			return nil
+		}
+		if !isNotFoundError(err) {
+			return err
+		}
+	}
+	return err
 }
 
 // ============================================================================

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -79,6 +79,14 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 		return nil
 	}
 
+	// Objects without an ETag are not cached: bodies are addressed by ETag, and an
+	// ETag-less object would share a single unversioned body key that a concurrent
+	// overwrite could clobber in place. Callers gate on IsCacheable (which also
+	// excludes empty ETags); this is a defensive backstop for direct callers.
+	if meta.ETag == "" {
+		return nil
+	}
+
 	if ttl == 0 {
 		ttl = int(c.defaultTTL)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -68,6 +68,36 @@ func (c *Cache) IsEnabled() bool {
 // IMPORTANT: Body is written BEFORE metadata to ensure metadata presence
 // guarantees body availability. This prevents race conditions where a reader
 // finds metadata but body hasn't been written yet.
+// currentBodyETag returns the ETag of the currently-cached metadata for the key
+// and whether such metadata exists. Used to locate a superseded body version for
+// eviction on overwrite.
+func (c *Cache) currentBodyETag(ctx context.Context, bucket, key string) (string, bool) {
+	m, ok, _ := c.GetMeta(ctx, bucket, key)
+	if !ok {
+		return "", false
+	}
+	return m.ETag, true
+}
+
+// evictSupersededBody deletes the body of a previously cached version once a new
+// version with a different ETag has been committed, bounding disk usage for keys
+// that are rewritten frequently. It runs after the new meta+body are live, so new
+// readers already resolve to the new version; an in-flight reader that resolved
+// the old meta reads its body via an atomic Get and therefore either completes
+// before this delete or cleanly misses and falls through to upstream.
+func (c *Cache) evictSupersededBody(ctx context.Context, bucket, key, prevETag string, hadPrev bool, newETag string) {
+	if !hadPrev {
+		return
+	}
+	prevBodyKey := MakeBodyKey(bucket, key, prevETag)
+	if prevBodyKey == MakeBodyKey(bucket, key, newETag) {
+		return // same ETag — body was overwritten in place, nothing to evict
+	}
+	if err := c.client.Delete(ctx, prevBodyKey); err != nil && !isNotFoundError(err) {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Failed to evict superseded body")
+	}
+}
+
 func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *CachedObjectMeta, body []byte, ttl int) error {
 	if !c.IsEnabled() {
 		return nil
@@ -77,8 +107,12 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 		ttl = int(c.defaultTTL)
 	}
 
+	// Capture the currently-cached version's ETag (if any) so we can evict its
+	// body after the new version is committed — see evictSupersededBody.
+	prevETag, hadPrev := c.currentBodyETag(ctx, bucket, key)
+
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
 
 	// Encode metadata as JSON
 	metaBytes, err := meta.Encode()
@@ -101,6 +135,8 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 		_ = c.client.Delete(ctx, bodyKey)
 		return err
 	}
+
+	c.evictSupersededBody(ctx, bucket, key, prevETag, hadPrev, meta.ETag)
 
 	log.Debug().
 		Str("bucket", bucket).
@@ -134,8 +170,10 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		ttl = int(c.defaultTTL)
 	}
 
+	prevETag, hadPrev := c.currentBodyETag(ctx, bucket, key)
+
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
 
 	// Encode metadata first (fail fast if encoding fails)
 	metaBytes, err := meta.Encode()
@@ -171,6 +209,8 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		_ = c.client.Delete(ctx, bodyKey)
 		return err
 	}
+
+	c.evictSupersededBody(ctx, bucket, key, prevETag, hadPrev, meta.ETag)
 
 	log.Debug().
 		Str("bucket", bucket).
@@ -222,14 +262,15 @@ func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectM
 
 // GetBodyStream streams the cached object body directly to the provided writer.
 // This avoids buffering the entire object in memory, which is critical for large objects.
-// Use this after GetMeta() to stream the body directly to the HTTP response.
-// Returns ErrNotFound if the body is not in cache.
-func (c *Cache) GetBodyStream(ctx context.Context, bucket, key string, w io.Writer) error {
+// Use this after GetMeta(), passing the meta's ETag so the body read resolves to
+// the exact version the metadata describes. Returns ErrNotFound if the body for
+// that version is not in cache.
+func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w io.Writer) error {
 	if !c.IsEnabled() {
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Stream body directly to writer - no intermediate buffer
 	err := c.client.GetStream(ctx, bodyKey, w)
@@ -263,7 +304,12 @@ func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	}
 
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
+
+	// Resolve the current version's body key from meta before deleting meta, so
+	// we can reclaim the matching body. Older superseded body versions (if any)
+	// are orphaned and age out via TTL.
+	etag, _ := c.currentBodyETag(ctx, bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Delete metadata (ignore not found)
 	if err := c.client.Delete(ctx, metaKey); err != nil && !isNotFoundError(err) {
@@ -295,13 +341,14 @@ func (c *Cache) Delete(ctx context.Context, bucket, key string) error {
 // GetRangeStream retrieves a byte range from the cached object body.
 // Uses ocache's GetRangeStream for efficient partial reads from disk.
 // start and end are inclusive byte positions (HTTP Range semantics).
+// Pass the meta's ETag so the range resolves to the exact cached version.
 // Returns ErrNotFound if the object is not in cache.
-func (c *Cache) GetRangeStream(ctx context.Context, bucket, key string, start, end int64, w io.Writer) error {
+func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, start, end int64, w io.Writer) error {
 	if !c.IsEnabled() {
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Handle ocache quirk: reading byte 0 alone requires reading 2 bytes
 	// and discarding the last byte

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -103,8 +103,10 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 	// Store metadata AFTER body is complete
 	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
-		// Try to clean up body on metadata failure
-		_ = c.client.Delete(ctx, bodyKey)
+		// Leave the versioned body to age out via TTL rather than deleting it
+		// synchronously: a concurrent populate of the same ETag could have a reader
+		// streaming this exact body key, and deleting it would truncate that reader.
+		// Without a visible meta entry the orphaned body is unreachable until it expires.
 		return err
 	}
 
@@ -241,27 +243,24 @@ func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w i
 		return ErrCacheDisabled
 	}
 
-	// Try the versioned key first, then the legacy unversioned key. A NotFound
-	// from GetStream writes nothing to w, so falling through to the next candidate
-	// is safe.
-	var err error
-	for _, bodyKey := range bodyKeyCandidates(bucket, key, etag) {
-		err = c.client.GetStream(ctx, bodyKey, w)
-		if err == nil {
-			log.Debug().
-				Str("bucket", bucket).
-				Str("key", key).
-				Msg("Cache hit (body streamed)")
-			return nil
+	bodyKey := MakeBodyKey(bucket, key, etag)
+
+	// Stream body directly to writer - no intermediate buffer
+	err := c.client.GetStream(ctx, bodyKey, w)
+	if err != nil {
+		if isNotFoundError(err) {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
+			return ErrNotFound
 		}
-		if !isNotFoundError(err) {
-			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
-			return err
-		}
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body stream error")
+		return err
 	}
 
-	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (body stream)")
-	return ErrNotFound
+	log.Debug().
+		Str("bucket", bucket).
+		Str("key", key).
+		Msg("Cache hit (body streamed)")
+	return nil
 }
 
 // DeleteWithMeta removes both metadata and body from cache.
@@ -316,14 +315,14 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 		return ErrCacheDisabled
 	}
 
-	candidates := bodyKeyCandidates(bucket, key, etag)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Handle ocache quirk: reading byte 0 alone requires reading 2 bytes
 	// and discarding the last byte
 	if start == 0 && end == 0 {
 		// Single byte at position 0 - need to read 2 bytes and discard last
 		var buf bytes.Buffer
-		err := c.rangeFromCandidates(ctx, candidates, 0, 1, &buf)
+		err := c.client.GetRangeStream(ctx, bodyKey, 0, 1, &buf)
 		if err != nil {
 			if isNotFoundError(err) {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (range)")
@@ -339,7 +338,7 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 	}
 
 	// ocache now uses inclusive end (same as HTTP Range semantics)
-	err := c.rangeFromCandidates(ctx, candidates, start, end, w)
+	err := c.client.GetRangeStream(ctx, bodyKey, start, end, w)
 	if err != nil {
 		if isNotFoundError(err) {
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache miss (range)")
@@ -362,25 +361,6 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 		Int64("length", end-start+1).
 		Msg("Cache hit (range)")
 	return nil
-}
-
-// rangeFromCandidates reads the given byte range from the first body key that
-// exists, trying each candidate in order. A NotFound from the underlying range
-// read writes nothing to w, so falling through to the next candidate is safe.
-// It returns the underlying error from the last candidate when all miss (a
-// NotFound that the caller maps to ErrNotFound).
-func (c *Cache) rangeFromCandidates(ctx context.Context, candidates []string, start, end int64, w io.Writer) error {
-	var err error
-	for _, bodyKey := range candidates {
-		err = c.client.GetRangeStream(ctx, bodyKey, start, end, w)
-		if err == nil {
-			return nil
-		}
-		if !isNotFoundError(err) {
-			return err
-		}
-	}
-	return err
 }
 
 // ============================================================================

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/config"
+)
+
+func newVersioningTestCache(t *testing.T) (*Cache, cacheclient.CacheClient) {
+	t.Helper()
+	mem := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	return NewCacheWithClient(mem, &cfg.Cache), mem
+}
+
+// The core guarantee: metadata for one version always resolves to that version's
+// body, never a concurrently-written different version's body (no torn pair).
+func TestETagVersionedBody_MetaResolvesToItsOwnBody(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta1 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	if err := c.PutWithMeta(ctx, bucket, key, meta1, []byte("v1"), 60); err != nil {
+		t.Fatalf("PutWithMeta v1: %v", err)
+	}
+
+	// A concurrent writer stores a different version's body at its own key,
+	// without touching v1's body.
+	if err := mem.Put(ctx, MakeBodyKey(bucket, key, `"v2"`), []byte("VERSION-TWO"), 60); err != nil {
+		t.Fatalf("seed v2 body: %v", err)
+	}
+
+	// A reader holding meta_v1 must resolve to body_v1 — never the v2 body.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, meta1.ETag, &buf); err != nil {
+		t.Fatalf("GetBodyStream v1: %v", err)
+	}
+	if buf.String() != "v1" {
+		t.Errorf("meta_v1 resolved to %q, want %q (torn pair!)", buf.String(), "v1")
+	}
+}
+
+// Overwriting a key with a new ETag eagerly evicts the superseded body.
+func TestETagVersionedBody_EagerEvictionOnOverwrite(t *testing.T) {
+	c, _ := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta1 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta1, []byte("v1"), 60)
+	meta2 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v2"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta2, []byte("v2"), 60)
+
+	// Superseded v1 body is gone.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != ErrNotFound {
+		t.Errorf("v1 body after overwrite: err=%v, want ErrNotFound (evicted)", err)
+	}
+	// Current v2 body is served.
+	buf.Reset()
+	if err := c.GetBodyStream(ctx, bucket, key, `"v2"`, &buf); err != nil || buf.String() != "v2" {
+		t.Errorf("v2 body: err=%v body=%q", err, buf.String())
+	}
+}
+
+// Objects with no ETag fall back to the unversioned body key and round-trip.
+func TestETagVersionedBody_EmptyETagFallsBackToFixedKey(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 4, StatusCode: 200}
+	if err := c.PutWithMeta(ctx, bucket, key, meta, []byte("body"), 60); err != nil {
+		t.Fatalf("PutWithMeta: %v", err)
+	}
+	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err != nil {
+		t.Errorf("empty-ETag body not stored at fixed key: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, "", &buf); err != nil || buf.String() != "body" {
+		t.Errorf("read empty-ETag body: err=%v body=%q", err, buf.String())
+	}
+}

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -119,8 +119,10 @@ func TestETagVersionedBody_VersionedMissDoesNotServeLegacyBody(t *testing.T) {
 	}
 }
 
-// Objects with no ETag use the unversioned body key and round-trip.
-func TestETagVersionedBody_EmptyETagFallsBackToFixedKey(t *testing.T) {
+// Objects with no ETag are not cached at all: there is no version discriminator,
+// so caching them at a single unversioned key would reintroduce the in-place
+// overwrite / truncation hazard the ETag versioning was introduced to prevent.
+func TestETagVersionedBody_EmptyETagIsNotCached(t *testing.T) {
 	c, mem := newVersioningTestCache(t)
 	ctx := context.Background()
 	bucket, key := "b", "k"
@@ -129,11 +131,11 @@ func TestETagVersionedBody_EmptyETagFallsBackToFixedKey(t *testing.T) {
 	if err := c.PutWithMeta(ctx, bucket, key, meta, []byte("body"), 60); err != nil {
 		t.Fatalf("PutWithMeta: %v", err)
 	}
-	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err != nil {
-		t.Errorf("empty-ETag body not stored at fixed key: %v", err)
+	// Neither meta nor body should have been written.
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("empty-ETag object should not be cached (meta present)")
 	}
-	var buf bytes.Buffer
-	if err := c.GetBodyStream(ctx, bucket, key, "", &buf); err != nil || buf.String() != "body" {
-		t.Errorf("read empty-ETag body: err=%v body=%q", err, buf.String())
+	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err == nil {
+		t.Error("empty-ETag object should not be cached (body present)")
 	}
 }

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -94,41 +94,32 @@ func TestETagVersionedBody_DeleteRemovesMetaNotBody(t *testing.T) {
 	}
 }
 
-// Migration window: a body written by a pre-versioning build lives at the
-// unversioned key while its metadata already carries an ETag. Reads must fall
-// back to the unversioned key so the object is still served (and, crucially, a
-// Range GET does not stream a truncated body under an already-committed 206).
-func TestETagVersionedBody_VersionedMissFallsBackToLegacyBody(t *testing.T) {
+// A versioned (non-empty ETag) read must NEVER serve bytes from the legacy
+// unversioned key. Overwrites and invalidation leave that legacy entry in place
+// until TTL, so falling back to it could return older, unrelated bytes under
+// metadata that describes a newer version. A versioned-key miss must surface as
+// ErrNotFound so the caller refetches from upstream instead of serving stale data.
+func TestETagVersionedBody_VersionedMissDoesNotServeLegacyBody(t *testing.T) {
 	c, mem := newVersioningTestCache(t)
 	ctx := context.Background()
 	bucket, key := "b", "k"
 
-	// Seed only the legacy unversioned body (as a pre-versioning build would),
-	// with no versioned body present.
-	if err := mem.Put(ctx, MakeBodyKey(bucket, key, ""), []byte("legacy-body"), 60); err != nil {
+	// Seed a stale legacy unversioned body, with no matching versioned body.
+	if err := mem.Put(ctx, MakeBodyKey(bucket, key, ""), []byte("STALE-LEGACY"), 60); err != nil {
 		t.Fatalf("seed legacy body: %v", err)
 	}
 
-	// Full-object read via the versioned ETag resolves the legacy body.
 	var buf bytes.Buffer
-	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil {
-		t.Fatalf("GetBodyStream fallback: %v", err)
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != ErrNotFound {
+		t.Errorf("GetBodyStream returned err=%v body=%q, want ErrNotFound (no legacy fallback)", err, buf.String())
 	}
-	if buf.String() != "legacy-body" {
-		t.Errorf("GetBodyStream got %q, want %q (fallback failed)", buf.String(), "legacy-body")
-	}
-
-	// Range read via the versioned ETag also resolves the legacy body.
 	buf.Reset()
-	if err := c.GetRangeStream(ctx, bucket, key, `"v1"`, 0, 5, &buf); err != nil {
-		t.Fatalf("GetRangeStream fallback: %v", err)
-	}
-	if buf.String() != "legacy" {
-		t.Errorf("GetRangeStream got %q, want %q (fallback failed)", buf.String(), "legacy")
+	if err := c.GetRangeStream(ctx, bucket, key, `"v1"`, 0, 5, &buf); err != ErrNotFound {
+		t.Errorf("GetRangeStream returned err=%v body=%q, want ErrNotFound (no legacy fallback)", err, buf.String())
 	}
 }
 
-// Objects with no ETag fall back to the unversioned body key and round-trip.
+// Objects with no ETag use the unversioned body key and round-trip.
 func TestETagVersionedBody_EmptyETagFallsBackToFixedKey(t *testing.T) {
 	c, mem := newVersioningTestCache(t)
 	ctx := context.Background()

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -94,6 +94,40 @@ func TestETagVersionedBody_DeleteRemovesMetaNotBody(t *testing.T) {
 	}
 }
 
+// Migration window: a body written by a pre-versioning build lives at the
+// unversioned key while its metadata already carries an ETag. Reads must fall
+// back to the unversioned key so the object is still served (and, crucially, a
+// Range GET does not stream a truncated body under an already-committed 206).
+func TestETagVersionedBody_VersionedMissFallsBackToLegacyBody(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	// Seed only the legacy unversioned body (as a pre-versioning build would),
+	// with no versioned body present.
+	if err := mem.Put(ctx, MakeBodyKey(bucket, key, ""), []byte("legacy-body"), 60); err != nil {
+		t.Fatalf("seed legacy body: %v", err)
+	}
+
+	// Full-object read via the versioned ETag resolves the legacy body.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil {
+		t.Fatalf("GetBodyStream fallback: %v", err)
+	}
+	if buf.String() != "legacy-body" {
+		t.Errorf("GetBodyStream got %q, want %q (fallback failed)", buf.String(), "legacy-body")
+	}
+
+	// Range read via the versioned ETag also resolves the legacy body.
+	buf.Reset()
+	if err := c.GetRangeStream(ctx, bucket, key, `"v1"`, 0, 5, &buf); err != nil {
+		t.Fatalf("GetRangeStream fallback: %v", err)
+	}
+	if buf.String() != "legacy" {
+		t.Errorf("GetRangeStream got %q, want %q (fallback failed)", buf.String(), "legacy")
+	}
+}
+
 // Objects with no ETag fall back to the unversioned body key and round-trip.
 func TestETagVersionedBody_EmptyETagFallsBackToFixedKey(t *testing.T) {
 	c, mem := newVersioningTestCache(t)

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -44,8 +44,10 @@ func TestETagVersionedBody_MetaResolvesToItsOwnBody(t *testing.T) {
 	}
 }
 
-// Overwriting a key with a new ETag eagerly evicts the superseded body.
-func TestETagVersionedBody_EagerEvictionOnOverwrite(t *testing.T) {
+// Bodies are never deleted synchronously: after an overwrite, the superseded
+// version's body still exists (it ages out via TTL), so an in-flight reader that
+// resolved the old meta can still stream it without truncation.
+func TestETagVersionedBody_VersionsCoexistUntilTTL(t *testing.T) {
 	c, _ := newVersioningTestCache(t)
 	ctx := context.Background()
 	bucket, key := "b", "k"
@@ -55,15 +57,40 @@ func TestETagVersionedBody_EagerEvictionOnOverwrite(t *testing.T) {
 	meta2 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v2"`, ContentLength: 2, StatusCode: 200}
 	_ = c.PutWithMeta(ctx, bucket, key, meta2, []byte("v2"), 60)
 
-	// Superseded v1 body is gone.
+	// Both versions' bodies remain readable — the old one is not evicted.
 	var buf bytes.Buffer
-	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != ErrNotFound {
-		t.Errorf("v1 body after overwrite: err=%v, want ErrNotFound (evicted)", err)
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil || buf.String() != "v1" {
+		t.Errorf("v1 body after overwrite: err=%v body=%q, want it to still exist", err, buf.String())
 	}
-	// Current v2 body is served.
 	buf.Reset()
 	if err := c.GetBodyStream(ctx, bucket, key, `"v2"`, &buf); err != nil || buf.String() != "v2" {
 		t.Errorf("v2 body: err=%v body=%q", err, buf.String())
+	}
+}
+
+// Invalidation removes only metadata; the body is left to age out via TTL so it
+// cannot truncate an in-flight reader still streaming that version.
+func TestETagVersionedBody_DeleteRemovesMetaNotBody(t *testing.T) {
+	c, _ := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("v1"), 60)
+
+	if err := c.DeleteWithMeta(ctx, bucket, key); err != nil {
+		t.Fatalf("DeleteWithMeta: %v", err)
+	}
+
+	// Meta is gone -> reads miss.
+	if _, ok, _ := c.GetMeta(ctx, bucket, key); ok {
+		t.Error("meta still present after DeleteWithMeta")
+	}
+	// Body still resolvable by its ETag (ages out via TTL) — a reader that
+	// resolved this version before the invalidation is not truncated.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil || buf.String() != "v1" {
+		t.Errorf("body after DeleteWithMeta: err=%v body=%q, want it to survive", err, buf.String())
 	}
 }
 

--- a/cache/object.go
+++ b/cache/object.go
@@ -246,6 +246,21 @@ func MakeBodyKey(bucket, key, etag string) string {
 	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
 }
 
+// bodyKeyCandidates returns the body keys to try when reading, in priority order.
+// For a versioned (non-empty ETag) object it appends the legacy unversioned key as
+// a fallback: bodies written by a pre-versioning build are still on disk at the
+// unversioned key after an upgrade, while their metadata already carries an ETag.
+// Without this fallback, the first Range GET for such an object after upgrade would
+// resolve the versioned key, miss, and stream a truncated body under a committed 206
+// for the entire cache-migration window.
+func bodyKeyCandidates(bucket, key, etag string) []string {
+	versioned := MakeBodyKey(bucket, key, etag)
+	if etag == "" {
+		return []string{versioned}
+	}
+	return []string{versioned, MakeBodyKey(bucket, key, "")}
+}
+
 // MakeTombstoneKey creates the cache key for invalidation tombstones.
 func MakeTombstoneKey(bucket, key string) string {
 	return tombKeyPrefix + bucket + "|" + key

--- a/cache/object.go
+++ b/cache/object.go
@@ -168,6 +168,16 @@ func (m *CachedObjectMeta) IsPublicRead() bool {
 
 // IsCacheable returns true if the object should be cached based on headers.
 func (m *CachedObjectMeta) IsCacheable(maxSize int64) bool {
+	// Don't cache objects without an ETag. Bodies are addressed by ETag so each
+	// version gets an immutable key; without one, all versions would share a single
+	// unversioned body key that a concurrent overwrite could clobber in place,
+	// truncating an in-flight reader. Objects Tigris serves always carry an ETag, so
+	// this only excludes rare ETag-less responses (e.g. some non-Tigris upstreams in
+	// signing mode), which are forwarded uncached rather than cached unsafely.
+	if m.ETag == "" {
+		return false
+	}
+
 	// Don't cache if Cache-Control says not to
 	cc := strings.ToLower(m.CacheControl)
 	if strings.Contains(cc, "no-store") || strings.Contains(cc, "private") {

--- a/cache/object.go
+++ b/cache/object.go
@@ -233,9 +233,17 @@ func MakeMetaKey(bucket, key string) string {
 	return metaKeyPrefix + bucket + "|" + key
 }
 
-// MakeBodyKey creates the cache key for object body.
-func MakeBodyKey(bucket, key string) string {
-	return bodyKeyPrefix + bucket + "|" + key
+// MakeBodyKey creates the cache key for an object body. Bodies are addressed by
+// the object's ETag ("body|bucket|key|<etag>") so a served metadata entry always
+// maps to the exact body version it describes: a concurrent overwrite writes a
+// new meta plus a new body key and never clobbers the version an in-flight reader
+// resolved. Objects with no ETag fall back to the unversioned key (there is no
+// version discriminator available for them).
+func MakeBodyKey(bucket, key, etag string) string {
+	if etag == "" {
+		return bodyKeyPrefix + bucket + "|" + key
+	}
+	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
 }
 
 // MakeTombstoneKey creates the cache key for invalidation tombstones.

--- a/cache/object.go
+++ b/cache/object.go
@@ -246,21 +246,6 @@ func MakeBodyKey(bucket, key, etag string) string {
 	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
 }
 
-// bodyKeyCandidates returns the body keys to try when reading, in priority order.
-// For a versioned (non-empty ETag) object it appends the legacy unversioned key as
-// a fallback: bodies written by a pre-versioning build are still on disk at the
-// unversioned key after an upgrade, while their metadata already carries an ETag.
-// Without this fallback, the first Range GET for such an object after upgrade would
-// resolve the versioned key, miss, and stream a truncated body under a committed 206
-// for the entire cache-migration window.
-func bodyKeyCandidates(bucket, key, etag string) []string {
-	versioned := MakeBodyKey(bucket, key, etag)
-	if etag == "" {
-		return []string{versioned}
-	}
-	return []string{versioned, MakeBodyKey(bucket, key, "")}
-}
-
 // MakeTombstoneKey creates the cache key for invalidation tombstones.
 func MakeTombstoneKey(bucket, key string) string {
 	return tombKeyPrefix + bucket + "|" + key

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -177,10 +177,15 @@ func TestMakeMetaKey(t *testing.T) {
 }
 
 func TestMakeBodyKey(t *testing.T) {
+	// No ETag falls back to the unversioned key.
 	expected := "body|my-bucket|path/to/object.txt"
-	result := MakeBodyKey("my-bucket", "path/to/object.txt")
+	result := MakeBodyKey("my-bucket", "path/to/object.txt", "")
 	if result != expected {
 		t.Errorf("MakeBodyKey() = %q, want %q", result, expected)
+	}
+	// With an ETag the body key is version-qualified (quotes/weak prefix stripped).
+	if got := MakeBodyKey("my-bucket", "path/to/object.txt", `"abc123"`); got != "body|my-bucket|path/to/object.txt|abc123" {
+		t.Errorf("MakeBodyKey(etag) = %q, want %q", got, "body|my-bucket|path/to/object.txt|abc123")
 	}
 }
 

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -104,6 +104,7 @@ func TestCachedObjectMeta_WriteHeaders(t *testing.T) {
 func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	tests := []struct {
 		name         string
+		etag         string
 		cacheControl string
 		contentLen   int64
 		maxSize      int64
@@ -111,13 +112,23 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	}{
 		{
 			name:         "cacheable object",
+			etag:         `"abc"`,
 			cacheControl: "max-age=3600",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
 			expected:     true,
 		},
 		{
+			name:         "no etag",
+			etag:         "",
+			cacheControl: "max-age=3600",
+			contentLen:   1024,
+			maxSize:      1024 * 1024,
+			expected:     false,
+		},
+		{
 			name:         "no-store",
+			etag:         `"abc"`,
 			cacheControl: "no-store",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -125,6 +136,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "private",
+			etag:         `"abc"`,
 			cacheControl: "private",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -132,6 +144,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "too large",
+			etag:         `"abc"`,
 			cacheControl: "max-age=3600",
 			contentLen:   10 * 1024 * 1024,
 			maxSize:      1024 * 1024,
@@ -139,6 +152,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "no cache control",
+			etag:         `"abc"`,
 			cacheControl: "",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -146,6 +160,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "public cache control",
+			etag:         `"abc"`,
 			cacheControl: "public, max-age=3600",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -156,6 +171,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			obj := &CachedObjectMeta{
+				ETag:          tt.etag,
 				CacheControl:  tt.cacheControl,
 				ContentLength: tt.contentLen,
 			}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -29,6 +29,49 @@ type deleteObjectEntry struct {
 	VersionId string `xml:"VersionId,omitempty"`
 }
 
+// deleteObjectsResult represents the S3 DeleteObjects response. Only the per-object
+// <Error> entries are captured: successful deletes may be omitted (Quiet mode), so
+// success is derived as "requested minus errored".
+type deleteObjectsResult struct {
+	XMLName xml.Name `xml:"DeleteResult"`
+	Errors  []struct {
+		Key string `xml:"Key"`
+	} `xml:"Error"`
+}
+
+// failedDeleteKeys returns the set of keys upstream reported as NOT deleted. On a
+// parse failure it returns an empty set, so callers re-invalidate all requested
+// keys — the safe over-invalidation.
+func failedDeleteKeys(body []byte) map[string]struct{} {
+	failed := make(map[string]struct{})
+	var result deleteObjectsResult
+	if err := xml.Unmarshal(body, &result); err != nil {
+		return failed
+	}
+	for _, e := range result.Errors {
+		failed[e.Key] = struct{}{}
+	}
+	return failed
+}
+
+// isS3ErrorBody reports whether an XML body's root element is <Error>, the shape S3
+// uses for an operation-level failure (including 200-status CopyObject failures).
+func isS3ErrorBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local == "Error"
+		}
+	}
+}
+
 // HandleDeleteObjects handles POST /{bucket}?delete for bulk object deletion.
 // Invalidates cache for requested objects BEFORE forwarding to ensure consistency.
 func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) error {
@@ -62,16 +105,24 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
-	// Forward request to upstream
-	err = s.forwarder.Forward(r.Context(), w, r)
+	// Forward request to upstream, capturing the response so we can tell which
+	// per-object deletes actually succeeded — S3 returns 200 OK with per-key
+	// <Error> elements for partial failures.
+	capture, err := s.forwarder.ForwardWithCapture(r.Context(), w, r)
 
 	// Re-invalidate AFTER upstream confirms the deletes, for the same
 	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
 	// bulk delete may have re-cached a not-yet-deleted object; this second
-	// tombstone blocks that stale repopulation. The metric is recorded once on
-	// the pre-forward invalidation above, so it is not counted again here.
-	if err == nil && s.cache.IsEnabled() {
+	// tombstone blocks that stale repopulation. Only keys upstream actually deleted
+	// are re-invalidated — a key that failed is still present, so tombstoning it
+	// would discard a valid racing refill. The metric is recorded once on the
+	// pre-forward invalidation above, so it is not counted again here.
+	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
+		failed := failedDeleteKeys(capture.Body)
 		for _, key := range deletedKeys {
+			if _, bad := failed[key]; bad {
+				continue
+			}
 			s.cache.Delete(context.Background(), bucket, key)
 		}
 	}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -46,12 +46,14 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
 	// This ensures cache consistency even if forwarding fails after cache invalidation
+	var deletedKeys []string
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
 			for _, obj := range deleteReq.Objects {
 				s.cache.Delete(context.Background(), bucket, obj.Key)
 				metrics.RecordCacheOperation("delete", "success")
+				deletedKeys = append(deletedKeys, obj.Key)
 				log.Debug().
 					Str("bucket", bucket).
 					Str("key", obj.Key).
@@ -62,6 +64,17 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Forward request to upstream
 	err = s.forwarder.Forward(r.Context(), w, r)
+
+	// Re-invalidate AFTER upstream confirms the deletes, for the same
+	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
+	// bulk delete may have re-cached a not-yet-deleted object; this second
+	// tombstone blocks that stale repopulation. The metric is recorded once on
+	// the pre-forward invalidation above, so it is not counted again here.
+	if err == nil && s.cache.IsEnabled() {
+		for _, key := range deletedKeys {
+			s.cache.Delete(context.Background(), bucket, key)
+		}
+	}
 
 	// Record metrics
 	status := "success"

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -164,7 +164,14 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 				// Serve full response from cache
 				if cacheBodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); cacheBodyErr != nil {
-					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, falling through to upstream")
+					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, invalidating orphaned meta and falling through to upstream")
+					// Metadata survived but its versioned body is gone. Invalidate the
+					// orphaned meta (same as the range and revalidation paths) so this
+					// does not become a meta-hit/body-miss loop that repeats the failed
+					// cache read on every request before refetching from upstream.
+					// serveFromCache errored before committing headers, so falling
+					// through to the miss path below is safe.
+					s.cache.Delete(context.Background(), bucket, key)
 					// Fall through to cache miss path
 				} else {
 					return nil

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -127,9 +127,12 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 					if served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
 						return rangeErr
 					}
-					// Cached body not resolvable - forward the range to upstream and
-					// warm the full object in the background (same as a range miss).
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - forwarding with background cache")
+					// Cached metadata survived but its versioned body is gone. Invalidate
+					// the orphaned meta so the background re-warm below is not blocked by
+					// its GetMeta(!found) gate — otherwise every range read for this key
+					// would forward to upstream until the meta TTL expires (cold-miss loop).
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - invalidating orphaned meta and forwarding with background cache")
+					s.cache.Delete(context.Background(), bucket, key)
 					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
 				}
 

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -597,7 +597,7 @@ func (s *Service) serveRangeFromCache(
 
 	// Stream range from cache using counting writer to track actual bytes
 	cw := &countingWriter{w: w}
-	streamErr := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, cw)
+	streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.ETag, rng.start, rng.end, cw)
 
 	// Track bytes out (even on error, some bytes may have been written)
 	if cw.written > 0 {

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -124,7 +124,13 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				// serve the range from the cached object
 				if rangeHeader != "" {
 					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-					return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+					if served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+						return rangeErr
+					}
+					// Cached body not resolvable - forward the range to upstream and
+					// warm the full object in the background (same as a range miss).
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - forwarding with background cache")
+					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
 				}
 
 				// Check conditional request: If-None-Match
@@ -560,6 +566,12 @@ func parseRangeHeader(rangeHeader string, totalSize int64) ([]byteRange, error) 
 }
 
 // serveRangeFromCache serves a Range request from the cached full object.
+// It returns served=true when it has produced a complete client response (a range
+// body, or a definitive error response like 416). It returns served=false, without
+// touching the response, when the cached body cannot be resolved (e.g. the body was
+// independently evicted while its metadata survived, or was written by a
+// pre-versioning build under a different key) — the caller then falls through to the
+// upstream range path rather than emitting a truncated 206.
 func (s *Service) serveRangeFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -568,15 +580,15 @@ func (s *Service) serveRangeFromCache(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	startTime time.Time,
-) error {
+) (served bool, err error) {
 	// Parse Range header
-	ranges, err := parseRangeHeader(rangeHeader, meta.ContentLength)
-	if err != nil || len(ranges) == 0 {
+	ranges, parseErr := parseRangeHeader(rangeHeader, meta.ContentLength)
+	if parseErr != nil || len(ranges) == 0 {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
 		w.Header().Set(XCacheHeader, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
+		return true, nil
 	}
 
 	// Only support single range (multi-range is complex and rare)
@@ -586,10 +598,35 @@ func (s *Service) serveRangeFromCache(
 		w.Header().Set(XCacheHeader, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
+		return true, nil
 	}
 
 	rng := ranges[0]
+
+	// Probe the body BEFORE committing 206 status + headers: stream the range
+	// through a pipe and read the first byte. If the versioned body is not
+	// resolvable, no headers have been sent yet, so we report served=false and let
+	// the caller forward to upstream instead of streaming a truncated 206 that the
+	// client cannot distinguish from a valid short read.
+	pr, pw := io.Pipe()
+	go func() {
+		streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.ETag, rng.start, rng.end, pw)
+		if streamErr != nil {
+			pw.CloseWithError(streamErr)
+		} else {
+			pw.Close()
+		}
+	}()
+
+	firstByte := make([]byte, 1)
+	n, readErr := pr.Read(firstByte)
+	if readErr != nil {
+		pr.Close()
+		log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).
+			Int64("start", rng.start).Int64("end", rng.end).
+			Msg("Range cache body unavailable before headers - falling through to upstream")
+		return false, nil
+	}
 
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	w.Header().Set(XCacheHeader, XCacheHit)
@@ -597,24 +634,26 @@ func (s *Service) serveRangeFromCache(
 
 	// Stream range from cache using counting writer to track actual bytes
 	cw := &countingWriter{w: w}
-	streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.ETag, rng.start, rng.end, cw)
+	cw.Write(firstByte[:n])
+	_, copyErr := io.Copy(cw, pr)
+	pr.Close()
 
 	// Track bytes out (even on error, some bytes may have been written)
 	if cw.written > 0 {
 		metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
 	}
 
-	if streamErr != nil {
-		log.Warn().Err(streamErr).Str("bucket", bucket).Str("key", key).
+	if copyErr != nil {
+		log.Warn().Err(copyErr).Str("bucket", bucket).Str("key", key).
 			Int64("start", rng.start).Int64("end", rng.end).
 			Msg("Failed to stream range from cache")
 		// Headers already sent, can't return error to client
-		return streamErr
+		return true, copyErr
 	}
 
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
-	return nil
+	return true, nil
 }
 
 // handleRangeWithBackgroundCache handles a Range request on cache miss.

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -1,0 +1,41 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// A GET that races an in-flight PUT can fetch the pre-PUT object and begin
+// re-caching it. HandlePutObject must re-invalidate AFTER forwarding so that
+// stale repopulation does not survive (read-after-write).
+func TestHandlePutObject_ReinvalidatesAfterForward(t *testing.T) {
+	var c *cache.Cache
+
+	// Simulate the racing GET writing a stale entry mid-PUT (during Forward).
+	repopulate := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("stale"), 60)
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{forwardFunc: repopulate}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/test-bucket/test-key", strings.NewReader("new body"))
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, r); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); found {
+		t.Error("stale entry still cached after PUT — post-forward re-invalidation missing")
+	}
+}

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -39,3 +39,130 @@ func TestHandlePutObject_ReinvalidatesAfterForward(t *testing.T) {
 		t.Error("stale entry still cached after PUT — post-forward re-invalidation missing")
 	}
 }
+
+// A rejected CopyObject leaves the destination unchanged, so the post-forward
+// re-invalidation must NOT fire — otherwise a racing refill of the still-valid
+// destination is discarded, causing an unnecessary later miss.
+func TestHandleCopyObject_FailedCopyKeepsRacingRefill(t *testing.T) {
+	var c *cache.Cache
+	repopulateThenFail := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		body := []byte(`<Error><Code>AccessDenied</Code></Error>`)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusForbidden, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenFail}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	r.Header.Set("X-Amz-Copy-Source", "/src-bucket/src-key")
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); !found {
+		t.Error("racing refill discarded after a FAILED copy — re-invalidation must be gated on success")
+	}
+}
+
+// A CopyObject that returns 200 OK but an <Error> body actually failed, so the
+// destination is unchanged and must not be re-invalidated.
+func TestHandleCopyObject_200ErrorBodyKeepsRacingRefill(t *testing.T) {
+	var c *cache.Cache
+	repopulateThen200Error := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		body := []byte(`<Error><Code>InternalError</Code></Error>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThen200Error}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); !found {
+		t.Error("racing refill discarded after a 200-with-error-body copy — that copy did not succeed")
+	}
+}
+
+// A successful CopyObject changed the destination, so the post-forward
+// re-invalidation must fire to drop any stale racing refill.
+func TestHandleCopyObject_SuccessReinvalidates(t *testing.T) {
+	var c *cache.Cache
+	repopulateThenSucceed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("stale"), 60)
+		body := []byte(`<CopyObjectResult><ETag>"new"</ETag></CopyObjectResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenSucceed}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); found {
+		t.Error("stale refill survived a SUCCESSFUL copy — post-forward re-invalidation should have removed it")
+	}
+}
+
+// A bulk delete with a per-object failure must re-invalidate only the keys that
+// were actually deleted; a racing refill of a FAILED key must survive.
+func TestHandleDeleteObjects_PartialFailureKeepsFailedKeyRefill(t *testing.T) {
+	var c *cache.Cache
+	const okKey = "ok-key"
+	const failKey = "fail-key"
+
+	repopulateThenPartial := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, _ := ParseBucketKey(r)
+		for _, k := range []string{okKey, failKey} {
+			meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+			_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		}
+		body := []byte(`<DeleteResult><Deleted><Key>ok-key</Key></Deleted><Error><Key>fail-key</Key><Code>AccessDenied</Code></Error></DeleteResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenPartial}, true)
+
+	reqBody := `<Delete><Object><Key>ok-key</Key></Object><Object><Key>fail-key</Key></Object></Delete>`
+	r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	if err := svc.HandleDeleteObjects(w, r); err != nil {
+		t.Fatalf("HandleDeleteObjects: %v", err)
+	}
+
+	b, _ := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, okKey); found {
+		t.Error("deleted key's stale refill survived — it should have been re-invalidated")
+	}
+	if _, found, _ := c.GetMeta(context.Background(), b, failKey); !found {
+		t.Error("failed key's valid refill was discarded — failed keys must not be re-invalidated")
+	}
+}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -238,7 +238,7 @@ func (s *Service) serveFromCache(
 		bodyBuf := bufferPool.Get().(*bytes.Buffer)
 		bodyBuf.Reset()
 
-		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
+		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, bodyBuf)
 		if bodyErr == nil && bodyBuf.Len() > 0 {
 			metrics.RecordCacheHit()
 			meta.WriteHeaders(w)
@@ -261,7 +261,7 @@ func (s *Service) serveFromCache(
 	// Large objects: stream via pipe
 	pr, pw := io.Pipe()
 	go func() {
-		err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+		err := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, pw)
 		if err != nil {
 			pw.CloseWithError(err)
 		} else {

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -113,7 +113,13 @@ func (s *Service) handleRevalidation304(
 
 	// Serve range or full body from cache
 	if rangeHeader != "" {
-		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served, err := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+			return err
+		}
+		// Range body not resolvable from cache; serve the full cached object
+		// instead of a truncated 206 (serveFromCache probes the body and errors
+		// cleanly if it too is gone).
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable on revalidation - serving full cached object")
 	}
 	return s.serveFromCache(ctx, w, bucket, key, meta, start)
 }
@@ -349,7 +355,12 @@ func (s *Service) serveStaleFromCache(
 	start time.Time,
 ) error {
 	if rangeHeader != "" {
-		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served, err := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+			return err
+		}
+		// Range body not resolvable from cache; serve the full cached object
+		// instead of a truncated 206.
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable on stale-serve - serving full cached object")
 	}
 	return s.serveFromCache(ctx, w, bucket, key, meta, start)
 }

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -47,14 +47,14 @@ func (s *Service) revalidateAndServe(
 		// Upstream error — serve stale from cache
 		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Revalidation failed, serving stale")
 		metrics.RecordRevalidationFailed()
-		metrics.RecordRevalidationStaleServed()
 		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 		if served {
+			metrics.RecordRevalidationStaleServed()
 			return staleErr
 		}
 		// No stale bytes available (versioned body gone) and nothing written yet —
 		// last-resort direct fetch so the client gets a real response.
-		return s.forwardAfterCacheMiss(ctx, w, r, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	}
 	defer resp.Body.Close()
 
@@ -72,7 +72,7 @@ func (s *Service) revalidateAndServe(
 		// returns the correct 206; this unifies the full-object and range paths.
 		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
 			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
-		return s.forwardAfterCacheMiss(ctx, w, r, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	case http.StatusOK:
 		// Full-object response (no range or upstream ignored range)
 		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
@@ -88,12 +88,12 @@ func (s *Service) revalidateAndServe(
 			Str("key", key).
 			Msg("Revalidation got unexpected status, serving stale")
 		metrics.RecordRevalidationFailed()
-		metrics.RecordRevalidationStaleServed()
 		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 		if served {
+			metrics.RecordRevalidationStaleServed()
 			return staleErr
 		}
-		return s.forwardAfterCacheMiss(ctx, w, r, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	}
 }
 
@@ -103,7 +103,15 @@ func (s *Service) revalidateAndServe(
 // survived). No response headers have been written yet, so this is safe for both
 // full-object and range requests — the Range header on r makes upstream return
 // the correct 206.
-func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, start time.Time) error {
+func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, start time.Time) error {
+	// Invalidate the orphaned metadata whose body was unresolvable. Without this
+	// the meta entry survives and every subsequent request is a meta-hit whose
+	// body probe fails and re-forwards to upstream — a persistent cold-miss loop,
+	// because the normal re-warm paths are gated on the metadata being absent.
+	// Deleting it makes the next request a clean miss that repopulates the cache.
+	if s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
 	w.Header().Set(XCacheHeader, XCacheMiss)
 	forwardErr := s.forwarder.Forward(ctx, w, r)
 	status := "success"

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -48,34 +48,31 @@ func (s *Service) revalidateAndServe(
 		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Revalidation failed, serving stale")
 		metrics.RecordRevalidationFailed()
 		metrics.RecordRevalidationStaleServed()
-		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			return staleErr
+		}
+		// No stale bytes available (versioned body gone) and nothing written yet —
+		// last-resort direct fetch so the client gets a real response.
+		return s.forwardAfterCacheMiss(ctx, w, r, start)
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusNotModified:
-		revalErr := s.handleRevalidation304(ctx, w, r, bucket, key, meta, rangeHeader, start)
-		if revalErr == nil {
-			return nil
-		}
-		// Cache body unavailable despite 304 — fall through to upstream.
-		// serveFromCache returns errors before committing headers, so we can
-		// safely write a new response. Range errors may have partial headers
-		// committed (serveRangeFromCache writes headers before streaming), so
-		// we return those directly.
-		if rangeHeader != "" {
+		served, revalErr := s.handleRevalidation304(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			// A response (full body, range, or a committed-then-failed stream) was
+			// produced; propagate its result. Headers are already sent on error, so
+			// we cannot safely forward.
 			return revalErr
 		}
+		// Cache body unavailable despite 304 and no response bytes written yet —
+		// fetch from upstream. The Range header (if any) is still on r, so upstream
+		// returns the correct 206; this unifies the full-object and range paths.
 		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
 			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
-		w.Header().Set(XCacheHeader, XCacheMiss)
-		forwardErr := s.forwarder.Forward(ctx, w, r)
-		status := "success"
-		if forwardErr != nil {
-			status = "error"
-		}
-		metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
-		return forwardErr
+		return s.forwardAfterCacheMiss(ctx, w, r, start)
 	case http.StatusOK:
 		// Full-object response (no range or upstream ignored range)
 		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
@@ -92,13 +89,38 @@ func (s *Service) revalidateAndServe(
 			Msg("Revalidation got unexpected status, serving stale")
 		metrics.RecordRevalidationFailed()
 		metrics.RecordRevalidationStaleServed()
-		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			return staleErr
+		}
+		return s.forwardAfterCacheMiss(ctx, w, r, start)
 	}
+}
+
+// forwardAfterCacheMiss fetches the object fresh from upstream when a
+// revalidation or stale-serve path could not produce any response bytes from
+// cache (typically the ETag-versioned body was evicted while its metadata
+// survived). No response headers have been written yet, so this is safe for both
+// full-object and range requests — the Range header on r makes upstream return
+// the correct 206.
+func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, start time.Time) error {
+	w.Header().Set(XCacheHeader, XCacheMiss)
+	forwardErr := s.forwarder.Forward(ctx, w, r)
+	status := "success"
+	if forwardErr != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	return forwardErr
 }
 
 // handleRevalidation304 handles a 304 Not Modified revalidation response.
 // Serves from cached body (or range if requested). Does not refresh cache TTL
 // because ocache has no TTL-refresh operation and re-writing data is inefficient.
+// It returns served=true when a client response was produced (a full body, a
+// range, or a committed stream that then failed). It returns served=false,
+// without writing any response bytes, when the cached body cannot be resolved —
+// the caller then fetches from upstream.
 func (s *Service) handleRevalidation304(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -107,21 +129,20 @@ func (s *Service) handleRevalidation304(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	start time.Time,
-) error {
+) (served bool, err error) {
 	metrics.RecordRevalidationNotModified()
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidation 304 - object unchanged")
 
-	// Serve range or full body from cache
+	// Serve range or full body from cache. Both serveRangeFromCache (via its
+	// pre-header probe) and serveFromCache report an unresolvable body without
+	// writing headers, so the caller can safely forward to upstream.
 	if rangeHeader != "" {
-		if served, err := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
-			return err
-		}
-		// Range body not resolvable from cache; serve the full cached object
-		// instead of a truncated 206 (serveFromCache probes the body and errors
-		// cleanly if it too is gone).
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable on revalidation - serving full cached object")
+		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 	}
-	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+	if bodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); bodyErr != nil {
+		return false, bodyErr
+	}
+	return true, nil
 }
 
 // handleRevalidation200 handles a 200 OK revalidation response (object changed).
@@ -344,7 +365,10 @@ func (s *Service) handleRevalidation206Range(
 	return copyErr
 }
 
-// serveStaleFromCache serves stale content from cache, handling both full and range requests.
+// serveStaleFromCache serves stale content from cache, handling both full and
+// range requests. It returns served=false, without writing any response bytes,
+// when the cached body cannot be resolved so the caller can fall back to a direct
+// upstream fetch instead of emitting a truncated or empty response.
 func (s *Service) serveStaleFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -353,16 +377,14 @@ func (s *Service) serveStaleFromCache(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	start time.Time,
-) error {
+) (served bool, err error) {
 	if rangeHeader != "" {
-		if served, err := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
-			return err
-		}
-		// Range body not resolvable from cache; serve the full cached object
-		// instead of a truncated 206.
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable on stale-serve - serving full cached object")
+		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 	}
-	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+	if bodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); bodyErr != nil {
+		return false, bodyErr
+	}
+	return true, nil
 }
 
 // revalidateAndServeHead sends a conditional HEAD to upstream for a HEAD request.

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -487,6 +487,7 @@ func TestServeFromCache_SmallObject(t *testing.T) {
 	meta := &cache.CachedObjectMeta{
 		Bucket:        bucket,
 		Key:           key,
+		ETag:          `"small"`,
 		ContentType:   "text/plain",
 		ContentLength: int64(len(body)),
 		StatusCode:    http.StatusOK,

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -703,7 +703,7 @@ func TestRevalidation304_CacheBodyUnavailable_FallsThrough(t *testing.T) {
 	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0)
 
 	// Delete only the body key to simulate cache body eviction
-	_ = memCache.Delete(ctx, cache.MakeBodyKey(bucket, key))
+	_ = memCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag))
 
 	// Execute revalidation — should fall through to Forward
 	w := httptest.NewRecorder()

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -565,6 +565,71 @@ func TestRevalidationRange304_ServesCachedRange(t *testing.T) {
 	}
 }
 
+// When a range revalidation gets a 304 but the ETag-versioned body has been
+// evicted (meta survives, body gone), the cache cannot serve the range. TAG must
+// forward the range to upstream — not return an error or a truncated 206.
+func TestRevalidationRange304_BodyEvictedForwardsUpstream(t *testing.T) {
+	const forwardBody = "UPSTREAM-RANGE"
+	forwarded := false
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+		forwardFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			forwarded = true
+			w.Header().Set("Content-Range", "bytes 0-13/100")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(forwardBody))
+			return nil
+		},
+	}
+
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	if err := c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0); err != nil {
+		t.Fatalf("PutWithMeta() error = %v", err)
+	}
+	// Evict ONLY the versioned body, keeping the metadata.
+	if err := memCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag)); err != nil {
+		t.Fatalf("evict body: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	r.Header.Set("Range", "bytes=0-4")
+	if err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now()); err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	if !forwarded {
+		t.Fatal("expected upstream Forward when the versioned body was evicted on a range 304")
+	}
+	if w.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPartialContent)
+	}
+	if w.Body.String() != forwardBody {
+		t.Errorf("body = %q, want %q (served from upstream)", w.Body.String(), forwardBody)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheMiss)
+	}
+}
+
 func TestRevalidationRange206_StreamsRangeFromUpstream(t *testing.T) {
 	// Setup: mock upstream returns 206 Partial Content (object changed, range returned)
 	rangeBody := "new range!"

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -24,6 +24,8 @@ type mockForwarder struct {
 	conditionalETag   string
 	// Optional Forward implementation for fallback tests
 	forwardFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+	// Optional ForwardWithCapture implementation for capture-gated tests
+	captureFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error)
 }
 
 func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
@@ -34,6 +36,9 @@ func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *h
 }
 
 func (m *mockForwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+	if m.captureFunc != nil {
+		return m.captureFunc(ctx, w, r)
+	}
 	return nil, nil
 }
 

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -628,6 +628,11 @@ func TestRevalidationRange304_BodyEvictedForwardsUpstream(t *testing.T) {
 	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
 		t.Errorf("X-Cache = %q, want %q", got, XCacheMiss)
 	}
+	// The orphaned meta (body gone) must be invalidated so subsequent requests are
+	// clean misses that repopulate, rather than looping through this same path.
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("orphaned metadata should be invalidated after body-gone upstream forward")
+	}
 }
 
 func TestRevalidationRange206_StreamsRangeFromUpstream(t *testing.T) {

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -99,6 +99,16 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// Forward to Tigris
 	err := s.forwarder.Forward(r.Context(), w, r)
 
+	// Re-invalidate AFTER upstream confirms the write. A GET that raced the
+	// in-flight PUT may have fetched the pre-PUT object and begun re-caching it;
+	// this second invalidation writes a tombstone newer than that write's start
+	// time, so the tombstone-aware cache write skips the stale repopulation —
+	// restoring read-after-write semantics.
+	if err == nil && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+		metrics.RecordCacheOperation("delete", "success")
+	}
+
 	status := "success"
 	if err != nil {
 		status = "error"
@@ -125,6 +135,15 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 
 	// Forward to upstream
 	err := s.forwarder.Forward(r.Context(), w, r)
+
+	// Re-invalidate AFTER upstream confirms the delete, for the same
+	// read-after-write reason as HandlePutObject: a GET racing the in-flight
+	// DELETE may have re-cached the not-yet-deleted object; this second
+	// tombstone blocks that stale repopulation.
+	if err == nil && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+		metrics.RecordCacheOperation("delete", "success")
+	}
 
 	status := "success"
 	if err != nil {

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -81,6 +81,42 @@ func (s *Service) releaseCacheSlot() {
 	<-s.cacheSemaphore
 }
 
+// statusRecorder wraps http.ResponseWriter to capture the response status code
+// written while forwarding an upstream response. Forward() returns nil even when
+// upstream responds 4xx/5xx (the response streamed successfully), so mutating
+// handlers use this to gate post-forward cache re-invalidation on an actual 2xx —
+// otherwise a rejected PUT/DELETE/COPY would still tombstone the destination and
+// discard a valid racing refill, causing later reads to miss unnecessarily.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rec *statusRecorder) WriteHeader(code int) {
+	rec.status = code
+	rec.ResponseWriter.WriteHeader(code)
+}
+
+func (rec *statusRecorder) Write(b []byte) (int, error) {
+	if rec.status == 0 {
+		rec.status = http.StatusOK
+	}
+	return rec.ResponseWriter.Write(b)
+}
+
+// Flush delegates to the underlying writer when it supports flushing, so wrapping
+// never disables streaming for handlers that rely on http.Flusher.
+func (rec *statusRecorder) Flush() {
+	if f, ok := rec.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// wroteSuccess reports whether upstream returned a 2xx status.
+func (rec *statusRecorder) wroteSuccess() bool {
+	return rec.status >= 200 && rec.status < 300
+}
+
 // HandlePutObject handles PUT requests for objects.
 // Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error {
@@ -96,17 +132,20 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 		metrics.RecordCacheOperation("delete", "success")
 	}
 
-	// Forward to Tigris
-	err := s.forwarder.Forward(r.Context(), w, r)
+	// Forward to Tigris, recording the upstream status.
+	rec := &statusRecorder{ResponseWriter: w}
+	err := s.forwarder.Forward(r.Context(), rec, r)
 
 	// Re-invalidate AFTER upstream confirms the write. A GET that raced the
 	// in-flight PUT may have fetched the pre-PUT object and begun re-caching it;
 	// this second invalidation writes a tombstone newer than that write's start
 	// time, so the tombstone-aware cache write skips the stale repopulation —
 	// restoring read-after-write semantics.
+	// Gated on a 2xx: a rejected PUT leaves the object unchanged, so re-invalidating
+	// would only discard a valid racing refill and cause an unnecessary later miss.
 	// The metric is recorded once on the pre-forward invalidation above; this
 	// second Delete is the same logical invalidation, so it is not counted again.
-	if err == nil && s.cache.IsEnabled() {
+	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
@@ -134,16 +173,19 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 		metrics.RecordCacheOperation("delete", "success")
 	}
 
-	// Forward to upstream
-	err := s.forwarder.Forward(r.Context(), w, r)
+	// Forward to upstream, recording the upstream status.
+	rec := &statusRecorder{ResponseWriter: w}
+	err := s.forwarder.Forward(r.Context(), rec, r)
 
 	// Re-invalidate AFTER upstream confirms the delete, for the same
 	// read-after-write reason as HandlePutObject: a GET racing the in-flight
 	// DELETE may have re-cached the not-yet-deleted object; this second
 	// tombstone blocks that stale repopulation.
+	// Gated on a 2xx: a rejected DELETE leaves the object present, so re-invalidating
+	// would only discard a valid racing refill and cause an unnecessary later miss.
 	// The metric is recorded once on the pre-forward invalidation above; this
 	// second Delete is the same logical invalidation, so it is not counted again.
-	if err == nil && s.cache.IsEnabled() {
+	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
@@ -239,18 +281,33 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
-	// Forward to upstream
-	err := s.forwarder.Forward(r.Context(), w, r)
+	// Forward to upstream, capturing the response so we can confirm the copy
+	// actually succeeded. CopyObject signals failure either with a non-2xx status
+	// or — famously — a 200 OK carrying an <Error> body, and Forward would report
+	// neither.
+	capture, err := s.forwarder.ForwardWithCapture(r.Context(), w, r)
 
 	// Re-invalidate the destination AFTER upstream confirms the copy, for the same
 	// read-after-write reason as HandlePutObject: a GET racing the in-flight copy
 	// may have re-cached the pre-copy destination object; this second tombstone
 	// blocks that stale repopulation.
-	if err == nil && s.cache.IsEnabled() {
+	// Gated on a confirmed-successful copy: a rejected copy leaves the destination
+	// unchanged, so re-invalidating would only discard a valid racing refill.
+	if err == nil && copyObjectSucceeded(capture) && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
 	return err
+}
+
+// copyObjectSucceeded reports whether a captured CopyObject response indicates the
+// copy actually happened: a 2xx status whose body is not an S3 <Error> document
+// (S3 can return 200 OK with an error body for copies that fail mid-operation).
+func copyObjectSucceeded(capture *ResponseCapture) bool {
+	if capture == nil || capture.StatusCode < 200 || capture.StatusCode >= 300 {
+		return false
+	}
+	return !isS3ErrorBody(capture.Body)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -104,9 +104,10 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// this second invalidation writes a tombstone newer than that write's start
 	// time, so the tombstone-aware cache write skips the stale repopulation —
 	// restoring read-after-write semantics.
+	// The metric is recorded once on the pre-forward invalidation above; this
+	// second Delete is the same logical invalidation, so it is not counted again.
 	if err == nil && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
-		metrics.RecordCacheOperation("delete", "success")
 	}
 
 	status := "success"
@@ -140,9 +141,10 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 	// read-after-write reason as HandlePutObject: a GET racing the in-flight
 	// DELETE may have re-cached the not-yet-deleted object; this second
 	// tombstone blocks that stale repopulation.
+	// The metric is recorded once on the pre-forward invalidation above; this
+	// second Delete is the same logical invalidation, so it is not counted again.
 	if err == nil && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
-		metrics.RecordCacheOperation("delete", "success")
 	}
 
 	status := "success"
@@ -238,7 +240,17 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	}
 
 	// Forward to upstream
-	return s.forwarder.Forward(r.Context(), w, r)
+	err := s.forwarder.Forward(r.Context(), w, r)
+
+	// Re-invalidate the destination AFTER upstream confirms the copy, for the same
+	// read-after-write reason as HandlePutObject: a GET racing the in-flight copy
+	// may have re-cached the pre-copy destination object; this second tombstone
+	// blocks that stale repopulation.
+	if err == nil && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
+
+	return err
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tag/cache"
 )
 
 // TestCache_HitWithMetadata verifies that cache hits return proper headers.
@@ -395,6 +396,51 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 
 	assert.Equal(t, []byte("ABCDEFGHIJ"), body4, "Second range request should return correct bytes")
 	env.AssertXCacheHit(t) // Second range request should also be served from cache
+}
+
+// TestCache_RangeBodyEvictedFallsThroughToUpstream verifies that when object
+// metadata is cached but its ETag-versioned body is gone (independently evicted,
+// or written by a pre-versioning build under a different key), a Range GET does
+// NOT emit a truncated 206 from cache — it forwards to upstream and returns the
+// correct bytes. Regression guard for the range-header-before-body-probe bug.
+func TestCache_RangeBodyEvictedFallsThroughToUpstream(t *testing.T) {
+	env := NewTestEnvironmentWithCache()
+	defer env.Close()
+
+	bucket := "cache-test-bucket"
+	key := "range-evicted.txt"
+	content := []byte("0123456789ABCDEFGHIJ") // 20 bytes
+	require.NoError(t, env.PutTestObject(bucket, key, content))
+
+	client := env.GetS3Client()
+	ctx := context.Background()
+
+	// Warm the cache with a full GET.
+	resp1, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+	require.NoError(t, err)
+	io.Copy(io.Discard, resp1.Body)
+	resp1.Body.Close()
+	require.True(t, env.WaitForCached(bucket, key, 2*time.Second), "object should be cached after first GET")
+
+	// Evict ONLY the versioned body, leaving metadata in place — the meta-present
+	// / body-absent state that made the range path commit a 206 over a truncated body.
+	meta, found, err := env.Cache.GetMeta(ctx, bucket, key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, env.EmbeddedCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag)))
+	require.True(t, env.IsCached(bucket, key), "metadata must still be present after body eviction")
+
+	// A Range GET must return the correct bytes (served from upstream), not a
+	// truncated or empty 206 from the cache.
+	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Range:  aws.String("bytes=5-14"),
+	})
+	require.NoError(t, err)
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	assert.Equal(t, []byte("56789ABCDE"), body2, "range must return correct bytes via upstream fallthrough")
 }
 
 // TestCache_RangeSingleByteAtZero verifies the byte-0 quirk handling.

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -692,16 +692,19 @@ func (e *TestEnvironment) ResetUpstreamRequestCount() {
 // GetCachedObject reads an object directly from the cache for test verification.
 // Returns (body, found). If not found or cache is disabled, returns (nil, false).
 func (e *TestEnvironment) GetCachedObject(bucket, key string) ([]byte, bool) {
-	if e.EmbeddedCache == nil {
+	if e.Cache == nil {
 		return nil, false
 	}
 
-	// Use the same key format as the cache package
-	bodyKey := "body|" + bucket + "|" + key
-	// Body is stored via PutStream, so we need to use GetStream to retrieve it
+	// Bodies are addressed by the object's ETag ("body|bucket|key|<etag>"), so
+	// resolve the current metadata first and read the body version it describes.
+	ctx := context.Background()
+	meta, found, err := e.Cache.GetMeta(ctx, bucket, key)
+	if err != nil || !found || meta == nil {
+		return nil, false
+	}
 	var buf bytes.Buffer
-	err := e.EmbeddedCache.GetStream(context.Background(), bodyKey, &buf)
-	if err != nil {
+	if err := e.Cache.GetBodyStream(ctx, bucket, key, meta.ETag, &buf); err != nil {
 		return nil, false
 	}
 	return buf.Bytes(), true


### PR DESCRIPTION
Root-cause fix for #92 (truncated/empty small-file bodies under concurrent read+write). Supersedes the closed mitigation PR #94.

## Problem

Each cached object is two independent entries — `meta|bucket|key` and `body|bucket|key` — with no version linkage, and the body slot is fixed (every rewrite overwrites it in place). For a constantly-rewritten hot key (Parseable's `manifest.json`, `.schema`, ingestor state), a reader can pair one version's metadata with another version's body:

1. **Truncation / wrong `Content-Length`** — meta_v1 (len 100) + body_v2 (50 bytes) → `request or response body errors`.
2. **Empty body / `cache body unavailable: EOF`** — a reader that got meta just before invalidation finds the body gone.
3. **Stale re-population (read-after-write)** — a GET racing an in-flight PUT re-caches the pre-PUT object.

## Fix

- **ETag-versioned body keys** — bodies live at `body|bucket|key|<etag>`; a reader derives the body address from `meta.ETag`, so a served meta always resolves to the exact body version it describes. Concurrent rewrites write a *new* meta + *new* body key and never clobber the version an in-flight reader resolved. **Torn pairs are impossible by construction** (races 1 & 2), small and large objects alike. No-ETag objects fall back to the unversioned key.
- **TTL-only body lifecycle** — bodies are **never deleted synchronously** (not on overwrite, not on invalidation). Each version is immutable and ages out via TTL, so a resolved meta always finds its body and no in-flight response can be truncated by a concurrent delete. Invalidation (`DeleteWithMeta`) removes only the metadata + writes a tombstone; that makes subsequent reads miss/refetch and blocks repopulation, while the body ages out.
- **Post-PUT/DELETE re-invalidation** — `HandlePutObject`/`HandleDeleteObject` re-invalidate *after* upstream acknowledges the write. The second tombstone blocks stale repopulation a racing GET started during the write window (race 3).

## Review-driven design note
A first pass used eager eviction (delete the superseded body on overwrite) to bound storage. The high-effort review showed that reintroduced a delete-during-read truncation window (confirmed for the range/206 path) and added a `GetMeta` read to every write. Switched to the **TTL-only** lifecycle above, which eliminates all three review findings. Trade-off: superseded body versions persist until TTL — negligible for the small metadata files in #92; a background reaper is the follow-up for large-object-heavy workloads.

## Migration
None. Old unversioned bodies become unreachable and age out via TTL; those reads miss and refill — a one-time miss bump on deploy, no correctness issue.

## Tests / verification
- `cache`: meta resolves to its own body even when another version's body exists (no torn pair); versions coexist after overwrite (no sync eviction); `DeleteWithMeta` removes meta but not body; empty-ETag fallback.
- `proxy`: post-PUT re-invalidation clears a racing repopulation.
- ✅ `make test`, `make test-race` (clean), `make vet`, `make lint-ci` all pass.

Closes #92.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core S3 object cache correctness and all GET/range/revalidation paths; mistakes could serve wrong bytes, truncated responses, or stale data after writes.
> 
> **Overview**
> Fixes torn meta/body pairs and read-after-write races under concurrent GETs and writes on hot keys (#92).
> 
> **ETag-versioned cache bodies** — Bodies are keyed by `body|bucket|key|<etag>`; reads use `meta.ETag` so metadata always pairs with the right bytes. Overwrites add new keys instead of clobbering in flight. **Invalidation drops metadata only** (plus tombstone); bodies age out via TTL and are not deleted on failed writes or tombstone skips, avoiding truncation of active readers. Empty-ETag objects are not cached (`IsCacheable` / `PutWithMeta`); versioned misses do not fall back to legacy unversioned body keys.
> 
> **Proxy consistency** — PUT/DELETE re-invalidate after successful upstream 2xx (`statusRecorder`); CopyObject and bulk delete use captured responses (including S3 200 + `<Error>`) so failed mutating ops do not tombstone valid racing refills. **Orphaned meta** (body evicted) is cleared and requests fall through to upstream; range-from-cache probes the body before sending 206.
> 
> Tests cover versioning guarantees, re-invalidation gating, and integration range fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc1c37d682e85e34f8eda4e61ac4d7e4a22dcc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->