### PR TITLE
fix: match DeleteObjects results by (key, versionId), not key alone

### DIFF
--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -30,37 +30,32 @@ type deleteObjectEntry struct {
 }
 
 // deleteObjectsResult represents the S3 DeleteObjects response. Only the per-object
-// <Error> entries are captured (with their VersionId): successful deletes may be
-// omitted (Quiet mode), but errors are always listed in both modes, so a requested
-// entry succeeded iff it is NOT in the errored set.
+// <Error> entries are captured: successful deletes may be omitted (Quiet mode), but
+// errors are always listed in both modes, so a key had at least one successful
+// delete iff more entries were requested for it than upstream reported as errored.
 type deleteObjectsResult struct {
 	XMLName xml.Name `xml:"DeleteResult"`
 	Errors  []struct {
-		Key       string `xml:"Key"`
-		VersionId string `xml:"VersionId"`
+		Key string `xml:"Key"`
 	} `xml:"Error"`
 }
 
-// deleteEntryID identifies a delete request/response entry by (key, versionId).
-// A DeleteObjects request may list the same key multiple times with different
-// version IDs, so entries must be matched by both, not by key alone.
-func deleteEntryID(key, versionID string) string {
-	return key + "\x00" + versionID
-}
-
-// erroredDeleteEntries returns the set of (key, versionId) entries upstream
-// reported as NOT deleted, and whether the response parsed. On a parse failure the
-// caller re-invalidates all requested keys (safe over-invalidation).
-func erroredDeleteEntries(body []byte) (map[string]struct{}, bool) {
+// erroredDeleteKeyCounts returns the number of failed <Error> entries per key, and
+// whether the response parsed. Counting by key (not by version) is deliberate: it
+// is robust to VersionId representation differences between request and response
+// (omitted "" vs "null" vs a concrete id), which exact-tuple matching gets wrong.
+// On a parse failure the caller re-invalidates all requested keys (safe
+// over-invalidation).
+func erroredDeleteKeyCounts(body []byte) (map[string]int, bool) {
 	var result deleteObjectsResult
 	if err := xml.Unmarshal(body, &result); err != nil {
 		return nil, false
 	}
-	errored := make(map[string]struct{}, len(result.Errors))
+	counts := make(map[string]int)
 	for _, e := range result.Errors {
-		errored[deleteEntryID(e.Key, e.VersionId)] = struct{}{}
+		counts[e.Key]++
 	}
-	return errored, true
+	return counts, true
 }
 
 // isS3ErrorBody reports whether an XML body's root element is <Error>, the shape S3
@@ -97,15 +92,18 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
-	// This ensures cache consistency even if forwarding fails after cache invalidation
-	var requested []deleteObjectEntry
+	// This ensures cache consistency even if forwarding fails after cache invalidation.
+	// requestedCounts tracks how many entries each key was requested under (the same
+	// key may appear multiple times with different version IDs).
+	var requestedCounts map[string]int
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
+			requestedCounts = make(map[string]int)
 			for _, obj := range deleteReq.Objects {
 				s.cache.Delete(context.Background(), bucket, obj.Key)
 				metrics.RecordCacheOperation("delete", "success")
-				requested = append(requested, obj)
+				requestedCounts[obj.Key]++
 				log.Debug().
 					Str("bucket", bucket).
 					Str("key", obj.Key).
@@ -121,26 +119,21 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Re-invalidate AFTER upstream confirms the deletes, for the same
 	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
-	// bulk delete may have re-cached a not-yet-deleted object; this second
-	// tombstone blocks that stale repopulation. A key is re-invalidated if AT LEAST
-	// ONE of its requested entries succeeded — the request may list the same key
-	// under multiple version IDs, so matching failures by key alone would wrongly
-	// skip a key whose current version was deleted while an old version's delete
-	// failed, leaving a racing refill cached as stale. The metric is recorded once
-	// on the pre-forward invalidation above, so it is not counted again here.
+	// bulk delete may have re-cached a not-yet-deleted object; this second tombstone
+	// blocks that stale repopulation. A key is re-invalidated when at least one of
+	// its requested entries was deleted — i.e. more entries were requested for the
+	// key than upstream reported as errored. Counting by key (never matching version
+	// IDs) is robust to VersionId representation differences and to Quiet mode, and
+	// can never leave a truly-deleted object cached (a success is never an <Error>).
+	// A key whose entries ALL errored keeps its refill (it's still upstream). The
+	// metric is recorded once on the pre-forward invalidation above, not again here.
 	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
-		errored, parsed := erroredDeleteEntries(capture.Body)
-		reinvalidate := make(map[string]struct{}, len(requested))
-		for _, obj := range requested {
+		erroredCounts, parsed := erroredDeleteKeyCounts(capture.Body)
+		for key, reqN := range requestedCounts {
 			// On a parse failure, over-invalidate every requested key (safe).
-			if parsed {
-				if _, failed := errored[deleteEntryID(obj.Key, obj.VersionId)]; failed {
-					continue // this entry failed; another entry for the same key may still succeed
-				}
+			if parsed && reqN <= erroredCounts[key] {
+				continue // every requested entry for this key errored — object still present
 			}
-			reinvalidate[obj.Key] = struct{}{}
-		}
-		for key := range reinvalidate {
 			s.cache.Delete(context.Background(), bucket, key)
 		}
 	}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -30,28 +30,37 @@ type deleteObjectEntry struct {
 }
 
 // deleteObjectsResult represents the S3 DeleteObjects response. Only the per-object
-// <Error> entries are captured: successful deletes may be omitted (Quiet mode), so
-// success is derived as "requested minus errored".
+// <Error> entries are captured (with their VersionId): successful deletes may be
+// omitted (Quiet mode), but errors are always listed in both modes, so a requested
+// entry succeeded iff it is NOT in the errored set.
 type deleteObjectsResult struct {
 	XMLName xml.Name `xml:"DeleteResult"`
 	Errors  []struct {
-		Key string `xml:"Key"`
+		Key       string `xml:"Key"`
+		VersionId string `xml:"VersionId"`
 	} `xml:"Error"`
 }
 
-// failedDeleteKeys returns the set of keys upstream reported as NOT deleted. On a
-// parse failure it returns an empty set, so callers re-invalidate all requested
-// keys — the safe over-invalidation.
-func failedDeleteKeys(body []byte) map[string]struct{} {
-	failed := make(map[string]struct{})
+// deleteEntryID identifies a delete request/response entry by (key, versionId).
+// A DeleteObjects request may list the same key multiple times with different
+// version IDs, so entries must be matched by both, not by key alone.
+func deleteEntryID(key, versionID string) string {
+	return key + "\x00" + versionID
+}
+
+// erroredDeleteEntries returns the set of (key, versionId) entries upstream
+// reported as NOT deleted, and whether the response parsed. On a parse failure the
+// caller re-invalidates all requested keys (safe over-invalidation).
+func erroredDeleteEntries(body []byte) (map[string]struct{}, bool) {
 	var result deleteObjectsResult
 	if err := xml.Unmarshal(body, &result); err != nil {
-		return failed
+		return nil, false
 	}
+	errored := make(map[string]struct{}, len(result.Errors))
 	for _, e := range result.Errors {
-		failed[e.Key] = struct{}{}
+		errored[deleteEntryID(e.Key, e.VersionId)] = struct{}{}
 	}
-	return failed
+	return errored, true
 }
 
 // isS3ErrorBody reports whether an XML body's root element is <Error>, the shape S3
@@ -89,14 +98,14 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 
 	// Parse request to get keys being deleted and invalidate cache BEFORE forwarding
 	// This ensures cache consistency even if forwarding fails after cache invalidation
-	var deletedKeys []string
+	var requested []deleteObjectEntry
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
 			for _, obj := range deleteReq.Objects {
 				s.cache.Delete(context.Background(), bucket, obj.Key)
 				metrics.RecordCacheOperation("delete", "success")
-				deletedKeys = append(deletedKeys, obj.Key)
+				requested = append(requested, obj)
 				log.Debug().
 					Str("bucket", bucket).
 					Str("key", obj.Key).
@@ -113,16 +122,25 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	// Re-invalidate AFTER upstream confirms the deletes, for the same
 	// read-after-write reason as HandleDeleteObject: a GET racing the in-flight
 	// bulk delete may have re-cached a not-yet-deleted object; this second
-	// tombstone blocks that stale repopulation. Only keys upstream actually deleted
-	// are re-invalidated — a key that failed is still present, so tombstoning it
-	// would discard a valid racing refill. The metric is recorded once on the
-	// pre-forward invalidation above, so it is not counted again here.
+	// tombstone blocks that stale repopulation. A key is re-invalidated if AT LEAST
+	// ONE of its requested entries succeeded — the request may list the same key
+	// under multiple version IDs, so matching failures by key alone would wrongly
+	// skip a key whose current version was deleted while an old version's delete
+	// failed, leaving a racing refill cached as stale. The metric is recorded once
+	// on the pre-forward invalidation above, so it is not counted again here.
 	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
-		failed := failedDeleteKeys(capture.Body)
-		for _, key := range deletedKeys {
-			if _, bad := failed[key]; bad {
-				continue
+		errored, parsed := erroredDeleteEntries(capture.Body)
+		reinvalidate := make(map[string]struct{}, len(requested))
+		for _, obj := range requested {
+			// On a parse failure, over-invalidate every requested key (safe).
+			if parsed {
+				if _, failed := errored[deleteEntryID(obj.Key, obj.VersionId)]; failed {
+					continue // this entry failed; another entry for the same key may still succeed
+				}
 			}
+			reinvalidate[obj.Key] = struct{}{}
+		}
+		for key := range reinvalidate {
 			s.cache.Delete(context.Background(), bucket, key)
 		}
 	}

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -166,3 +166,37 @@ func TestHandleDeleteObjects_PartialFailureKeepsFailedKeyRefill(t *testing.T) {
 		t.Error("failed key's valid refill was discarded — failed keys must not be re-invalidated")
 	}
 }
+
+// A DeleteObjects request can list the same key under multiple version IDs. If one
+// version's delete succeeds and another fails, the key's current object may have
+// changed, so a racing refill must be dropped. Matching failures by key alone would
+// wrongly treat the key as fully failed and keep the stale refill.
+func TestHandleDeleteObjects_MixedVersionSuccessReinvalidatesKey(t *testing.T) {
+	var c *cache.Cache
+	const key = "versioned-key"
+
+	repopulateThenMixed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		b, _ := ParseBucketKey(r)
+		meta := &cache.CachedObjectMeta{Bucket: b, Key: key, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), b, key, meta, []byte("refill"), 60)
+		body := []byte(`<DeleteResult><Deleted><Key>versioned-key</Key><VersionId>v1</VersionId></Deleted><Error><Key>versioned-key</Key><VersionId>v2</VersionId><Code>AccessDenied</Code></Error></DeleteResult>`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenMixed}, true)
+
+	reqBody := `<Delete><Object><Key>versioned-key</Key><VersionId>v1</VersionId></Object><Object><Key>versioned-key</Key><VersionId>v2</VersionId></Object></Delete>`
+	r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	if err := svc.HandleDeleteObjects(w, r); err != nil {
+		t.Fatalf("HandleDeleteObjects: %v", err)
+	}
+
+	b, _ := ParseBucketKey(r)
+	if _, found, _ := c.GetMeta(context.Background(), b, key); found {
+		t.Error("key with a succeeded version-delete kept its stale refill — should be re-invalidated")
+	}
+}

--- a/proxy/reinvalidation_test.go
+++ b/proxy/reinvalidation_test.go
@@ -200,3 +200,43 @@ func TestHandleDeleteObjects_MixedVersionSuccessReinvalidatesKey(t *testing.T) {
 		t.Error("key with a succeeded version-delete kept its stale refill — should be re-invalidated")
 	}
 }
+
+// A failed unqualified delete may be reported with a VersionId the request never
+// sent ("null" on a version-suspended bucket, or a concrete id the server
+// resolved). Counting errors by key (not matching version tuples) keeps such a
+// failed key's valid refill instead of over-invalidating it.
+func TestHandleDeleteObjects_VersionIdMismatchFailureKeepsRefill(t *testing.T) {
+	for _, respVersion := range []string{"null", "concrete-v3"} {
+		t.Run(respVersion, func(t *testing.T) {
+			var c *cache.Cache
+			const key = "unqualified-key"
+
+			repopulateThenFail := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+				b, _ := ParseBucketKey(r)
+				meta := &cache.CachedObjectMeta{Bucket: b, Key: key, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+				_ = c.PutWithMeta(context.Background(), b, key, meta, []byte("refill"), 60)
+				// Request sent no VersionId; response errors with a different representation.
+				body := []byte(`<DeleteResult><Error><Key>unqualified-key</Key><VersionId>` + respVersion + `</VersionId><Code>AccessDenied</Code></Error></DeleteResult>`)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+				return &ResponseCapture{StatusCode: http.StatusOK, Body: body, Complete: true}, nil
+			}
+
+			var svc *Service
+			svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenFail}, true)
+
+			// Request omits VersionId entirely.
+			reqBody := `<Delete><Object><Key>unqualified-key</Key></Object></Delete>`
+			r := httptest.NewRequest(http.MethodPost, "/bulk-bucket?delete", strings.NewReader(reqBody))
+			w := httptest.NewRecorder()
+			if err := svc.HandleDeleteObjects(w, r); err != nil {
+				t.Fatalf("HandleDeleteObjects: %v", err)
+			}
+
+			b, _ := ParseBucketKey(r)
+			if _, found, _ := c.GetMeta(context.Background(), b, key); !found {
+				t.Errorf("failed delete (response VersionId=%q) over-invalidated the key — valid refill discarded", respVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

Cursor bot review (Medium). A `DeleteObjects` request can list the **same key multiple times with different `VersionId`s**. The post-forward re-invalidation (added in #99) matched failures by **key alone** (`failedDeleteKeys`), so if one entry for a key succeeded and another failed, the key landed in the "failed" set and was **skipped** — leaving a refill that raced the successful deletion cached as **stale data** (a read-after-write violation).

## Fix

Match delete request/response entries by **`(key, versionId)`**:
- Parse `<Error>` entries with their `VersionId`.
- Re-invalidate a key if **at least one** of its requested entries is *not* in the errored set (i.e. at least one version was actually deleted).

Errors are always listed in **both** Quiet and non-Quiet modes (only successes are omitted in Quiet mode), so "requested entry ∉ errored ⇒ succeeded" holds in both. A parse failure still over-invalidates every requested key (safe).

## Tests
- `TestHandleDeleteObjects_MixedVersionSuccessReinvalidatesKey` — same key, v1 succeeds + v2 fails ⇒ key is re-invalidated (stale refill dropped).
- Existing `TestHandleDeleteObjects_PartialFailureKeepsFailedKeyRefill` still passes (a fully-failed key keeps its refill).

Build, proxy tests (incl. race), the DeleteObjects integration test, and lint pass locally.

Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation logic on a hot S3 proxy path; incorrect gating could serve stale objects or drop valid cache entries, though behavior is narrowed and covered by new tests.
> 
> **Overview**
> Fixes **post-forward cache re-invalidation** for bulk `DeleteObjects` when S3 returns partial per-object `<Error>` entries on a 200 response.
> 
> Instead of treating any error for a key as “fully failed,” the handler now compares **how many delete entries were requested per key** with **how many `<Error>` entries upstream returned for that key**. A key is re-invalidated when at least one requested entry likely succeeded (`requested > errored`); if every entry for a key errored, the racing refill is kept. **Parse failures** still re-invalidate all requested keys (safe over-invalidation).
> 
> Error counting is **by key only** (not `(key, VersionId)` tuples) so mixed success/failure for the same key under different versions re-invalidates correctly, while failed unqualified deletes with mismatched `VersionId` in the response do not over-invalidate.
> 
> Adds tests for mixed version success/failure and `VersionId` representation mismatches on failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41671b10b198cda2ea5682c4e4896f7cc673a5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->