### PR TITLE
fix: harden ETag-versioned body keys (empty + weak ETags)

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -146,6 +146,17 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		return nil
 	}
 
+	// Objects without an ETag are not cached: they would share a single
+	// unversioned body key (MakeBodyKey(..., "")) that a concurrent overwrite could
+	// clobber in place, truncating an in-flight reader — the hazard ETag-versioned
+	// bodies exist to prevent. Callers gate on IsCacheable (which excludes empty
+	// ETags) before building the stream; this is a backstop matching PutWithMeta.
+	// Drain the body first so the producer side of the pipe never blocks.
+	if meta.ETag == "" {
+		_, _ = io.Copy(io.Discard, body)
+		return nil
+	}
+
 	if ttl == 0 {
 		ttl = int(c.defaultTTL)
 	}

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -119,6 +119,29 @@ func TestETagVersionedBody_VersionedMissDoesNotServeLegacyBody(t *testing.T) {
 	}
 }
 
+// The streaming write path (the primary populate path) must also refuse empty-ETag
+// objects, and must drain the body so the producer side of the pipe doesn't block.
+func TestETagVersionedBody_EmptyETagNotCachedViaStream(t *testing.T) {
+	c, mem := newVersioningTestCache(t)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	body := bytes.NewReader([]byte("body-bytes"))
+	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 10, StatusCode: 200}
+	if err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1); err != nil {
+		t.Fatalf("PutWithMetaStreamTombstoneAware: %v", err)
+	}
+	if _, found, _ := c.GetMeta(ctx, bucket, key); found {
+		t.Error("empty-ETag object should not be cached via the streaming path (meta present)")
+	}
+	if _, err := mem.Get(ctx, MakeBodyKey(bucket, key, "")); err == nil {
+		t.Error("empty-ETag object should not be cached via the streaming path (body present)")
+	}
+	if body.Len() != 0 {
+		t.Errorf("body not drained: %d bytes remain (producer pipe would block)", body.Len())
+	}
+}
+
 // Objects with no ETag are not cached at all: there is no version discriminator,
 // so caching them at a single unversioned key would reintroduce the in-place
 // overwrite / truncation hazard the ETag versioning was introduced to prevent.

--- a/cache/object.go
+++ b/cache/object.go
@@ -217,10 +217,26 @@ func (m *CachedObjectMeta) IsModifiedSince(since time.Time) bool {
 	return objTime.After(since.Truncate(time.Second))
 }
 
-// normalizeETag strips quotes from ETag for comparison.
+// normalizeETag strips the weak prefix and quotes from an ETag for comparison.
+// This is a weak comparison (W/"abc" matches "abc"), used for conditional requests.
 func normalizeETag(etag string) string {
 	etag = strings.TrimPrefix(etag, "W/") // Remove weak validator prefix
 	etag = strings.Trim(etag, "\"")
+	return etag
+}
+
+// etagKeyComponent normalizes an ETag for use in a body cache key while PRESERVING
+// the weak/strong distinction. A weak validator (W/"abc") only asserts semantic
+// equivalence, so it can label different bytes than the strong validator "abc";
+// collapsing them (as normalizeETag does) would map both to one body key, letting a
+// later populate clobber the other version's bytes under an in-flight reader. Quotes
+// are stripped (they are only delimiters) but the weak marker is kept.
+func etagKeyComponent(etag string) string {
+	weak := strings.HasPrefix(etag, "W/")
+	etag = strings.Trim(strings.TrimPrefix(etag, "W/"), "\"")
+	if weak {
+		return "W/" + etag
+	}
 	return etag
 }
 
@@ -247,13 +263,14 @@ func MakeMetaKey(bucket, key string) string {
 // the object's ETag ("body|bucket|key|<etag>") so a served metadata entry always
 // maps to the exact body version it describes: a concurrent overwrite writes a
 // new meta plus a new body key and never clobbers the version an in-flight reader
-// resolved. Objects with no ETag fall back to the unversioned key (there is no
-// version discriminator available for them).
+// resolved. The ETag is normalized with etagKeyComponent, which keeps the
+// weak/strong distinction so different validators never collide on one key. Objects
+// with no ETag fall back to the unversioned key (no version discriminator exists).
 func MakeBodyKey(bucket, key, etag string) string {
 	if etag == "" {
 		return bodyKeyPrefix + bucket + "|" + key
 	}
-	return bodyKeyPrefix + bucket + "|" + key + "|" + normalizeETag(etag)
+	return bodyKeyPrefix + bucket + "|" + key + "|" + etagKeyComponent(etag)
 }
 
 // MakeTombstoneKey creates the cache key for invalidation tombstones.

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -199,9 +199,19 @@ func TestMakeBodyKey(t *testing.T) {
 	if result != expected {
 		t.Errorf("MakeBodyKey() = %q, want %q", result, expected)
 	}
-	// With an ETag the body key is version-qualified (quotes/weak prefix stripped).
+	// With an ETag the body key is version-qualified (quotes stripped).
 	if got := MakeBodyKey("my-bucket", "path/to/object.txt", `"abc123"`); got != "body|my-bucket|path/to/object.txt|abc123" {
 		t.Errorf("MakeBodyKey(etag) = %q, want %q", got, "body|my-bucket|path/to/object.txt|abc123")
+	}
+	// A weak validator and a strong validator with the same value must NOT collide:
+	// they can describe different bytes, so they get distinct body keys.
+	strong := MakeBodyKey("b", "k", `"abc"`)
+	weak := MakeBodyKey("b", "k", `W/"abc"`)
+	if strong == weak {
+		t.Errorf("weak and strong ETag share a body key %q — different validators must differ", strong)
+	}
+	if weak != "body|b|k|W/abc" {
+		t.Errorf("MakeBodyKey(weak) = %q, want %q", weak, "body|b|k|W/abc")
 	}
 }
 


### PR DESCRIPTION
## What & why

Two Cursor-bot findings on the ETag-versioned-body work (#95), both about `MakeBodyKey` / body-cache-key correctness.

### 1. Empty-ETag objects on the streaming write path (Medium)
`PutWithMeta` refuses objects with no ETag — they'd share a single unversioned body key (`MakeBodyKey(..., "")`) a concurrent overwrite could clobber in place. But the **primary streaming path**, `PutWithMetaStreamTombstoneAware`, never got the same guard. Both current callers gate on `IsCacheable` (which excludes empty ETags) before building the stream, so it's currently unreachable — but the primary path lacking the backstop the buffered path has is a latent hazard.

**Fix:** add the guard to `PutWithMetaStreamTombstoneAware`, draining the body first so a hypothetical streaming caller's pipe producer never blocks.

### 2. Weak vs. strong ETags collide on one body key (Medium)
`MakeBodyKey` normalized the ETag with `normalizeETag`, which strips the `W/` weak-validator prefix — so `"abc"` and `W/"abc"` map to the **same** body key. A weak validator only asserts semantic equivalence, so those can label different bytes; sharing a key lets a later populate clobber the other version's body under an in-flight reader (a torn read).

**Fix:** add `etagKeyComponent` (strips quotes, **preserves** the weak marker) and use it in `MakeBodyKey`. `normalizeETag` is unchanged for `MatchesETag` (conditional requests still use weak comparison).

## Tests
- `TestETagVersionedBody_EmptyETagNotCachedViaStream` — nothing cached + body drained.
- `TestMakeBodyKey` extended — weak and strong ETags don't collide.

Build, cache tests, race, and lint pass locally.

Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes object-cache keying and write-path invariants that protect against torn reads and concurrent overwrites; behavior is defensive but affects correctness of cached bodies.
> 
> **Overview**
> Aligns the **streaming** cache populate path with the buffered path by refusing objects with an empty ETag in `PutWithMetaStreamTombstoneAware`, and **draining** the reader to `io.Discard` so a hypothetical pipe producer cannot block. Adds `TestETagVersionedBody_EmptyETagNotCachedViaStream` to lock that in.
> 
> Separately, **body cache keys** no longer collapse weak and strong validators: `MakeBodyKey` uses new `etagKeyComponent` (quotes stripped, `W/` kept) instead of `normalizeETag`, so `"abc"` and `W/"abc"` cannot share one body key and clobber each other under concurrent populate. Tests assert distinct keys for weak vs strong.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb3d95b52f108f9b0fbd111e5d1d22bc8caefa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->