### PR TITLE
Release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway)
+# TAG (Tigris Acceleration Gateway)
 
 High-performance S3-compatible caching proxy for Tigris object storage with embedded distributed cache.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TAG
 
-Thanks for your interest in contributing to TAG (Tigris Access Gateway)! This
+Thanks for your interest in contributing to TAG (Tigris Acceleration Gateway)! This
 document covers how to get set up, our conventions, and the contribution
 process.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway) Makefile
+# TAG (Tigris Acceleration Gateway) Makefile
 
 # Variables
 BINARY_NAME := tag
@@ -262,7 +262,7 @@ clean-all: clean rocksdb-static-clean
 # Help target
 .PHONY: help
 help:
-	@echo "TAG (Tigris Access Gateway) Makefile targets:"
+	@echo "TAG (Tigris Acceleration Gateway) Makefile targets:"
 	@echo ""
 	@echo "Build targets:"
 	@echo "  all             - Build the binary (default)"

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-TAG (Tigris Access Gateway)
+TAG (Tigris Acceleration Gateway)
 Copyright 2026 Tigris Data, Inc.
 
 This product includes software developed at Tigris Data, Inc.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TAG (Tigris Access Gateway)
+# TAG (Tigris Acceleration Gateway)
 
 TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigris.dev) object storage. It provides transparent caching with request coalescing to reduce upstream load and improve latency for frequently accessed objects.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.10.0/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.11.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ When multiple concurrent requests arrive for the same uncached object:
 
 See [docs/architecture.md](docs/architecture.md) for detailed architecture documentation.
 
+## Performance
+
+A single TAG node saturates a 100 Gbps NIC at **~85+ Gbps** for objects 1 MiB and larger, serves **~75K ops/sec** for small objects at sub-millisecond p50, and holds low single-digit-millisecond TTFB — all while using around **12% of available CPU**.
+
+| Object size | OPS (64 threads) | Throughput | TTFB p50 |
+| ----------- | ---------------- | ---------- | -------- |
+| 1 KiB       | ~75,700          | 74 MiB/s   | < 1 ms   |
+| 100 KiB     | ~33,300          | 3.2 GiB/s  | 1 ms     |
+| 1 MiB       | ~11,000          | 10.7 GiB/s | 1 ms     |
+| 4 MiB       | ~2,800           | 10.8 GiB/s | 1 ms     |
+
+Measured with [warp](https://github.com/minio/warp) against a single `i3en.24xlarge` node over a 100 Gbps link. See [docs/benchmarks.md](docs/benchmarks.md) for the full methodology, go-ycsb results, and limitations.
+
 ## Metrics
 
 TAG exposes Prometheus metrics at `/metrics` including request counts, latencies, cache hit/miss rates, and broadcast statistics.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -68,8 +68,22 @@ func (c *Cache) IsEnabled() bool {
 // IMPORTANT: Body is written BEFORE metadata to ensure metadata presence
 // guarantees body availability. This prevents race conditions where a reader
 // finds metadata but body hasn't been written yet.
+// Body lifecycle note: bodies are addressed by ETag and are never deleted
+// synchronously (not on overwrite, not on invalidation). Each version is an
+// immutable entry that ages out via TTL, so a reader that resolved a given
+// metadata version always finds its exact body — no delete-during-read can
+// truncate an in-flight response. Invalidation removes only the metadata (plus a
+// tombstone), which is enough to make subsequent reads miss and refetch.
 func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *CachedObjectMeta, body []byte, ttl int) error {
 	if !c.IsEnabled() {
+		return nil
+	}
+
+	// Objects without an ETag are not cached: bodies are addressed by ETag, and an
+	// ETag-less object would share a single unversioned body key that a concurrent
+	// overwrite could clobber in place. Callers gate on IsCacheable (which also
+	// excludes empty ETags); this is a defensive backstop for direct callers.
+	if meta.ETag == "" {
 		return nil
 	}
 
@@ -78,7 +92,7 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 	}
 
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
 
 	// Encode metadata as JSON
 	metaBytes, err := meta.Encode()
@@ -97,8 +111,10 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 	// Store metadata AFTER body is complete
 	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
-		// Try to clean up body on metadata failure
-		_ = c.client.Delete(ctx, bodyKey)
+		// Leave the versioned body to age out via TTL rather than deleting it
+		// synchronously: a concurrent populate of the same ETag could have a reader
+		// streaming this exact body key, and deleting it would truncate that reader.
+		// Without a visible meta entry the orphaned body is unreachable until it expires.
 		return err
 	}
 
@@ -135,7 +151,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	}
 
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, meta.ETag)
 
 	// Encode metadata first (fail fast if encoding fails)
 	metaBytes, err := meta.Encode()
@@ -161,14 +177,19 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 			Int64("tombstone_ts", tombTs).
 			Int64("write_start", writeStartTime).
 			Msg("Skipping meta write - tombstone detected after body stream")
-		_ = c.client.Delete(ctx, bodyKey) // Clean up orphaned body
+		// The just-written versioned body is left to age out via TTL rather than
+		// deleted synchronously: a concurrent populate of the same ETag could have
+		// a reader streaming this exact body key, and deleting it would truncate
+		// that reader. Without a visible meta entry the orphaned body is unreachable
+		// and harmless until it expires.
 		return nil
 	}
 
 	// Write metadata AFTER body (makes entry visible)
 	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
-		_ = c.client.Delete(ctx, bodyKey)
+		// Same rationale as the tombstone branch: leave the versioned body to TTL
+		// rather than risk truncating a concurrent same-version reader.
 		return err
 	}
 
@@ -222,14 +243,15 @@ func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectM
 
 // GetBodyStream streams the cached object body directly to the provided writer.
 // This avoids buffering the entire object in memory, which is critical for large objects.
-// Use this after GetMeta() to stream the body directly to the HTTP response.
-// Returns ErrNotFound if the body is not in cache.
-func (c *Cache) GetBodyStream(ctx context.Context, bucket, key string, w io.Writer) error {
+// Use this after GetMeta(), passing the meta's ETag so the body read resolves to
+// the exact version the metadata describes. Returns ErrNotFound if the body for
+// that version is not in cache.
+func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w io.Writer) error {
 	if !c.IsEnabled() {
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Stream body directly to writer - no intermediate buffer
 	err := c.client.GetStream(ctx, bodyKey, w)
@@ -263,19 +285,18 @@ func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	}
 
 	metaKey := MakeMetaKey(bucket, key)
-	bodyKey := MakeBodyKey(bucket, key)
 
-	// Delete metadata (ignore not found)
+	// Delete only the metadata. That is sufficient to make subsequent reads miss
+	// (a read resolves the body from meta.ETag, so with meta gone there is no body
+	// lookup), and the tombstone above blocks any in-flight repopulation. The
+	// versioned body is intentionally left to age out via TTL rather than deleted
+	// synchronously — deleting it could truncate an in-flight reader still
+	// streaming that exact version.
 	if err := c.client.Delete(ctx, metaKey); err != nil && !isNotFoundError(err) {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta delete error")
 	}
 
-	// Delete body (ignore not found)
-	if err := c.client.Delete(ctx, bodyKey); err != nil && !isNotFoundError(err) {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body delete error")
-	}
-
-	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Deleted from cache (meta+body)")
+	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Invalidated cache metadata (body ages out via TTL)")
 	return nil
 }
 
@@ -295,13 +316,14 @@ func (c *Cache) Delete(ctx context.Context, bucket, key string) error {
 // GetRangeStream retrieves a byte range from the cached object body.
 // Uses ocache's GetRangeStream for efficient partial reads from disk.
 // start and end are inclusive byte positions (HTTP Range semantics).
+// Pass the meta's ETag so the range resolves to the exact cached version.
 // Returns ErrNotFound if the object is not in cache.
-func (c *Cache) GetRangeStream(ctx context.Context, bucket, key string, start, end int64, w io.Writer) error {
+func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, start, end int64, w io.Writer) error {
 	if !c.IsEnabled() {
 		return ErrCacheDisabled
 	}
 
-	bodyKey := MakeBodyKey(bucket, key)
+	bodyKey := MakeBodyKey(bucket, key, etag)
 
 	// Handle ocache quirk: reading byte 0 alone requires reading 2 bytes
 	// and discarding the last byte

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -146,6 +146,17 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		return nil
 	}
 
+	// Objects without an ETag are not cached: they would share a single
+	// unversioned body key (MakeBodyKey(..., "")) that a concurrent overwrite could
+	// clobber in place, truncating an in-flight reader — the hazard ETag-versioned
+	// bodies exist to prevent. Callers gate on IsCacheable (which excludes empty
+	// ETags) before building the stream; this is a backstop matching PutWithMeta.
+	// Drain the body first so the producer side of the pipe never blocks.
+	if meta.ETag == "" {
+		_, _ = io.Copy(io.Discard, body)
+		return nil
+	}
+
 	if ttl == 0 {
 		ttl = int(c.defaultTTL)
 	}

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -1,0 +1,141 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/config"
+)
+
+func newVersioningTestCache(t *testing.T) (*Cache, cacheclient.CacheClient) {
+	t.Helper()
+	mem := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	return NewCacheWithClient(mem, &cfg.Cache), mem
+}
+
+// The core guarantee: metadata for one version always resolves to that version's
+// body, never a concurrently-written different version's body (no torn pair).
+func TestETagVersionedBody_MetaResolvesToItsOwnBody(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta1 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	if err := c.PutWithMeta(ctx, bucket, key, meta1, []byte("v1"), 60); err != nil {
+		t.Fatalf("PutWithMeta v1: %v", err)
+	}
+
+	// A concurrent writer stores a different version's body at its own key,
+	// without touching v1's body.
+	if err := mem.Put(ctx, MakeBodyKey(bucket, key, `"v2"`), []byte("VERSION-TWO"), 60); err != nil {
+		t.Fatalf("seed v2 body: %v", err)
+	}
+
+	// A reader holding meta_v1 must resolve to body_v1 — never the v2 body.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, meta1.ETag, &buf); err != nil {
+		t.Fatalf("GetBodyStream v1: %v", err)
+	}
+	if buf.String() != "v1" {
+		t.Errorf("meta_v1 resolved to %q, want %q (torn pair!)", buf.String(), "v1")
+	}
+}
+
+// Bodies are never deleted synchronously: after an overwrite, the superseded
+// version's body still exists (it ages out via TTL), so an in-flight reader that
+// resolved the old meta can still stream it without truncation.
+func TestETagVersionedBody_VersionsCoexistUntilTTL(t *testing.T) {
+	c, _ := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta1 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta1, []byte("v1"), 60)
+	meta2 := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v2"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta2, []byte("v2"), 60)
+
+	// Both versions' bodies remain readable — the old one is not evicted.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil || buf.String() != "v1" {
+		t.Errorf("v1 body after overwrite: err=%v body=%q, want it to still exist", err, buf.String())
+	}
+	buf.Reset()
+	if err := c.GetBodyStream(ctx, bucket, key, `"v2"`, &buf); err != nil || buf.String() != "v2" {
+		t.Errorf("v2 body: err=%v body=%q", err, buf.String())
+	}
+}
+
+// Invalidation removes only metadata; the body is left to age out via TTL so it
+// cannot truncate an in-flight reader still streaming that version.
+func TestETagVersionedBody_DeleteRemovesMetaNotBody(t *testing.T) {
+	c, _ := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("v1"), 60)
+
+	if err := c.DeleteWithMeta(ctx, bucket, key); err != nil {
+		t.Fatalf("DeleteWithMeta: %v", err)
+	}
+
+	// Meta is gone -> reads miss.
+	if _, ok, _ := c.GetMeta(ctx, bucket, key); ok {
+		t.Error("meta still present after DeleteWithMeta")
+	}
+	// Body still resolvable by its ETag (ages out via TTL) — a reader that
+	// resolved this version before the invalidation is not truncated.
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != nil || buf.String() != "v1" {
+		t.Errorf("body after DeleteWithMeta: err=%v body=%q, want it to survive", err, buf.String())
+	}
+}
+
+// A versioned (non-empty ETag) read must NEVER serve bytes from the legacy
+// unversioned key. Overwrites and invalidation leave that legacy entry in place
+// until TTL, so falling back to it could return older, unrelated bytes under
+// metadata that describes a newer version. A versioned-key miss must surface as
+// ErrNotFound so the caller refetches from upstream instead of serving stale data.
+func TestETagVersionedBody_VersionedMissDoesNotServeLegacyBody(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	// Seed a stale legacy unversioned body, with no matching versioned body.
+	if err := mem.Put(ctx, MakeBodyKey(bucket, key, ""), []byte("STALE-LEGACY"), 60); err != nil {
+		t.Fatalf("seed legacy body: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(ctx, bucket, key, `"v1"`, &buf); err != ErrNotFound {
+		t.Errorf("GetBodyStream returned err=%v body=%q, want ErrNotFound (no legacy fallback)", err, buf.String())
+	}
+	buf.Reset()
+	if err := c.GetRangeStream(ctx, bucket, key, `"v1"`, 0, 5, &buf); err != ErrNotFound {
+		t.Errorf("GetRangeStream returned err=%v body=%q, want ErrNotFound (no legacy fallback)", err, buf.String())
+	}
+}
+
+// Objects with no ETag are not cached at all: there is no version discriminator,
+// so caching them at a single unversioned key would reintroduce the in-place
+// overwrite / truncation hazard the ETag versioning was introduced to prevent.
+func TestETagVersionedBody_EmptyETagIsNotCached(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 4, StatusCode: 200}
+	if err := c.PutWithMeta(ctx, bucket, key, meta, []byte("body"), 60); err != nil {
+		t.Fatalf("PutWithMeta: %v", err)
+	}
+	// Neither meta nor body should have been written.
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("empty-ETag object should not be cached (meta present)")
+	}
+	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err == nil {
+		t.Error("empty-ETag object should not be cached (body present)")
+	}
+}

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -119,6 +119,29 @@ func TestETagVersionedBody_VersionedMissDoesNotServeLegacyBody(t *testing.T) {
 	}
 }
 
+// The streaming write path (the primary populate path) must also refuse empty-ETag
+// objects, and must drain the body so the producer side of the pipe doesn't block.
+func TestETagVersionedBody_EmptyETagNotCachedViaStream(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	body := bytes.NewReader([]byte("body-bytes"))
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 10, StatusCode: 200}
+	if err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1); err != nil {
+		t.Fatalf("PutWithMetaStreamTombstoneAware: %v", err)
+	}
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("empty-ETag object should not be cached via the streaming path (meta present)")
+	}
+	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err == nil {
+		t.Error("empty-ETag object should not be cached via the streaming path (body present)")
+	}
+	if body.Len() != 0 {
+		t.Errorf("body not drained: %d bytes remain (producer pipe would block)", body.Len())
+	}
+}
+
 // Objects with no ETag are not cached at all: there is no version discriminator,
 // so caching them at a single unversioned key would reintroduce the in-place
 // overwrite / truncation hazard the ETag versioning was introduced to prevent.

--- a/cache/object.go
+++ b/cache/object.go
@@ -217,10 +217,26 @@ func (m *CachedObjectMeta) IsModifiedSince(since time.Time) bool {
 	return objTime.After(since.Truncate(time.Second))
 }
 
-// normalizeETag strips quotes from ETag for comparison.
+// normalizeETag strips the weak prefix and quotes from an ETag for comparison.
+// This is a weak comparison (W/"abc" matches "abc"), used for conditional requests.
 func normalizeETag(etag string) string {
 	etag = strings.TrimPrefix(etag, "W/") // Remove weak validator prefix
 	etag = strings.Trim(etag, "\"")
+	return etag
+}
+
+// etagKeyComponent normalizes an ETag for use in a body cache key while PRESERVING
+// the weak/strong distinction. A weak validator (W/"abc") only asserts semantic
+// equivalence, so it can label different bytes than the strong validator "abc";
+// collapsing them (as normalizeETag does) would map both to one body key, letting a
+// later populate clobber the other version's bytes under an in-flight reader. Quotes
+// are stripped (they are only delimiters) but the weak marker is kept.
+func etagKeyComponent(etag string) string {
+	weak := strings.HasPrefix(etag, "W/")
+	etag = strings.Trim(strings.TrimPrefix(etag, "W/"), "\"")
+	if weak {
+		return "W/" + etag
+	}
 	return etag
 }
 
@@ -247,13 +263,14 @@ func MakeMetaKey(bucket, key string) string {
 // the object's ETag ("body|bucket|key|<etag>") so a served metadata entry always
 // maps to the exact body version it describes: a concurrent overwrite writes a
 // new meta plus a new body key and never clobbers the version an in-flight reader
-// resolved. Objects with no ETag fall back to the unversioned key (there is no
-// version discriminator available for them).
+// resolved. The ETag is normalized with etagKeyComponent, which keeps the
+// weak/strong distinction so different validators never collide on one key. Objects
+// with no ETag fall back to the unversioned key (no version discriminator exists).
 func MakeBodyKey(bucket, key, etag string) string {
 	if etag == "" {
 		return bodyKeyPrefix + bucket + "|" + key
 	}
-	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
+	return bodyKeyPrefix + bucket + "|" + key + "|" + etagKeyComponent(etag)
 }
 
 // MakeTombstoneKey creates the cache key for invalidation tombstones.

--- a/cache/object.go
+++ b/cache/object.go
@@ -168,6 +168,16 @@ func (m *CachedObjectMeta) IsPublicRead() bool {
 
 // IsCacheable returns true if the object should be cached based on headers.
 func (m *CachedObjectMeta) IsCacheable(maxSize int64) bool {
+	// Don't cache objects without an ETag. Bodies are addressed by ETag so each
+	// version gets an immutable key; without one, all versions would share a single
+	// unversioned body key that a concurrent overwrite could clobber in place,
+	// truncating an in-flight reader. Objects Tigris serves always carry an ETag, so
+	// this only excludes rare ETag-less responses (e.g. some non-Tigris upstreams in
+	// signing mode), which are forwarded uncached rather than cached unsafely.
+	if m.ETag == "" {
+		return false
+	}
+
 	// Don't cache if Cache-Control says not to
 	cc := strings.ToLower(m.CacheControl)
 	if strings.Contains(cc, "no-store") || strings.Contains(cc, "private") {
@@ -233,9 +243,17 @@ func MakeMetaKey(bucket, key string) string {
 	return metaKeyPrefix + bucket + "|" + key
 }
 
-// MakeBodyKey creates the cache key for object body.
-func MakeBodyKey(bucket, key string) string {
-	return bodyKeyPrefix + bucket + "|" + key
+// MakeBodyKey creates the cache key for an object body. Bodies are addressed by
+// the object's ETag ("body|bucket|key|<etag>") so a served metadata entry always
+// maps to the exact body version it describes: a concurrent overwrite writes a
+// new meta plus a new body key and never clobbers the version an in-flight reader
+// resolved. Objects with no ETag fall back to the unversioned key (there is no
+// version discriminator available for them).
+func MakeBodyKey(bucket, key, etag string) string {
+	if etag == "" {
+		return bodyKeyPrefix + bucket + "|" + key
+	}
+	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
 }
 
 // MakeTombstoneKey creates the cache key for invalidation tombstones.

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -104,6 +104,7 @@ func TestCachedObjectMeta_WriteHeaders(t *testing.T) {
 func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	tests := []struct {
 		name         string
+		etag         string
 		cacheControl string
 		contentLen   int64
 		maxSize      int64
@@ -111,13 +112,23 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	}{
 		{
 			name:         "cacheable object",
+			etag:         `"abc"`,
 			cacheControl: "max-age=3600",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
 			expected:     true,
 		},
 		{
+			name:         "no etag",
+			etag:         "",
+			cacheControl: "max-age=3600",
+			contentLen:   1024,
+			maxSize:      1024 * 1024,
+			expected:     false,
+		},
+		{
 			name:         "no-store",
+			etag:         `"abc"`,
 			cacheControl: "no-store",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -125,6 +136,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "private",
+			etag:         `"abc"`,
 			cacheControl: "private",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -132,6 +144,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "too large",
+			etag:         `"abc"`,
 			cacheControl: "max-age=3600",
 			contentLen:   10 * 1024 * 1024,
 			maxSize:      1024 * 1024,
@@ -139,6 +152,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "no cache control",
+			etag:         `"abc"`,
 			cacheControl: "",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -146,6 +160,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 		},
 		{
 			name:         "public cache control",
+			etag:         `"abc"`,
 			cacheControl: "public, max-age=3600",
 			contentLen:   1024,
 			maxSize:      1024 * 1024,
@@ -156,6 +171,7 @@ func TestCachedObjectMeta_IsCacheable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			obj := &CachedObjectMeta{
+				ETag:          tt.etag,
 				CacheControl:  tt.cacheControl,
 				ContentLength: tt.contentLen,
 			}
@@ -177,10 +193,15 @@ func TestMakeMetaKey(t *testing.T) {
 }
 
 func TestMakeBodyKey(t *testing.T) {
+	// No ETag falls back to the unversioned key.
 	expected := "body|my-bucket|path/to/object.txt"
-	result := MakeBodyKey("my-bucket", "path/to/object.txt")
+	result := MakeBodyKey("my-bucket", "path/to/object.txt", "")
 	if result != expected {
 		t.Errorf("MakeBodyKey() = %q, want %q", result, expected)
+	}
+	// With an ETag the body key is version-qualified (quotes/weak prefix stripped).
+	if got := MakeBodyKey("my-bucket", "path/to/object.txt", `"abc123"`); got != "body|my-bucket|path/to/object.txt|abc123" {
+		t.Errorf("MakeBodyKey(etag) = %q, want %q", got, "body|my-bucket|path/to/object.txt|abc123")
 	}
 }
 

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -199,9 +199,19 @@ func TestMakeBodyKey(t *testing.T) {
 	if result != expected {
 		t.Errorf("MakeBodyKey() = %q, want %q", result, expected)
 	}
-	// With an ETag the body key is version-qualified (quotes/weak prefix stripped).
+	// With an ETag the body key is version-qualified (quotes stripped).
 	if got := MakeBodyKey("my-bucket", "path/to/object.txt", `"abc123"`); got != "body|my-bucket|path/to/object.txt|abc123" {
 		t.Errorf("MakeBodyKey(etag) = %q, want %q", got, "body|my-bucket|path/to/object.txt|abc123")
+	}
+	// A weak validator and a strong validator with the same value must NOT collide:
+	// they can describe different bytes, so they get distinct body keys.
+	strong := MakeBodyKey("b", "k", `"abc"`)
+	weak := MakeBodyKey("b", "k", `W/"abc"`)
+	if strong == weak {
+		t.Errorf("weak and strong ETag share a body key %q — different validators must differ", strong)
+	}
+	if weak != "body|b|k|W/abc" {
+		t.Errorf("MakeBodyKey(weak) = %q, want %q", weak, "body|b|k|W/abc")
 	}
 }
 

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for TAG (Tigris Access Gateway).
+// Package main is the entry point for TAG (Tigris Acceleration Gateway).
 package main
 
 import (
@@ -49,7 +49,7 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: tag [options]\n\n")
-		fmt.Fprintf(os.Stderr, "TAG (Tigris Access Gateway) - S3-compatible caching proxy for Tigris\n\n")
+		fmt.Fprintf(os.Stderr, "TAG (Tigris Acceleration Gateway) - S3-compatible caching proxy for Tigris\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		fmt.Fprintf(os.Stderr, "  --version              Print version information and exit\n")
 		fmt.Fprintf(os.Stderr, "  --config PATH          Path to YAML configuration file\n")
@@ -65,7 +65,7 @@ func main() {
 
 	// Handle --version before any config loading
 	if *showVersion {
-		fmt.Printf("TAG (Tigris Access Gateway)\n")
+		fmt.Printf("TAG (Tigris Acceleration Gateway)\n")
 		fmt.Printf("  Version:    %s\n", Version)
 		fmt.Printf("  Build Time: %s\n", BuildTime)
 		fmt.Printf("  Git Commit: %s\n", GitCommit)
@@ -169,7 +169,7 @@ func main() {
 			Str("level", cfg.Log.Level).
 			Str("format", cfg.Log.Format),
 		).
-		Msg("Starting TAG (Tigris Access Gateway)")
+		Msg("Starting TAG (Tigris Acceleration Gateway)")
 
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/tag/main_test.go
+++ b/cmd/tag/main_test.go
@@ -31,7 +31,7 @@ func TestVersionFlag(t *testing.T) {
 
 	output := string(out)
 	for _, expected := range []string{
-		"TAG (Tigris Access Gateway)",
+		"TAG (Tigris Acceleration Gateway)",
 		"Version:",
 		"Build Time:",
 		"Git Commit:",

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,15 @@ const (
 	// DefaultCacheMaxConcurrentWrites is the default ceiling on concurrent
 	// cache-populate operations.
 	DefaultCacheMaxConcurrentWrites = 256
+
+	// DefaultCacheMaxPopulateMemoryBytes bounds the aggregate memory buffered by
+	// concurrent cache-populate operations (1 GiB). Each populate reserves the
+	// object's size, capped at the per-populate buffer ceiling (roughly
+	// (channel_buffer + max(channel_buffer/4, 64)) × chunk_size). A byte-unaware
+	// count alone (MaxConcurrentWrites) can pin gigabytes under large-object
+	// fan-out — e.g. 256 large populates × ~80 MB ≈ 20 GB — so this budget, not the
+	// count, is what actually bounds populate memory.
+	DefaultCacheMaxPopulateMemoryBytes = 1 << 30
 )
 
 // Config holds all configuration for TAG.
@@ -162,6 +171,17 @@ type CacheConfig struct {
 	// unbounded. 0 or unset uses DefaultCacheMaxConcurrentWrites; a negative
 	// value disables the limit.
 	MaxConcurrentWrites int `yaml:"max_concurrent_writes"`
+	// MaxPopulateMemoryBytes bounds the aggregate memory buffered by concurrent
+	// cache-populate operations. Each populate reserves its object size, capped at
+	// the per-populate buffer ceiling (~(channel_buffer + max(channel_buffer/4, 64))
+	// × chunk_size), against this budget; when it can't fit, the object is served
+	// from upstream uncached. Small objects reserve little (high concurrency) while
+	// a burst of large objects is throttled — this is what actually bounds populate
+	// memory, since a byte-unaware count can pin many GB under large-object fan-out.
+	// Applied independently of MaxConcurrentWrites (both limits apply). 0 or unset
+	// uses DefaultCacheMaxPopulateMemoryBytes; a negative value disables the memory
+	// cap (count-only, prior behavior).
+	MaxPopulateMemoryBytes int64 `yaml:"max_populate_memory_bytes"`
 }
 
 // IsEnabled returns whether caching is enabled.
@@ -195,7 +215,7 @@ func (c *CacheConfig) SetGRPCAuth(enabled bool) {
 // BroadcastConfig holds streaming broadcast configuration for request coalescing.
 type BroadcastConfig struct {
 	ChunkSize     int `yaml:"chunk_size"`     // Size of chunks for streaming (default: 64KB)
-	ChannelBuffer int `yaml:"channel_buffer"` // Buffer size per listener in chunks (default: 32)
+	ChannelBuffer int `yaml:"channel_buffer"` // Buffer size per listener in chunks (default: 1024, ~64MB at 64KB chunks)
 }
 
 // LogConfig holds logging configuration.
@@ -296,6 +316,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Cache.MaxConcurrentWrites == 0 {
 		cfg.Cache.MaxConcurrentWrites = DefaultCacheMaxConcurrentWrites
 	}
+	if cfg.Cache.MaxPopulateMemoryBytes == 0 {
+		cfg.Cache.MaxPopulateMemoryBytes = DefaultCacheMaxPopulateMemoryBytes
+	}
 
 	// Broadcast defaults
 	if cfg.Broadcast.ChunkSize == 0 {
@@ -385,6 +408,12 @@ func applyEnvOverrides(cfg *Config) {
 		if val := os.Getenv("TAG_CACHE_MAX_CONCURRENT_WRITES"); val != "" {
 			if n, err := strconv.Atoi(val); err == nil && n > 0 {
 				cfg.Cache.MaxConcurrentWrites = n
+			}
+		}
+		// Override cache-populate memory budget from environment (negative disables)
+		if val := os.Getenv("TAG_CACHE_MAX_POPULATE_MEMORY"); val != "" {
+			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n != 0 {
+				cfg.Cache.MaxPopulateMemoryBytes = n
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -267,6 +267,56 @@ cache:
 	}
 }
 
+func TestLoad_CachePopulateMemoryDefault(t *testing.T) {
+	content := "cache:\n  enabled: true\n"
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cache.MaxPopulateMemoryBytes != DefaultCacheMaxPopulateMemoryBytes {
+		t.Errorf("Cache.MaxPopulateMemoryBytes = %d, want %d", cfg.Cache.MaxPopulateMemoryBytes, DefaultCacheMaxPopulateMemoryBytes)
+	}
+}
+
+func TestLoad_CachePopulateMemoryOverrideByEnv(t *testing.T) {
+	content := "cache:\n  enabled: true\n"
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	// A negative value disables the memory cap (count-only).
+	t.Setenv("TAG_CACHE_MAX_POPULATE_MEMORY", "-1")
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cache.MaxPopulateMemoryBytes != -1 {
+		t.Errorf("Cache.MaxPopulateMemoryBytes = %d, want -1 (disabled)", cfg.Cache.MaxPopulateMemoryBytes)
+	}
+}
+
+func TestLoad_CachePopulateMemoryFromYAML(t *testing.T) {
+	content := "cache:\n  enabled: true\n  max_populate_memory_bytes: 536870912\n"
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cache.MaxPopulateMemoryBytes != 536870912 {
+		t.Errorf("Cache.MaxPopulateMemoryBytes = %d, want 536870912", cfg.Cache.MaxPopulateMemoryBytes)
+	}
+}
+
 func TestLoad_StorageTuningInvalidEnvIgnored(t *testing.T) {
 	content := `
 cache:

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -1,4 +1,4 @@
-# Docker Compose for TAG (Tigris Access Gateway) — released image
+# Docker Compose for TAG (Tigris Acceleration Gateway) — released image
 #
 # Pulls the published tigrisdata/tag image instead of building from source.
 # For the build-from-source variant, use docker-compose.yml.

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.9.4
+    newTag: v1.11.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.9.4
+          image: tigrisdata/tag:v1.11.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Docker Compose for TAG (Tigris Access Gateway)
+# Docker Compose for TAG (Tigris Acceleration Gateway)
 #
 # TAG uses embedded OCache - no separate cache server needed.
 #

--- a/docs/CLA.md
+++ b/docs/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement
 
-Thank you for your interest in contributing to TAG (Tigris Access Gateway),
+Thank you for your interest in contributing to TAG (Tigris Acceleration Gateway),
 a project of Tigris Data, Inc. ("Tigris"). This Contributor License Agreement
 ("Agreement") documents the rights granted by contributors to Tigris. This is a
 legally binding document, so please read it carefully before agreeing to it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # TAG Architecture
 
-This document describes the architecture of TAG (Tigris Access Gateway), a high-performance S3-compatible caching proxy with an embedded distributed cache.
+This document describes the architecture of TAG (Tigris Acceleration Gateway), a high-performance S3-compatible caching proxy with an embedded distributed cache.
 
 ## System Overview
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                               | `1000`                   |
 | `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                      | `16`                     |
 | `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                        | `256`                    |
+| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for concurrent cache-populate buffering         | `1073741824` (1 GiB)     |
 | `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrently-served S3 requests before shedding with 503 SlowDown           | `1024`                   |
 | `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
 | `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                 | `json`                   |
@@ -157,6 +158,17 @@ cache:
   # Override with TAG_CACHE_MAX_CONCURRENT_WRITES env var
   max_concurrent_writes: 256
 
+  # Aggregate memory budget for concurrent cache-populate buffering. Each populate
+  # reserves its object size (capped at the per-populate buffer ceiling,
+  # ~(channel_buffer + max(channel_buffer/4, 64)) x chunk_size) against this budget;
+  # when it can't fit, the object is served from upstream uncached. Small objects
+  # reserve little (high concurrency) while a burst of large objects is throttled.
+  # Applied independently of max_concurrent_writes (both limits apply). This is what
+  # actually bounds populate memory — a byte-unaware count can pin many GB.
+  # Default: 1073741824 (1 GiB) (0 or unset = default; negative = memory cap disabled)
+  # Override with TAG_CACHE_MAX_POPULATE_MEMORY env var
+  max_populate_memory_bytes: 1073741824
+
 # Broadcast configuration (request coalescing)
 broadcast:
   # Chunk size for streaming (in bytes)
@@ -286,6 +298,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `delete_batch_size`     | int      | `1000`           | File deletions processed per deletion-queue batch                                   |
 | `recovery_workers`      | int      | `16`             | Parallel workers for startup file recovery                                          |
 | `max_concurrent_writes` | int      | `256`            | Max concurrent cache-populate operations (`0`/unset = default, negative = disabled) |
+| `max_populate_memory_bytes` | int  | `1073741824`     | Aggregate memory budget for concurrent cache-populate buffering; each populate reserves its size (capped at the buffer ceiling), applied independently of `max_concurrent_writes` (`0`/unset = default 1 GiB, negative = memory cap disabled) |
 
 **TTL Format:**
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.9.3
+    newTag: v1.11.0
 ```
 
 ## Production Considerations

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.9.4
+    image: tigrisdata/tag:v1.11.0
     ports:
       - "8080:8080"
     environment:

--- a/proxy/body_gone_test.go
+++ b/proxy/body_gone_test.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestBodyGone pins the denylist contract: only transient failures (where the
+// cached body is probably fine and we merely couldn't finish reading it) skip the
+// heal. Every other error invalidates the orphaned metadata — the cache reports an
+// unusable body in several shapes, and missing one leaves meta outliving its body,
+// which forwards every request upstream until the meta TTL expires.
+func TestBodyGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error is not gone", nil, false},
+
+		// Unusable body — must heal.
+		{"body missing", cache.ErrNotFound, true},
+		{"wrapped body missing", fmt.Errorf("cache body unavailable: %w", cache.ErrNotFound), true},
+		{"empty stream reads as EOF", io.EOF, true},
+		{"wrapped empty stream", fmt.Errorf("cache body unavailable: %w", io.EOF), true},
+		{"body shorter than metadata claims", status.Error(codes.InvalidArgument, "invalid range"), true},
+		{"plain empty-body error", errors.New("cache body empty for b/k"), true},
+
+		// Transient — must NOT evict a still-valid entry.
+		{"canceled context", context.Canceled, false},
+		{"wrapped canceled context", fmt.Errorf("cache body unavailable: %w", context.Canceled), false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"grpc canceled (cluster read)", status.Error(codes.Canceled, "context canceled"), false},
+		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "deadline"), false},
+		{"grpc peer unavailable", status.Error(codes.Unavailable, "connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bodyGone(tt.err); got != tt.want {
+				t.Errorf("bodyGone(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// A metadata entry whose versioned body is present but ZERO bytes is inconsistent.
+// ocache surfaces this as an out-of-range read rather than a clean EOF, so it must
+// still heal — otherwise the orphaned meta survives and every request re-probes and
+// forwards upstream until its TTL expires.
+func TestServeRangeFromCache_EmptyBodyReportsGone(t *testing.T) {
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(&mockForwarder{}, c, cfg)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &cache.CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"e1"`, ContentLength: 100, StatusCode: 200}
+	// Seed a zero-byte body at the versioned key while meta claims 100 bytes.
+	if err := memCache.Put(ctx, cache.MakeBodyKey(bucket, key, meta.ETag), []byte{}, 60); err != nil {
+		t.Fatalf("seed empty body: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	served, err := svc.serveRangeFromCache(ctx, w, r, bucket, key, meta, "bytes=0-9", time.Now())
+	if served {
+		t.Fatal("an empty body must not be served as a 206")
+	}
+	if !bodyGone(err) {
+		t.Errorf("serveRangeFromCache err = %v, bodyGone = false; want true so the orphaned meta heals", err)
+	}
+}

--- a/proxy/cache_slot_test.go
+++ b/proxy/cache_slot_test.go
@@ -1,36 +1,178 @@
 package proxy
 
-import "testing"
+import (
+	"testing"
 
-// TestService_CacheSlotLimit verifies the concurrent-cache-write limiter admits
-// up to its capacity, rejects beyond it (so callers skip caching instead of
-// spawning unbounded populate work), and frees slots on release.
-func TestService_CacheSlotLimit(t *testing.T) {
+	"github.com/tigrisdata/tag/config"
+)
+
+// TestService_CacheSlotCountLimit verifies the count ceiling admits up to its
+// capacity, rejects beyond it (so callers skip caching instead of spawning
+// unbounded populate work), and frees slots on release.
+func TestService_CacheSlotCountLimit(t *testing.T) {
 	s := &Service{cacheSemaphore: make(chan struct{}, 2)}
 
-	if !s.acquireCacheSlot() {
+	if !s.acquireCacheSlot(1) {
 		t.Fatal("1st acquire should succeed")
 	}
-	if !s.acquireCacheSlot() {
+	if !s.acquireCacheSlot(1) {
 		t.Fatal("2nd acquire should succeed")
 	}
-	if s.acquireCacheSlot() {
-		t.Fatal("3rd acquire should fail when the limit (2) is reached")
+	if s.acquireCacheSlot(1) {
+		t.Fatal("3rd acquire should fail when the count limit (2) is reached")
 	}
 
-	s.releaseCacheSlot()
-	if !s.acquireCacheSlot() {
+	s.releaseCacheSlot(1)
+	if !s.acquireCacheSlot(1) {
 		t.Fatal("acquire after release should succeed")
 	}
 }
 
-// TestService_CacheSlotUnlimited verifies a nil semaphore disables the limit.
+// TestService_CacheSlotUnlimited verifies nil limiters disable both caps.
 func TestService_CacheSlotUnlimited(t *testing.T) {
-	s := &Service{cacheSemaphore: nil}
-	for i := 0; i < 100; i++ {
-		if !s.acquireCacheSlot() {
-			t.Fatal("nil semaphore must always admit")
+	s := &Service{} // nil cacheSemaphore and nil populateBudget
+	for range 100 {
+		if !s.acquireCacheSlot(1 << 30) {
+			t.Fatal("nil limiters must always admit")
 		}
 	}
-	s.releaseCacheSlot() // must be a no-op, not panic
+	s.releaseCacheSlot(1 << 30) // must be a no-op, not panic
+}
+
+// TestService_CacheSlotByteBudget verifies the byte budget admits until the
+// aggregate reserved bytes would exceed it, independent of the count, and that
+// releasing bytes frees capacity.
+func TestService_CacheSlotByteBudget(t *testing.T) {
+	// Count effectively unlimited (large), budget = 100 bytes.
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 1000),
+		populateBudget: newByteBudget(100),
+	}
+
+	if !s.acquireCacheSlot(60) {
+		t.Fatal("reserve 60/100 should succeed")
+	}
+	if !s.acquireCacheSlot(40) {
+		t.Fatal("reserve 40 more (100/100) should succeed")
+	}
+	if s.acquireCacheSlot(1) {
+		t.Fatal("reserve beyond the byte budget should fail")
+	}
+	// A rejected acquire must not leak the count slot it briefly took.
+	s.releaseCacheSlot(40) // free 40 bytes
+	if !s.acquireCacheSlot(40) {
+		t.Fatal("acquire after releasing bytes should succeed")
+	}
+}
+
+// TestService_CacheSlotByteBudgetReleasesCountOnByteReject verifies that when the
+// byte budget rejects, the count slot taken first is handed back (no leak).
+func TestService_CacheSlotByteBudgetReleasesCountOnByteReject(t *testing.T) {
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 1),
+		populateBudget: newByteBudget(10),
+	}
+	// Byte budget too small — acquire must fail and free the single count slot.
+	if s.acquireCacheSlot(1000) {
+		t.Fatal("acquire should fail when weight exceeds the byte budget")
+	}
+	// The count slot must be available again.
+	if !s.acquireCacheSlot(5) {
+		t.Fatal("count slot leaked after byte-budget rejection")
+	}
+}
+
+// TestPopulateWeight verifies the reserved weight is the object size capped at the
+// per-populate buffer ceiling, with unknown sizes reserving the ceiling and a
+// budget clamp so an over-large object still populates one-at-a-time.
+func TestPopulateWeight(t *testing.T) {
+	s := &Service{
+		perPopulateCap: 80 << 20, // 80MB ceiling
+		config:         &config.Config{},
+	}
+	s.config.Cache.MaxPopulateMemoryBytes = 1 << 30 // 1 GiB budget
+
+	tests := []struct {
+		name          string
+		contentLength int64
+		want          int64
+	}{
+		{"small object reserves its size", 4096, 4096},
+		{"unknown size reserves the ceiling", -1, 80 << 20},
+		{"zero size reserves the ceiling", 0, 80 << 20},
+		{"large object capped at ceiling", 500 << 20, 80 << 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.populateWeight(tt.contentLength); got != tt.want {
+				t.Errorf("populateWeight(%d) = %d, want %d", tt.contentLength, got, tt.want)
+			}
+		})
+	}
+
+	// Budget smaller than the ceiling: an object bigger than the whole budget is
+	// clamped to the budget so it can still populate one at a time.
+	s.config.Cache.MaxPopulateMemoryBytes = 1 << 20 // 1 MiB budget < 80MB ceiling
+	if got := s.populateWeight(-1); got != 1<<20 {
+		t.Errorf("populateWeight(-1) with 1MiB budget = %d, want %d", got, 1<<20)
+	}
+}
+
+// TestService_BackgroundReservationClampedToBudget guards against the background
+// path reserving the raw ceiling: when the budget is smaller than the per-populate
+// ceiling, a background populate (unknown size) must still admit — one at a time —
+// via populateWeight's budget clamp, not fail admission entirely.
+func TestService_BackgroundReservationClampedToBudget(t *testing.T) {
+	const budget = 8 << 20 // 8MB budget, below the 80MB ceiling
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 256),
+		populateBudget: newByteBudget(budget),
+		perPopulateCap: 80 << 20,
+		config:         &config.Config{},
+	}
+	s.config.Cache.MaxPopulateMemoryBytes = budget
+
+	w := s.populateWeight(-1) // what fetchFullObjectToCache reserves
+	if w != budget {
+		t.Fatalf("populateWeight(-1) = %d, want %d (clamped to budget)", w, budget)
+	}
+	if !s.acquireCacheSlot(w) {
+		t.Fatal("background populate should admit one-at-a-time when budget < ceiling")
+	}
+	if s.acquireCacheSlot(s.populateWeight(-1)) {
+		t.Fatal("second concurrent background populate should be throttled by the full budget")
+	}
+	s.releaseCacheSlot(w)
+	if !s.acquireCacheSlot(s.populateWeight(-1)) {
+		t.Fatal("after release the next background populate should admit")
+	}
+}
+
+// TestPerPopulateBufferBytes verifies the per-populate ceiling accounts for the
+// broadcast listener channel plus the cache-write queue's 64-chunk floor.
+func TestPerPopulateBufferBytes(t *testing.T) {
+	mk := func(chunk, channelBuf int) *config.Config {
+		c := &config.Config{}
+		c.Broadcast.ChunkSize = chunk
+		c.Broadcast.ChannelBuffer = channelBuf
+		return c
+	}
+
+	// Defaults: (1024 + 256) * 64KB.
+	if got, want := perPopulateBufferBytes(mk(64*1024, 1024)), int64(1024+256)*64*1024; got != want {
+		t.Errorf("perPopulateBufferBytes(default) = %d, want %d", got, want)
+	}
+	// Small channel_buffer: queue is floored at 64, not channelBuf/4=4.
+	if got, want := perPopulateBufferBytes(mk(64*1024, 16)), int64(16+64)*64*1024; got != want {
+		t.Errorf("perPopulateBufferBytes(channelBuf=16) = %d, want %d (64-chunk floor)", got, want)
+	}
+	// chunk_size below the pool size is charged at DefaultChunkSize: queued chunks
+	// retain pooled 64KB backing arrays regardless of the configured chunk_size.
+	if got, want := perPopulateBufferBytes(mk(16*1024, 1024)), int64(1024+256)*64*1024; got != want {
+		t.Errorf("perPopulateBufferBytes(chunk=16KB) = %d, want %d (pool floor, not 16KB)", got, want)
+	}
+	// Zero broadcast values fall back to defaults.
+	if got, want := perPopulateBufferBytes(mk(0, 0)), int64(1024+256)*64*1024; got != want {
+		t.Errorf("perPopulateBufferBytes(zero) = %d, want %d (defaults)", got, want)
+	}
 }

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -95,6 +95,7 @@ func (s *Service) setupCacheListener(
 	bucket, key string,
 	broadcaster *broadcast.Broadcaster,
 	slotHeld bool,
+	weight int64,
 ) (*io.PipeWriter, chan error) {
 	// Bound concurrent cache-populate operations. When the limit is saturated,
 	// skip caching entirely: the object is still served/forwarded from upstream,
@@ -103,9 +104,10 @@ func (s *Service) setupCacheListener(
 	// growing without bound under load. slotHeld is true when the caller has
 	// already reserved a slot (the background path reserves it before the upstream
 	// request); once past this point the slot is owned by this function and is
-	// released on the no-listener path below or by the populate goroutine.
+	// released on the no-listener path below or by the populate goroutine. weight is
+	// the byte reservation (matching what was/should be acquired) to release.
 	if !slotHeld {
-		if !s.acquireCacheSlot() {
+		if !s.acquireCacheSlot(weight) {
 			metrics.CachePopulateSkipped.Inc()
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache populate - concurrent write limit reached")
 			return nil, nil
@@ -117,7 +119,7 @@ func (s *Service) setupCacheListener(
 
 	listener := broadcaster.Subscribe()
 	if listener == nil {
-		s.releaseCacheSlot()
+		s.releaseCacheSlot(weight)
 		return nil, nil
 	}
 
@@ -127,7 +129,7 @@ func (s *Service) setupCacheListener(
 
 	// Start goroutine to consume chunks, build metadata, and write to cache
 	go func() {
-		defer s.releaseCacheSlot()
+		defer s.releaseCacheSlot(weight)
 		defer close(errCh)
 
 		// Wait for headers to build metadata
@@ -292,14 +294,21 @@ func (s *Service) fetchFullObjectToCache(
 	// rather than fetch and then discard the result under the very pressure the
 	// limit is meant to relieve. errCachePopulateDeclined distinguishes this
 	// deliberate skip from a real fetch success/failure for the caller's metrics.
-	if !s.acquireCacheSlot() {
+	// Background fetches warm the full object and the size isn't known until the
+	// response arrives, so reserve the per-populate buffer ceiling up front (via
+	// populateWeight, which clamps to the budget so warming still runs — one at a
+	// time — when the budget is smaller than the ceiling). This throttles a burst of
+	// large-object warms to keep buffered memory bounded (small objects, cached
+	// inline, reserve their actual size instead).
+	weight := s.populateWeight(-1)
+	if !s.acquireCacheSlot(weight) {
 		metrics.CachePopulateSkipped.Inc()
 		return errCachePopulateDeclined
 	}
 	slotOwned := true
 	defer func() {
 		if slotOwned {
-			s.releaseCacheSlot()
+			s.releaseCacheSlot(weight)
 		}
 	}()
 
@@ -334,7 +343,7 @@ func (s *Service) fetchFullObjectToCache(
 	// Hand the reserved slot to the cache listener (streams to cache via pipe).
 	// Ownership of releasing the slot transfers to setupCacheListener, so drop
 	// our own release regardless of the result.
-	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster, true)
+	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster, true, weight)
 	slotOwned = false
 	if cachePipeWriter == nil {
 		// No listener could be created; nothing to populate.

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy/broadcast"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // signalingReader wraps an io.Reader and signals when the first Read() is called.
@@ -64,6 +66,41 @@ const (
 // It is distinct from a fetch failure so callers do not record it as either a
 // success or a failure.
 var errCachePopulateDeclined = errors.New("cache populate declined: concurrent write limit reached")
+
+// bodyGone reports whether a failed cache-body read should invalidate the metadata
+// that pointed at it, letting the orphaned entry heal (and unblocking the
+// GetMeta(!found)-gated re-warm).
+//
+// It is deliberately a denylist of transient errors rather than an allowlist of
+// "body missing" ones. The cache signals an unusable body in more ways than can be
+// reliably enumerated — not-found, a stream that ends with no bytes (io.EOF), an
+// out-of-range read against a body shorter than its metadata claims (ocache returns
+// InvalidArgument) — and missing any one of them lets metadata outlive its body, so
+// every request re-probes, fails, and forwards upstream until the metadata TTL
+// expires (up to 24h). That cold-miss loop is the severe, persistent failure.
+//
+// The errors that must NOT evict are the transient ones, where the cached body is
+// probably fine and we merely could not finish reading it — overwhelmingly a
+// canceled context from a client that disconnected mid-stream (in cluster mode the
+// read is routed over gRPC, so it can arrive as a status code instead of a plain
+// context error), or a briefly unreachable peer. Those leave the entry alone.
+// Anything else heals the entry; the worst case is one extra miss on a rare I/O
+// error, which repopulates immediately — a far better trade than a 24h loop.
+func bodyGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Canceled, codes.DeadlineExceeded, codes.Unavailable:
+			return false
+		}
+	}
+	return true
+}
 
 // cacheWriteTimeoutForSize returns a timeout scaled to contentLength.
 // Returns at least cacheWriteTimeout (60s), scaling up for large objects.

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -30,8 +30,9 @@ type deleteObjectEntry struct {
 }
 
 // deleteObjectsResult represents the S3 DeleteObjects response. Only the per-object
-// <Error> entries are captured: successful deletes may be omitted (Quiet mode), so
-// success is derived as "requested minus errored".
+// <Error> entries are captured: successful deletes may be omitted (Quiet mode), but
+// errors are always listed in both modes, so a key had at least one successful
+// delete iff more entries were requested for it than upstream reported as errored.
 type deleteObjectsResult struct {
 	XMLName xml.Name `xml:"DeleteResult"`
 	Errors  []struct {
@@ -39,19 +40,22 @@ type deleteObjectsResult struct {
 	} `xml:"Error"`
 }
 
-// failedDeleteKeys returns the set of keys upstream reported as NOT deleted. On a
-// parse failure it returns an empty set, so callers re-invalidate all requested
-// keys — the safe over-invalidation.
-func failedDeleteKeys(body []byte) map[string]struct{} {
-	failed := make(map[string]struct{})
+// erroredDeleteKeyCounts returns the number of failed <Error> entries per key, and
+// whether the response parsed. Counting by key (not by version) is deliberate: it
+// is robust to VersionId representation differences between request and response
+// (omitted "" vs "null" vs a concrete id), which exact-tuple matching gets wrong.
+// On a parse failure the caller re-invalidates all requested keys (safe
+// over-invalidation).
+func erroredDeleteKeyCounts(body []byte) (map[string]int, bool) {
 	var result deleteObjectsResult
 	if err := xml.Unmarshal(body, &result); err != nil {
-		return failed
+		return nil, false
 	}
+	counts := make(map[string]int)
 	for _, e := range result.Errors {
-		failed[e.Key] = struct{}{}
+		counts[e.Key]++
 	}
-	return failed
+	return counts, true
 }
 
 // isS3ErrorBody reports whether an XML body's root element is <Error>, the shape S3
@@ -88,15 +92,18 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
-	// This ensures cache consistency even if forwarding fails after cache invalidation
-	var deletedKeys []string
+	// This ensures cache consistency even if forwarding fails after cache invalidation.
+	// requestedCounts tracks how many entries each key was requested under (the same
+	// key may appear multiple times with different version IDs).
+	var requestedCounts map[string]int
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
+			requestedCounts = make(map[string]int)
 			for _, obj := range deleteReq.Objects {
 				s.cache.Delete(context.Background(), bucket, obj.Key)
 				metrics.RecordCacheOperation("delete", "success")
-				deletedKeys = append(deletedKeys, obj.Key)
+				requestedCounts[obj.Key]++
 				log.Debug().
 					Str("bucket", bucket).
 					Str("key", obj.Key).
@@ -112,16 +119,20 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Re-invalidate AFTER upstream confirms the deletes, for the same
 	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
-	// bulk delete may have re-cached a not-yet-deleted object; this second
-	// tombstone blocks that stale repopulation. Only keys upstream actually deleted
-	// are re-invalidated — a key that failed is still present, so tombstoning it
-	// would discard a valid racing refill. The metric is recorded once on the
-	// pre-forward invalidation above, so it is not counted again here.
+	// bulk delete may have re-cached a not-yet-deleted object; this second tombstone
+	// blocks that stale repopulation. A key is re-invalidated when at least one of
+	// its requested entries was deleted — i.e. more entries were requested for the
+	// key than upstream reported as errored. Counting by key (never matching version
+	// IDs) is robust to VersionId representation differences and to Quiet mode, and
+	// can never leave a truly-deleted object cached (a success is never an <Error>).
+	// A key whose entries ALL errored keeps its refill (it's still upstream). The
+	// metric is recorded once on the pre-forward invalidation above, not again here.
 	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
-		failed := failedDeleteKeys(capture.Body)
-		for _, key := range deletedKeys {
-			if _, bad := failed[key]; bad {
-				continue
+		erroredCounts, parsed := erroredDeleteKeyCounts(capture.Body)
+		for key, reqN := range requestedCounts {
+			// On a parse failure, over-invalidate every requested key (safe).
+			if parsed && reqN <= erroredCounts[key] {
+				continue // every requested entry for this key errored — object still present
 			}
 			s.cache.Delete(context.Background(), bucket, key)
 		}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -29,6 +29,49 @@ type deleteObjectEntry struct {
 	VersionId string `xml:"VersionId,omitempty"`
 }
 
+// deleteObjectsResult represents the S3 DeleteObjects response. Only the per-object
+// <Error> entries are captured: successful deletes may be omitted (Quiet mode), so
+// success is derived as "requested minus errored".
+type deleteObjectsResult struct {
+	XMLName xml.Name `xml:"DeleteResult"`
+	Errors  []struct {
+		Key string `xml:"Key"`
+	} `xml:"Error"`
+}
+
+// failedDeleteKeys returns the set of keys upstream reported as NOT deleted. On a
+// parse failure it returns an empty set, so callers re-invalidate all requested
+// keys — the safe over-invalidation.
+func failedDeleteKeys(body []byte) map[string]struct{} {
+	failed := make(map[string]struct{})
+	var result deleteObjectsResult
+	if err := xml.Unmarshal(body, &result); err != nil {
+		return failed
+	}
+	for _, e := range result.Errors {
+		failed[e.Key] = struct{}{}
+	}
+	return failed
+}
+
+// isS3ErrorBody reports whether an XML body's root element is <Error>, the shape S3
+// uses for an operation-level failure (including 200-status CopyObject failures).
+func isS3ErrorBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local == "Error"
+		}
+	}
+}
+
 // HandleDeleteObjects handles POST /{bucket}?delete for bulk object deletion.
 // Invalidates cache for requested objects BEFORE forwarding to ensure consistency.
 func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) error {
@@ -46,12 +89,14 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
 	// This ensures cache consistency even if forwarding fails after cache invalidation
+	var deletedKeys []string
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
 			for _, obj := range deleteReq.Objects {
 				s.cache.Delete(context.Background(), bucket, obj.Key)
 				metrics.RecordCacheOperation("delete", "success")
+				deletedKeys = append(deletedKeys, obj.Key)
 				log.Debug().
 					Str("bucket", bucket).
 					Str("key", obj.Key).
@@ -60,8 +105,27 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
-	// Forward request to upstream
-	err = s.forwarder.Forward(r.Context(), w, r)
+	// Forward request to upstream, capturing the response so we can tell which
+	// per-object deletes actually succeeded — S3 returns 200 OK with per-key
+	// <Error> elements for partial failures.
+	capture, err := s.forwarder.ForwardWithCapture(r.Context(), w, r)
+
+	// Re-invalidate AFTER upstream confirms the deletes, for the same
+	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
+	// bulk delete may have re-cached a not-yet-deleted object; this second
+	// tombstone blocks that stale repopulation. Only keys upstream actually deleted
+	// are re-invalidated — a key that failed is still present, so tombstoning it
+	// would discard a valid racing refill. The metric is recorded once on the
+	// pre-forward invalidation above, so it is not counted again here.
+	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
+		failed := failedDeleteKeys(capture.Body)
+		for _, key := range deletedKeys {
+			if _, bad := failed[key]; bad {
+				continue
+			}
+			s.cache.Delete(context.Background(), bucket, key)
+		}
+	}
 
 	// Record metrics
 	status := "success"

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -330,7 +330,10 @@ func (s *Service) streamFromUpstream(
 	var cacheErrCh chan error
 
 	if shouldCache {
-		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false)
+		// Reserve against the memory budget by the object's actual size (capped at
+		// the buffer ceiling), so small objects don't each reserve the worst case.
+		weight := s.populateWeight(resp.ContentLength)
+		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false, weight)
 	}
 
 	// If an anonymous GET succeeded and Tigris didn't set an explicit per-object ACL,

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -124,15 +124,20 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				// serve the range from the cached object
 				if rangeHeader != "" {
 					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-					if served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+					served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+					if served {
 						return rangeErr
 					}
-					// Cached metadata survived but its versioned body is gone. Invalidate
-					// the orphaned meta so the background re-warm below is not blocked by
-					// its GetMeta(!found) gate — otherwise every range read for this key
-					// would forward to upstream until the meta TTL expires (cold-miss loop).
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - invalidating orphaned meta and forwarding with background cache")
-					s.cache.Delete(context.Background(), bucket, key)
+					// Only invalidate when the body is genuinely gone: the metadata is then
+					// orphaned, and clearing it both heals the entry and unblocks the
+					// background re-warm below (gated on GetMeta(!found)) — otherwise every
+					// range read for this key forwards upstream until the meta TTL expires
+					// (cold-miss loop). A transient failure (e.g. the client disconnected
+					// mid-probe) leaves the still-valid entry cached.
+					if bodyGone(rangeErr) {
+						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body missing - invalidating orphaned meta and forwarding with background cache")
+						s.cache.Delete(context.Background(), bucket, key)
+					}
 					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
 				}
 
@@ -164,14 +169,16 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 				// Serve full response from cache
 				if cacheBodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); cacheBodyErr != nil {
-					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, invalidating orphaned meta and falling through to upstream")
-					// Metadata survived but its versioned body is gone. Invalidate the
-					// orphaned meta (same as the range and revalidation paths) so this
-					// does not become a meta-hit/body-miss loop that repeats the failed
-					// cache read on every request before refetching from upstream.
-					// serveFromCache errored before committing headers, so falling
-					// through to the miss path below is safe.
-					s.cache.Delete(context.Background(), bucket, key)
+					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, falling through to upstream")
+					// Invalidate only when the body is genuinely gone: the metadata is then
+					// orphaned, and clearing it stops a meta-hit/body-miss loop that repeats
+					// the failed cache read on every request before refetching. A transient
+					// failure (e.g. the client disconnected mid-read) must not evict a
+					// still-valid hot entry. serveFromCache errors before committing
+					// headers, so falling through to the miss path below is safe either way.
+					if bodyGone(cacheBodyErr) {
+						s.cache.Delete(context.Background(), bucket, key)
+					}
 					// Fall through to cache miss path
 				} else {
 					return nil
@@ -638,7 +645,10 @@ func (s *Service) serveRangeFromCache(
 		log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).
 			Int64("start", rng.start).Int64("end", rng.end).
 			Msg("Range cache body unavailable before headers - falling through to upstream")
-		return false, nil
+		// Report the underlying error, not just served=false: the caller uses it to
+		// tell a genuinely-missing body (invalidate the orphaned meta) from a
+		// transient failure like a canceled client (leave the entry alone).
+		return false, readErr
 	}
 
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -124,7 +124,16 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				// serve the range from the cached object
 				if rangeHeader != "" {
 					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-					return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+					if served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+						return rangeErr
+					}
+					// Cached metadata survived but its versioned body is gone. Invalidate
+					// the orphaned meta so the background re-warm below is not blocked by
+					// its GetMeta(!found) gate — otherwise every range read for this key
+					// would forward to upstream until the meta TTL expires (cold-miss loop).
+					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - invalidating orphaned meta and forwarding with background cache")
+					s.cache.Delete(context.Background(), bucket, key)
+					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
 				}
 
 				// Check conditional request: If-None-Match
@@ -155,7 +164,14 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 				// Serve full response from cache
 				if cacheBodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); cacheBodyErr != nil {
-					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, falling through to upstream")
+					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, invalidating orphaned meta and falling through to upstream")
+					// Metadata survived but its versioned body is gone. Invalidate the
+					// orphaned meta (same as the range and revalidation paths) so this
+					// does not become a meta-hit/body-miss loop that repeats the failed
+					// cache read on every request before refetching from upstream.
+					// serveFromCache errored before committing headers, so falling
+					// through to the miss path below is safe.
+					s.cache.Delete(context.Background(), bucket, key)
 					// Fall through to cache miss path
 				} else {
 					return nil
@@ -560,6 +576,12 @@ func parseRangeHeader(rangeHeader string, totalSize int64) ([]byteRange, error) 
 }
 
 // serveRangeFromCache serves a Range request from the cached full object.
+// It returns served=true when it has produced a complete client response (a range
+// body, or a definitive error response like 416). It returns served=false, without
+// touching the response, when the cached body cannot be resolved (e.g. the body was
+// independently evicted while its metadata survived, or was written by a
+// pre-versioning build under a different key) — the caller then falls through to the
+// upstream range path rather than emitting a truncated 206.
 func (s *Service) serveRangeFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -568,15 +590,15 @@ func (s *Service) serveRangeFromCache(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	startTime time.Time,
-) error {
+) (served bool, err error) {
 	// Parse Range header
-	ranges, err := parseRangeHeader(rangeHeader, meta.ContentLength)
-	if err != nil || len(ranges) == 0 {
+	ranges, parseErr := parseRangeHeader(rangeHeader, meta.ContentLength)
+	if parseErr != nil || len(ranges) == 0 {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
 		w.Header().Set(XCacheHeader, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
+		return true, nil
 	}
 
 	// Only support single range (multi-range is complex and rare)
@@ -586,10 +608,35 @@ func (s *Service) serveRangeFromCache(
 		w.Header().Set(XCacheHeader, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
-		return nil
+		return true, nil
 	}
 
 	rng := ranges[0]
+
+	// Probe the body BEFORE committing 206 status + headers: stream the range
+	// through a pipe and read the first byte. If the versioned body is not
+	// resolvable, no headers have been sent yet, so we report served=false and let
+	// the caller forward to upstream instead of streaming a truncated 206 that the
+	// client cannot distinguish from a valid short read.
+	pr, pw := io.Pipe()
+	go func() {
+		streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.ETag, rng.start, rng.end, pw)
+		if streamErr != nil {
+			pw.CloseWithError(streamErr)
+		} else {
+			pw.Close()
+		}
+	}()
+
+	firstByte := make([]byte, 1)
+	n, readErr := pr.Read(firstByte)
+	if readErr != nil {
+		pr.Close()
+		log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).
+			Int64("start", rng.start).Int64("end", rng.end).
+			Msg("Range cache body unavailable before headers - falling through to upstream")
+		return false, nil
+	}
 
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	w.Header().Set(XCacheHeader, XCacheHit)
@@ -597,24 +644,26 @@ func (s *Service) serveRangeFromCache(
 
 	// Stream range from cache using counting writer to track actual bytes
 	cw := &countingWriter{w: w}
-	streamErr := s.cache.GetRangeStream(ctx, bucket, key, rng.start, rng.end, cw)
+	cw.Write(firstByte[:n])
+	_, copyErr := io.Copy(cw, pr)
+	pr.Close()
 
 	// Track bytes out (even on error, some bytes may have been written)
 	if cw.written > 0 {
 		metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
 	}
 
-	if streamErr != nil {
-		log.Warn().Err(streamErr).Str("bucket", bucket).Str("key", key).
+	if copyErr != nil {
+		log.Warn().Err(copyErr).Str("bucket", bucket).Str("key", key).
 			Int64("start", rng.start).Int64("end", rng.end).
 			Msg("Failed to stream range from cache")
 		// Headers already sent, can't return error to client
-		return streamErr
+		return true, copyErr
 	}
 
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
-	return nil
+	return true, nil
 }
 
 // handleRangeWithBackgroundCache handles a Range request on cache miss.

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -166,3 +166,77 @@ func TestHandleDeleteObjects_PartialFailureKeepsFailedKeyRefill(t *testing.T) {
 		t.Error("failed key's valid refill was discarded — failed keys must not be re-invalidated")
 	}
 }
+
+// A DeleteObjects request can list the same key under multiple version IDs. If one
+// version's delete succeeds and another fails, the key's current object may have
+// changed, so a racing refill must be dropped. Matching failures by key alone would
+// wrongly treat the key as fully failed and keep the stale refill.
+func TestHandleDeleteObjects_MixedVersionSuccessReinvalidatesKey(t *testing.T) {
+	var c *cache.Cache
+	const key = "versioned-key"
+
+	repopulateThenMixed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, _ := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: key, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, key, meta, []byte("refill"), 60)
+		body := []byte(`<DeleteResult><Deleted><Key>versioned-key</Key><VersionId>v1</VersionId></Deleted><Error><Key>versioned-key</Key><VersionId>v2</VersionId><Code>AccessDenied</Code></Error></DeleteResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenMixed}, true)
+
+	reqBody := `<Delete><Object><Key>versioned-key</Key><VersionId>v1</VersionId></Object><Object><Key>versioned-key</Key><VersionId>v2</VersionId></Object></Delete>`
+	r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	if err := svc.HandleDeleteObjects(w, r); err != nil {
+		t.Fatalf("HandleDeleteObjects: %v", err)
+	}
+
+	b, _ := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, key); found {
+		t.Error("key with a succeeded version-delete kept its stale refill — should be re-invalidated")
+	}
+}
+
+// A failed unqualified delete may be reported with a VersionId the request never
+// sent ("null" on a version-suspended bucket, or a concrete id the server
+// resolved). Counting errors by key (not matching version tuples) keeps such a
+// failed key's valid refill instead of over-invalidating it.
+func TestHandleDeleteObjects_VersionIdMismatchFailureKeepsRefill(t *testing.T) {
+	for _, respVersion := range []string{"null", "concrete-v3"} {
+		t.Run(respVersion, func(t *testing.T) {
+			var c *cache.Cache
+			const key = "unqualified-key"
+
+			repopulateThenFail := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+				b, _ := ParseBucketKey(r)
+				meta := &cache.CachedObjectMeta{Bucket: b, Key: key, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+				_ = c.PutWithMeta(context.Background(), b, key, meta, []byte("refill"), 60)
+				// Request sent no VersionId; response errors with a different representation.
+				body := []byte(`<DeleteResult><Error><Key>unqualified-key</Key><VersionId>` + respVersion + `</VersionId><Code>AccessDenied</Code></Error></DeleteResult>`)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+				return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+			}
+
+			var svc *Service
+			svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenFail}, true)
+
+			// Request omits VersionId entirely.
+			reqBody := `<Delete><Object><Key>unqualified-key</Key></Object></Delete>`
+			r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+			w := httptest.NewRecorder()
+			if err := svc.HandleDeleteObjects(w, r); err != nil {
+				t.Fatalf("HandleDeleteObjects: %v", err)
+			}
+
+			b, _ := ParseBucketKey(r)
+			if _, found, _ := c.GetMeta(context.Background(), b, key); !found {
+				t.Errorf("failed delete (response VersionId=%q) over-invalidated the key — valid refill discarded", respVersion)
+			}
+		})
+	}
+}

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -1,0 +1,168 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// A GET that races an in-flight PUT can fetch the pre-PUT object and begin
+// re-caching it. HandlePutObject must re-invalidate AFTER forwarding so that
+// stale repopulation does not survive (read-after-write).
+func TestHandlePutObject_ReinvalidatesAfterForward(t *testing.T) {
+	var c *cache.Cache
+
+	// Simulate the racing GET writing a stale entry mid-PUT (during Forward).
+	repopulate := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("stale"), 60)
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{forwardFunc: repopulate}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/test-bucket/test-key", strings.NewReader("new body"))
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, r); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); found {
+		t.Error("stale entry still cached after PUT — post-forward re-invalidation missing")
+	}
+}
+
+// A rejected CopyObject leaves the destination unchanged, so the post-forward
+// re-invalidation must NOT fire — otherwise a racing refill of the still-valid
+// destination is discarded, causing an unnecessary later miss.
+func TestHandleCopyObject_FailedCopyKeepsRacingRefill(t *testing.T) {
+	var c *cache.Cache
+	repopulateThenFail := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		body := []byte(`<Error><Code>AccessDenied</Code></Error>`)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusForbidden, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenFail}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	r.Header.Set("X-Amz-Copy-Source", "/src-bucket/src-key")
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); !found {
+		t.Error("racing refill discarded after a FAILED copy — re-invalidation must be gated on success")
+	}
+}
+
+// A CopyObject that returns 200 OK but an <Error> body actually failed, so the
+// destination is unchanged and must not be re-invalidated.
+func TestHandleCopyObject_200ErrorBodyKeepsRacingRefill(t *testing.T) {
+	var c *cache.Cache
+	repopulateThen200Error := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		body := []byte(`<Error><Code>InternalError</Code></Error>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThen200Error}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); !found {
+		t.Error("racing refill discarded after a 200-with-error-body copy — that copy did not succeed")
+	}
+}
+
+// A successful CopyObject changed the destination, so the post-forward
+// re-invalidation must fire to drop any stale racing refill.
+func TestHandleCopyObject_SuccessReinvalidates(t *testing.T) {
+	var c *cache.Cache
+	repopulateThenSucceed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, k := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("stale"), 60)
+		body := []byte(`<CopyObjectResult><ETag>"new"</ETag></CopyObjectResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenSucceed}, true)
+
+	r := httptest.NewRequest(http.MethodPut, "/dst-bucket/dst-key", nil)
+	w := httptest.NewRecorder()
+	if err := svc.HandleCopyObject(w, r); err != nil {
+		t.Fatalf("HandleCopyObject: %v", err)
+	}
+
+	b, k := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, k); found {
+		t.Error("stale refill survived a SUCCESSFUL copy — post-forward re-invalidation should have removed it")
+	}
+}
+
+// A bulk delete with a per-object failure must re-invalidate only the keys that
+// were actually deleted; a racing refill of a FAILED key must survive.
+func TestHandleDeleteObjects_PartialFailureKeepsFailedKeyRefill(t *testing.T) {
+	var c *cache.Cache
+	const okKey = "ok-key"
+	const failKey = "fail-key"
+
+	repopulateThenPartial := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, _ := ParseBucketKey(r)
+		for _, k := range []string{okKey, failKey} {
+			meta := &cache.CachedObjectMeta{Bucket: b, Key: k, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+			_ = c.PutWithMeta(context.Background(), b, k, meta, []byte("refill"), 60)
+		}
+		body := []byte(`<DeleteResult><Deleted><Key>ok-key</Key></Deleted><Error><Key>fail-key</Key><Code>AccessDenied</Code></Error></DeleteResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenPartial}, true)
+
+	reqBody := `<Delete><Object><Key>ok-key</Key></Object><Object><Key>fail-key</Key></Object></Delete>`
+	r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	if err := svc.HandleDeleteObjects(w, r); err != nil {
+		t.Fatalf("HandleDeleteObjects: %v", err)
+	}
+
+	b, _ := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, okKey); found {
+		t.Error("deleted key's stale refill survived — it should have been re-invalidated")
+	}
+	if _, found, _ := c.GetMeta(context.Background(), b, failKey); !found {
+		t.Error("failed key's valid refill was discarded — failed keys must not be re-invalidated")
+	}
+}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -54,7 +54,7 @@ func (s *Service) revalidateAndServe(
 		}
 		// No stale bytes available (versioned body gone) and nothing written yet —
 		// last-resort direct fetch so the client gets a real response.
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, staleErr, start)
 	}
 	defer resp.Body.Close()
 
@@ -72,7 +72,7 @@ func (s *Service) revalidateAndServe(
 		// returns the correct 206; this unifies the full-object and range paths.
 		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
 			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, revalErr, start)
 	case http.StatusOK:
 		// Full-object response (no range or upstream ignored range)
 		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
@@ -93,7 +93,7 @@ func (s *Service) revalidateAndServe(
 			metrics.RecordRevalidationStaleServed()
 			return staleErr
 		}
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, staleErr, start)
 	}
 }
 
@@ -103,13 +103,17 @@ func (s *Service) revalidateAndServe(
 // survived). No response headers have been written yet, so this is safe for both
 // full-object and range requests — the Range header on r makes upstream return
 // the correct 206.
-func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, start time.Time) error {
-	// Invalidate the orphaned metadata whose body was unresolvable. Without this
-	// the meta entry survives and every subsequent request is a meta-hit whose
-	// body probe fails and re-forwards to upstream — a persistent cold-miss loop,
+// bodyErr is why the cache could not serve; it decides whether the metadata is
+// invalidated (see bodyGone).
+func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, bodyErr error, start time.Time) error {
+	// Invalidate the metadata only when its body is genuinely gone. Otherwise the
+	// meta entry survives and every subsequent request is a meta-hit whose body
+	// probe fails and re-forwards to upstream — a persistent cold-miss loop,
 	// because the normal re-warm paths are gated on the metadata being absent.
 	// Deleting it makes the next request a clean miss that repopulates the cache.
-	if s.cache.IsEnabled() {
+	// A transient failure (e.g. a canceled context from a disconnected client) must
+	// not evict a still-valid entry, so bodyGone gates the delete.
+	if s.cache.IsEnabled() && bodyGone(bodyErr) {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 	w.Header().Set(XCacheHeader, XCacheMiss)

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -47,35 +47,32 @@ func (s *Service) revalidateAndServe(
 		// Upstream error — serve stale from cache
 		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Revalidation failed, serving stale")
 		metrics.RecordRevalidationFailed()
-		metrics.RecordRevalidationStaleServed()
-		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			metrics.RecordRevalidationStaleServed()
+			return staleErr
+		}
+		// No stale bytes available (versioned body gone) and nothing written yet —
+		// last-resort direct fetch so the client gets a real response.
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusNotModified:
-		revalErr := s.handleRevalidation304(ctx, w, r, bucket, key, meta, rangeHeader, start)
-		if revalErr == nil {
-			return nil
-		}
-		// Cache body unavailable despite 304 — fall through to upstream.
-		// serveFromCache returns errors before committing headers, so we can
-		// safely write a new response. Range errors may have partial headers
-		// committed (serveRangeFromCache writes headers before streaming), so
-		// we return those directly.
-		if rangeHeader != "" {
+		served, revalErr := s.handleRevalidation304(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			// A response (full body, range, or a committed-then-failed stream) was
+			// produced; propagate its result. Headers are already sent on error, so
+			// we cannot safely forward.
 			return revalErr
 		}
+		// Cache body unavailable despite 304 and no response bytes written yet —
+		// fetch from upstream. The Range header (if any) is still on r, so upstream
+		// returns the correct 206; this unifies the full-object and range paths.
 		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
 			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
-		w.Header().Set(XCacheHeader, XCacheMiss)
-		forwardErr := s.forwarder.Forward(ctx, w, r)
-		status := "success"
-		if forwardErr != nil {
-			status = "error"
-		}
-		metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
-		return forwardErr
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	case http.StatusOK:
 		// Full-object response (no range or upstream ignored range)
 		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
@@ -91,14 +88,47 @@ func (s *Service) revalidateAndServe(
 			Str("key", key).
 			Msg("Revalidation got unexpected status, serving stale")
 		metrics.RecordRevalidationFailed()
-		metrics.RecordRevalidationStaleServed()
-		return s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		served, staleErr := s.serveStaleFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			metrics.RecordRevalidationStaleServed()
+			return staleErr
+		}
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
 	}
+}
+
+// forwardAfterCacheMiss fetches the object fresh from upstream when a
+// revalidation or stale-serve path could not produce any response bytes from
+// cache (typically the ETag-versioned body was evicted while its metadata
+// survived). No response headers have been written yet, so this is safe for both
+// full-object and range requests — the Range header on r makes upstream return
+// the correct 206.
+func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, start time.Time) error {
+	// Invalidate the orphaned metadata whose body was unresolvable. Without this
+	// the meta entry survives and every subsequent request is a meta-hit whose
+	// body probe fails and re-forwards to upstream — a persistent cold-miss loop,
+	// because the normal re-warm paths are gated on the metadata being absent.
+	// Deleting it makes the next request a clean miss that repopulates the cache.
+	if s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
+	w.Header().Set(XCacheHeader, XCacheMiss)
+	forwardErr := s.forwarder.Forward(ctx, w, r)
+	status := "success"
+	if forwardErr != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	return forwardErr
 }
 
 // handleRevalidation304 handles a 304 Not Modified revalidation response.
 // Serves from cached body (or range if requested). Does not refresh cache TTL
 // because ocache has no TTL-refresh operation and re-writing data is inefficient.
+// It returns served=true when a client response was produced (a full body, a
+// range, or a committed stream that then failed). It returns served=false,
+// without writing any response bytes, when the cached body cannot be resolved —
+// the caller then fetches from upstream.
 func (s *Service) handleRevalidation304(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -107,15 +137,20 @@ func (s *Service) handleRevalidation304(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	start time.Time,
-) error {
+) (served bool, err error) {
 	metrics.RecordRevalidationNotModified()
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Revalidation 304 - object unchanged")
 
-	// Serve range or full body from cache
+	// Serve range or full body from cache. Both serveRangeFromCache (via its
+	// pre-header probe) and serveFromCache report an unresolvable body without
+	// writing headers, so the caller can safely forward to upstream.
 	if rangeHeader != "" {
 		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 	}
-	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+	if bodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); bodyErr != nil {
+		return false, bodyErr
+	}
+	return true, nil
 }
 
 // handleRevalidation200 handles a 200 OK revalidation response (object changed).
@@ -238,7 +273,7 @@ func (s *Service) serveFromCache(
 		bodyBuf := bufferPool.Get().(*bytes.Buffer)
 		bodyBuf.Reset()
 
-		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, bodyBuf)
+		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, bodyBuf)
 		if bodyErr == nil && bodyBuf.Len() > 0 {
 			metrics.RecordCacheHit()
 			meta.WriteHeaders(w)
@@ -261,7 +296,7 @@ func (s *Service) serveFromCache(
 	// Large objects: stream via pipe
 	pr, pw := io.Pipe()
 	go func() {
-		err := s.cache.GetBodyStream(ctx, bucket, key, pw)
+		err := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, pw)
 		if err != nil {
 			pw.CloseWithError(err)
 		} else {
@@ -338,7 +373,10 @@ func (s *Service) handleRevalidation206Range(
 	return copyErr
 }
 
-// serveStaleFromCache serves stale content from cache, handling both full and range requests.
+// serveStaleFromCache serves stale content from cache, handling both full and
+// range requests. It returns served=false, without writing any response bytes,
+// when the cached body cannot be resolved so the caller can fall back to a direct
+// upstream fetch instead of emitting a truncated or empty response.
 func (s *Service) serveStaleFromCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -347,11 +385,14 @@ func (s *Service) serveStaleFromCache(
 	meta *cache.CachedObjectMeta,
 	rangeHeader string,
 	start time.Time,
-) error {
+) (served bool, err error) {
 	if rangeHeader != "" {
 		return s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
 	}
-	return s.serveFromCache(ctx, w, bucket, key, meta, start)
+	if bodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); bodyErr != nil {
+		return false, bodyErr
+	}
+	return true, nil
 }
 
 // revalidateAndServeHead sends a conditional HEAD to upstream for a HEAD request.

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -24,6 +24,8 @@ type mockForwarder struct {
 	conditionalETag   string
 	// Optional Forward implementation for fallback tests
 	forwardFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+	// Optional ForwardWithCapture implementation for capture-gated tests
+	captureFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error)
 }
 
 func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
@@ -34,6 +36,9 @@ func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *h
 }
 
 func (m *mockForwarder) ForwardWithCapture(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+	if m.captureFunc != nil {
+		return m.captureFunc(ctx, w, r)
+	}
 	return nil, nil
 }
 
@@ -487,6 +492,7 @@ func TestServeFromCache_SmallObject(t *testing.T) {
 	meta := &cache.CachedObjectMeta{
 		Bucket:        bucket,
 		Key:           key,
+		ETag:          `"small"`,
 		ContentType:   "text/plain",
 		ContentLength: int64(len(body)),
 		StatusCode:    http.StatusOK,
@@ -562,6 +568,76 @@ func TestRevalidationRange304_ServesCachedRange(t *testing.T) {
 	}
 	if got := w.Header().Get("Content-Range"); got == "" {
 		t.Error("expected Content-Range header to be set")
+	}
+}
+
+// When a range revalidation gets a 304 but the ETag-versioned body has been
+// evicted (meta survives, body gone), the cache cannot serve the range. TAG must
+// forward the range to upstream — not return an error or a truncated 206.
+func TestRevalidationRange304_BodyEvictedForwardsUpstream(t *testing.T) {
+	const forwardBody = "UPSTREAM-RANGE"
+	forwarded := false
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusNotModified,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{},
+		},
+		forwardFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			forwarded = true
+			w.Header().Set("Content-Range", "bytes 0-13/100")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(forwardBody))
+			return nil
+		},
+	}
+
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+	ctx := context.Background()
+	bucket, key := "test-bucket", "test-key"
+
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"abc123"`,
+		ContentType:   "text/plain",
+		ContentLength: 12,
+		StatusCode:    http.StatusOK,
+	}
+	if err := c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0); err != nil {
+		t.Fatalf("PutWithMeta() error = %v", err)
+	}
+	// Evict ONLY the versioned body, keeping the metadata.
+	if err := memCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag)); err != nil {
+		t.Fatalf("evict body: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test-bucket/test-key", nil)
+	r.Header.Set("Range", "bytes=0-4")
+	if err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", meta, time.Now()); err != nil {
+		t.Fatalf("revalidateAndServe() error = %v", err)
+	}
+
+	if !forwarded {
+		t.Fatal("expected upstream Forward when the versioned body was evicted on a range 304")
+	}
+	if w.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPartialContent)
+	}
+	if w.Body.String() != forwardBody {
+		t.Errorf("body = %q, want %q (served from upstream)", w.Body.String(), forwardBody)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheMiss)
+	}
+	// The orphaned meta (body gone) must be invalidated so subsequent requests are
+	// clean misses that repopulate, rather than looping through this same path.
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("orphaned metadata should be invalidated after body-gone upstream forward")
 	}
 }
 
@@ -703,7 +779,7 @@ func TestRevalidation304_CacheBodyUnavailable_FallsThrough(t *testing.T) {
 	_ = c.PutWithMeta(ctx, bucket, key, meta, []byte("hello world!"), 0)
 
 	// Delete only the body key to simulate cache body eviction
-	_ = memCache.Delete(ctx, cache.MakeBodyKey(bucket, key))
+	_ = memCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag))
 
 	// Execute revalidation — should fall through to Forward
 	w := httptest.NewRecorder()

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -30,7 +30,9 @@ type Service struct {
 	forwarder               RequestForwarder
 	cache                   *cache.Cache
 	config                  *config.Config
-	cacheSemaphore          chan struct{}      // Bounds concurrent cache-populate operations (nil = unlimited)
+	cacheSemaphore          chan struct{}      // Count ceiling on concurrent cache-populate ops (nil = unlimited)
+	populateBudget          *byteBudget        // Byte budget bounding aggregate populate buffering (nil = unlimited)
+	perPopulateCap          int64              // Max bytes a single populate can buffer (reservation ceiling)
 	broadcastManager        *broadcast.Manager // For streaming request coalescing
 	activeBackgroundFetches sync.Map           // Dedup for background full-object fetches (range caching)
 }
@@ -42,43 +44,145 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		channelBuf = broadcast.DefaultChannelBuffer
 	}
 
+	// Concurrent cache-populate operations are bounded two independent ways, and a
+	// populate must pass both:
+	//   1. A hard COUNT ceiling (MaxConcurrentWrites) — caps total in-flight populates.
+	//   2. A BYTE budget (MaxPopulateMemoryBytes) — caps aggregate buffered memory.
+	// The byte budget is what prevents the OOM failure mode: each populate reserves
+	// min(object size, per-populate buffer ceiling), so many small objects populate
+	// concurrently while a burst of large objects is throttled to keep buffered
+	// memory bounded (a byte-unaware count alone can pin many GB — e.g. 256 large
+	// populates × ~64–80MB ≈ 16–20GB).
 	var cacheSem chan struct{}
 	if cfg.Cache.MaxConcurrentWrites > 0 {
 		cacheSem = make(chan struct{}, cfg.Cache.MaxConcurrentWrites)
 	}
+
+	perPopulateCap := perPopulateBufferBytes(cfg)
+
+	var populateBudget *byteBudget
+	if cfg.Cache.MaxPopulateMemoryBytes > 0 {
+		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes)
+	}
+
+	log.Info().
+		Int("max_concurrent_writes", cfg.Cache.MaxConcurrentWrites).
+		Int64("max_populate_memory_bytes", cfg.Cache.MaxPopulateMemoryBytes).
+		Int64("per_populate_buffer_cap_bytes", perPopulateCap).
+		Msg("Cache-populate limits configured")
 
 	return &Service{
 		forwarder:        forwarder,
 		cache:            cache,
 		config:           cfg,
 		cacheSemaphore:   cacheSem,
+		populateBudget:   populateBudget,
+		perPopulateCap:   perPopulateCap,
 		broadcastManager: broadcast.NewManager(channelBuf),
 	}
 }
 
-// acquireCacheSlot tries to reserve a cache-populate slot without blocking. It
-// returns true (and must be paired with releaseCacheSlot) when a slot is
-// reserved, or when the limiter is disabled (nil semaphore). It returns false
-// when the concurrent-cache-write limit is saturated, in which case the caller
-// should skip caching rather than block or spawn unbounded work.
-func (s *Service) acquireCacheSlot() bool {
-	if s.cacheSemaphore == nil {
-		return true
+// perPopulateBufferBytes returns the maximum bytes a single cache-populate can
+// buffer: the broadcast listener channel (channel_buffer chunks) plus the
+// cache-write queue in setupCacheListener (channel_buffer/4 chunks, floored at 64).
+// Each queued chunk retains at least a pooled DefaultChunkSize backing array
+// (broadcast.GetChunkBuf pools DefaultChunkSize buffers), so a smaller configured
+// chunk_size still holds that much per chunk — charge the larger of the two. This
+// is the ceiling a populate ever reserves; smaller objects reserve their actual size.
+func perPopulateBufferBytes(cfg *config.Config) int64 {
+	chunkSize := int64(cfg.Broadcast.ChunkSize)
+	if chunkSize < broadcast.DefaultChunkSize {
+		chunkSize = broadcast.DefaultChunkSize
 	}
-	select {
-	case s.cacheSemaphore <- struct{}{}:
-		return true
-	default:
-		return false
+	channelBuf := int64(cfg.Broadcast.ChannelBuffer)
+	if channelBuf <= 0 {
+		channelBuf = broadcast.DefaultChannelBuffer
 	}
+	queue := channelBuf / 4
+	if queue < 64 {
+		queue = 64 // matches setupCacheListener's cacheQueueSize floor
+	}
+	return (channelBuf + queue) * chunkSize
 }
 
-// releaseCacheSlot releases a slot previously reserved by acquireCacheSlot.
-func (s *Service) releaseCacheSlot() {
-	if s.cacheSemaphore == nil {
-		return
+// populateWeight is the byte weight a populate reserves against the memory budget:
+// the object's size, capped at the per-populate buffer ceiling (a populate never
+// buffers more than the pipeline can hold). Unknown/negative sizes (e.g. chunked
+// responses) reserve the full ceiling. It never exceeds the total budget, so an
+// object larger than the whole budget can still populate one-at-a-time. Always ≥ 1.
+func (s *Service) populateWeight(contentLength int64) int64 {
+	w := s.perPopulateCap
+	if contentLength > 0 && contentLength < w {
+		w = contentLength
 	}
-	<-s.cacheSemaphore
+	if w < 1 {
+		w = 1
+	}
+	if budget := s.config.Cache.MaxPopulateMemoryBytes; budget > 0 && w > budget {
+		w = budget
+	}
+	return w
+}
+
+// byteBudget is a non-blocking weighted semaphore bounding the aggregate bytes
+// reserved by concurrent cache-populate operations.
+type byteBudget struct {
+	mu        sync.Mutex
+	remaining int64
+}
+
+func newByteBudget(total int64) *byteBudget {
+	return &byteBudget{remaining: total}
+}
+
+func (b *byteBudget) tryAcquire(n int64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.remaining < n {
+		return false
+	}
+	b.remaining -= n
+	return true
+}
+
+func (b *byteBudget) release(n int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remaining += n
+}
+
+// acquireCacheSlot tries to reserve a cache-populate slot without blocking,
+// reserving `weight` bytes against the memory budget. It returns true (and must be
+// paired with releaseCacheSlot passing the SAME weight) when both the count slot
+// and the byte budget are reserved, or when a limiter is disabled (nil). It returns
+// false when either the count limit or the memory budget is saturated, in which
+// case the caller should skip caching rather than block or spawn unbounded work.
+func (s *Service) acquireCacheSlot(weight int64) bool {
+	if s.cacheSemaphore != nil {
+		select {
+		case s.cacheSemaphore <- struct{}{}:
+		default:
+			return false
+		}
+	}
+	if s.populateBudget != nil && !s.populateBudget.tryAcquire(weight) {
+		if s.cacheSemaphore != nil {
+			<-s.cacheSemaphore // hand back the count slot we just took
+		}
+		return false
+	}
+	return true
+}
+
+// releaseCacheSlot releases a slot reserved by acquireCacheSlot. `weight` must
+// match the value passed to the paired acquireCacheSlot.
+func (s *Service) releaseCacheSlot(weight int64) {
+	if s.populateBudget != nil {
+		s.populateBudget.release(weight)
+	}
+	if s.cacheSemaphore != nil {
+		<-s.cacheSemaphore
+	}
 }
 
 // statusRecorder wraps http.ResponseWriter to capture the response status code

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -81,6 +81,42 @@ func (s *Service) releaseCacheSlot() {
 	<-s.cacheSemaphore
 }
 
+// statusRecorder wraps http.ResponseWriter to capture the response status code
+// written while forwarding an upstream response. Forward() returns nil even when
+// upstream responds 4xx/5xx (the response streamed successfully), so mutating
+// handlers use this to gate post-forward cache re-invalidation on an actual 2xx —
+// otherwise a rejected PUT/DELETE/COPY would still tombstone the destination and
+// discard a valid racing refill, causing later reads to miss unnecessarily.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rec *statusRecorder) WriteHeader(code int) {
+	rec.status = code
+	rec.ResponseWriter.WriteHeader(code)
+}
+
+func (rec *statusRecorder) Write(b []byte) (int, error) {
+	if rec.status == 0 {
+		rec.status = http.StatusOK
+	}
+	return rec.ResponseWriter.Write(b)
+}
+
+// Flush delegates to the underlying writer when it supports flushing, so wrapping
+// never disables streaming for handlers that rely on http.Flusher.
+func (rec *statusRecorder) Flush() {
+	if f, ok := rec.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// wroteSuccess reports whether upstream returned a 2xx status.
+func (rec *statusRecorder) wroteSuccess() bool {
+	return rec.status >= 200 && rec.status < 300
+}
+
 // HandlePutObject handles PUT requests for objects.
 // Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error {
@@ -96,8 +132,22 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 		metrics.RecordCacheOperation("delete", "success")
 	}
 
-	// Forward to Tigris
-	err := s.forwarder.Forward(r.Context(), w, r)
+	// Forward to Tigris, recording the upstream status.
+	rec := &statusRecorder{ResponseWriter: w}
+	err := s.forwarder.Forward(r.Context(), rec, r)
+
+	// Re-invalidate AFTER upstream confirms the write. A GET that raced the
+	// in-flight PUT may have fetched the pre-PUT object and begun re-caching it;
+	// this second invalidation writes a tombstone newer than that write's start
+	// time, so the tombstone-aware cache write skips the stale repopulation —
+	// restoring read-after-write semantics.
+	// Gated on a 2xx: a rejected PUT leaves the object unchanged, so re-invalidating
+	// would only discard a valid racing refill and cause an unnecessary later miss.
+	// The metric is recorded once on the pre-forward invalidation above; this
+	// second Delete is the same logical invalidation, so it is not counted again.
+	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
 
 	status := "success"
 	if err != nil {
@@ -123,8 +173,21 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 		metrics.RecordCacheOperation("delete", "success")
 	}
 
-	// Forward to upstream
-	err := s.forwarder.Forward(r.Context(), w, r)
+	// Forward to upstream, recording the upstream status.
+	rec := &statusRecorder{ResponseWriter: w}
+	err := s.forwarder.Forward(r.Context(), rec, r)
+
+	// Re-invalidate AFTER upstream confirms the delete, for the same
+	// read-after-write reason as HandlePutObject: a GET racing the in-flight
+	// DELETE may have re-cached the not-yet-deleted object; this second
+	// tombstone blocks that stale repopulation.
+	// Gated on a 2xx: a rejected DELETE leaves the object present, so re-invalidating
+	// would only discard a valid racing refill and cause an unnecessary later miss.
+	// The metric is recorded once on the pre-forward invalidation above; this
+	// second Delete is the same logical invalidation, so it is not counted again.
+	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
 
 	status := "success"
 	if err != nil {
@@ -218,8 +281,33 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
-	// Forward to upstream
-	return s.forwarder.Forward(r.Context(), w, r)
+	// Forward to upstream, capturing the response so we can confirm the copy
+	// actually succeeded. CopyObject signals failure either with a non-2xx status
+	// or — famously — a 200 OK carrying an <Error> body, and Forward would report
+	// neither.
+	capture, err := s.forwarder.ForwardWithCapture(r.Context(), w, r)
+
+	// Re-invalidate the destination AFTER upstream confirms the copy, for the same
+	// read-after-write reason as HandlePutObject: a GET racing the in-flight copy
+	// may have re-cached the pre-copy destination object; this second tombstone
+	// blocks that stale repopulation.
+	// Gated on a confirmed-successful copy: a rejected copy leaves the destination
+	// unchanged, so re-invalidating would only discard a valid racing refill.
+	if err == nil && copyObjectSucceeded(capture) && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
+
+	return err
+}
+
+// copyObjectSucceeded reports whether a captured CopyObject response indicates the
+// copy actually happened: a 2xx status whose body is not an S3 <Error> document
+// (S3 can return 200 OK with an error body for copies that fail mid-operation).
+func copyObjectSucceeded(capture *ResponseCapture) bool {
+	if capture == nil || capture.StatusCode < 200 || capture.StatusCode >= 300 {
+		return false
+	}
+	return !isS3ErrorBody(capture.Body)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -407,6 +407,15 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 // copyObjectSucceeded reports whether a captured CopyObject response indicates the
 // copy actually happened: a 2xx status whose body is not an S3 <Error> document
 // (S3 can return 200 OK with an error body for copies that fail mid-operation).
+//
+// It deliberately does NOT gate on capture.Complete. The two ways to be wrong are
+// not symmetric: treating a failed copy as successful only re-invalidates a
+// destination that didn't change (an extra cache miss), while treating a successful
+// copy as failed skips the invalidation and can leave a racing refill of the OLD
+// destination cached — serving stale data. So an unconfirmable outcome must be
+// assumed successful. An incomplete capture still detects a failure whenever the
+// <Error> root element was captured (isS3ErrorBody only reads the first element);
+// only a body truncated before that root reads as success, which is the safe side.
 func copyObjectSucceeded(capture *ResponseCapture) bool {
 	if capture == nil || capture.StatusCode < 200 || capture.StatusCode >= 300 {
 		return false

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tag/cache"
 )
 
 // TestCache_HitWithMetadata verifies that cache hits return proper headers.
@@ -395,6 +396,51 @@ func TestCache_RangeServedFromCache(t *testing.T) {
 
 	assert.Equal(t, []byte("ABCDEFGHIJ"), body4, "Second range request should return correct bytes")
 	env.AssertXCacheHit(t) // Second range request should also be served from cache
+}
+
+// TestCache_RangeBodyEvictedFallsThroughToUpstream verifies that when object
+// metadata is cached but its ETag-versioned body is gone (independently evicted,
+// or written by a pre-versioning build under a different key), a Range GET does
+// NOT emit a truncated 206 from cache — it forwards to upstream and returns the
+// correct bytes. Regression guard for the range-header-before-body-probe bug.
+func TestCache_RangeBodyEvictedFallsThroughToUpstream(t *testing.T) {
+	env := NewTestEnvironmentWithCache()
+	defer env.Close()
+
+	bucket := "cache-test-bucket"
+	key := "range-evicted.txt"
+	content := []byte("0123456789ABCDEFGHIJ") // 20 bytes
+	require.NoError(t, env.PutTestObject(bucket, key, content))
+
+	client := env.GetS3Client()
+	ctx := context.Background()
+
+	// Warm the cache with a full GET.
+	resp1, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+	require.NoError(t, err)
+	io.Copy(io.Discard, resp1.Body)
+	resp1.Body.Close()
+	require.True(t, env.WaitForCached(bucket, key, 2*time.Second), "object should be cached after first GET")
+
+	// Evict ONLY the versioned body, leaving metadata in place — the meta-present
+	// / body-absent state that made the range path commit a 206 over a truncated body.
+	meta, found, err := env.Cache.GetMeta(ctx, bucket, key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, env.EmbeddedCache.Delete(ctx, cache.MakeBodyKey(bucket, key, meta.ETag)))
+	require.True(t, env.IsCached(bucket, key), "metadata must still be present after body eviction")
+
+	// A Range GET must return the correct bytes (served from upstream), not a
+	// truncated or empty 206 from the cache.
+	resp2, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Range:  aws.String("bytes=5-14"),
+	})
+	require.NoError(t, err)
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	assert.Equal(t, []byte("56789ABCDE"), body2, "range must return correct bytes via upstream fallthrough")
 }
 
 // TestCache_RangeSingleByteAtZero verifies the byte-0 quirk handling.

--- a/tests/integration/testutil.go
+++ b/tests/integration/testutil.go
@@ -692,16 +692,19 @@ func (e *TestEnvironment) ResetUpstreamRequestCount() {
 // GetCachedObject reads an object directly from the cache for test verification.
 // Returns (body, found). If not found or cache is disabled, returns (nil, false).
 func (e *TestEnvironment) GetCachedObject(bucket, key string) ([]byte, bool) {
-	if e.EmbeddedCache == nil {
+	if e.Cache == nil {
 		return nil, false
 	}
 
-	// Use the same key format as the cache package
-	bodyKey := "body|" + bucket + "|" + key
-	// Body is stored via PutStream, so we need to use GetStream to retrieve it
+	// Bodies are addressed by the object's ETag ("body|bucket|key|<etag>"), so
+	// resolve the current metadata first and read the body version it describes.
+	ctx := context.Background()
+	meta, found, err := e.Cache.GetMeta(ctx, bucket, key)
+	if err != nil || !found || meta == nil {
+		return nil, false
+	}
 	var buf bytes.Buffer
-	err := e.EmbeddedCache.GetStream(context.Background(), bodyKey, &buf)
-	if err != nil {
+	if err := e.Cache.GetBodyStream(ctx, bucket, key, meta.ETag, &buf); err != nil {
 		return nil, false
 	}
 	return buf.Bytes(), true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core cache keying, invalidation, and GET/range/revalidation paths where incorrect behavior could serve stale or truncated data or mis-handle concurrent writes; defaults also raise broadcast buffer size and add memory budgeting for populates.
> 
> **Overview**
> Release **v1.11.0** renames the product to **Tigris Acceleration Gateway**, bumps deployment image tags, and documents warp benchmark numbers in the README.
> 
> **Cache storage** now keys object bodies by **ETag** (`MakeBodyKey` / `GetBodyStream` / `GetRangeStream`), skips caching empty-ETag objects, stops synchronous body deletes on overwrite or invalidation (metadata + tombstone only; bodies age out via TTL), and distinguishes weak vs strong validators in keys. **Populate admission** adds `max_populate_memory_bytes` (default 1 GiB) and byte-weighted `acquireCacheSlot` alongside the existing concurrent-write count.
> 
> **Proxy behavior** adds `bodyGone` to invalidate orphaned metadata on real body loss (not client disconnects), probes range bodies before sending **206**, and **re-invalidates after successful** PUT/DELETE/COPY/DeleteObjects (with partial bulk-delete and CopyObject `<Error>` body handling) to fix read-after-write races.
> 
> Tests and docs cover versioning, slots, re-invalidation, and integration range fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0db5d3cb432358a4ff4e9b5ca04eda5a0d9da50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->