### PR TITLE
fix: don't evict valid cache entries on transient body-read errors

### DIFF
--- a/proxy/body_gone_test.go
+++ b/proxy/body_gone_test.go
@@ -4,14 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	cacheclient "github.com/tigrisdata/ocache/client"
 	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// TestBodyGone verifies only a genuinely missing/inconsistent body invalidates the
-// orphaned metadata. Transient failures — most importantly a canceled context from
-// a client that disconnected mid-read — must NOT evict a still-valid hot entry.
+// TestBodyGone pins the denylist contract: only transient failures (where the
+// cached body is probably fine and we merely couldn't finish reading it) skip the
+// heal. Every other error invalidates the orphaned metadata — the cache reports an
+// unusable body in several shapes, and missing one leaves meta outliving its body,
+// which forwards every request upstream until the meta TTL expires.
 func TestBodyGone(t *testing.T) {
 	tests := []struct {
 		name string
@@ -19,14 +29,22 @@ func TestBodyGone(t *testing.T) {
 		want bool
 	}{
 		{"nil error is not gone", nil, false},
+
+		// Unusable body — must heal.
 		{"body missing", cache.ErrNotFound, true},
 		{"wrapped body missing", fmt.Errorf("cache body unavailable: %w", cache.ErrNotFound), true},
-		{"empty body", errCacheBodyEmpty, true},
-		{"wrapped empty body", fmt.Errorf("cache body empty for b/k: %w", errCacheBodyEmpty), true},
-		{"canceled context must not evict", context.Canceled, false},
-		{"wrapped canceled context must not evict", fmt.Errorf("cache body unavailable: %w", context.Canceled), false},
-		{"deadline exceeded must not evict", context.DeadlineExceeded, false},
-		{"transient io error must not evict", errors.New("read tcp: i/o timeout"), false},
+		{"empty stream reads as EOF", io.EOF, true},
+		{"wrapped empty stream", fmt.Errorf("cache body unavailable: %w", io.EOF), true},
+		{"body shorter than metadata claims", status.Error(codes.InvalidArgument, "invalid range"), true},
+		{"plain empty-body error", errors.New("cache body empty for b/k"), true},
+
+		// Transient — must NOT evict a still-valid entry.
+		{"canceled context", context.Canceled, false},
+		{"wrapped canceled context", fmt.Errorf("cache body unavailable: %w", context.Canceled), false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"grpc canceled (cluster read)", status.Error(codes.Canceled, "context canceled"), false},
+		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "deadline"), false},
+		{"grpc peer unavailable", status.Error(codes.Unavailable, "connection refused"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -34,5 +52,34 @@ func TestBodyGone(t *testing.T) {
 				t.Errorf("bodyGone(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// A metadata entry whose versioned body is present but ZERO bytes is inconsistent.
+// ocache surfaces this as an out-of-range read rather than a clean EOF, so it must
+// still heal — otherwise the orphaned meta survives and every request re-probes and
+// forwards upstream until its TTL expires.
+func TestServeRangeFromCache_EmptyBodyReportsGone(t *testing.T) {
+	cfg := config.NewDefault()
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(&mockForwarder{}, c, cfg)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	meta := &cache.CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"e1"`, ContentLength: 100, StatusCode: 200}
+	// Seed a zero-byte body at the versioned key while meta claims 100 bytes.
+	if err := memCache.Put(ctx, cache.MakeBodyKey(bucket, key, meta.ETag), []byte{}, 60); err != nil {
+		t.Fatalf("seed empty body: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	served, err := svc.serveRangeFromCache(ctx, w, r, bucket, key, meta, "bytes=0-9", time.Now())
+	if served {
+		t.Fatal("an empty body must not be served as a 206")
+	}
+	if !bodyGone(err) {
+		t.Errorf("serveRangeFromCache err = %v, bodyGone = false; want true so the orphaned meta heals", err)
 	}
 }

--- a/proxy/body_gone_test.go
+++ b/proxy/body_gone_test.go
@@ -1,0 +1,38 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// TestBodyGone verifies only a genuinely missing/inconsistent body invalidates the
+// orphaned metadata. Transient failures — most importantly a canceled context from
+// a client that disconnected mid-read — must NOT evict a still-valid hot entry.
+func TestBodyGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error is not gone", nil, false},
+		{"body missing", cache.ErrNotFound, true},
+		{"wrapped body missing", fmt.Errorf("cache body unavailable: %w", cache.ErrNotFound), true},
+		{"empty body", errCacheBodyEmpty, true},
+		{"wrapped empty body", fmt.Errorf("cache body empty for b/k: %w", errCacheBodyEmpty), true},
+		{"canceled context must not evict", context.Canceled, false},
+		{"wrapped canceled context must not evict", fmt.Errorf("cache body unavailable: %w", context.Canceled), false},
+		{"deadline exceeded must not evict", context.DeadlineExceeded, false},
+		{"transient io error must not evict", errors.New("read tcp: i/o timeout"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bodyGone(tt.err); got != tt.want {
+				t.Errorf("bodyGone(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy/broadcast"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // signalingReader wraps an io.Reader and signals when the first Read() is called.
@@ -65,22 +67,39 @@ const (
 // success or a failure.
 var errCachePopulateDeclined = errors.New("cache populate declined: concurrent write limit reached")
 
-// errCacheBodyEmpty marks a cached entry whose metadata claims a non-zero body but
-// whose body read returned no bytes — an inconsistent entry, like a missing body.
-var errCacheBodyEmpty = errors.New("cache body empty")
-
-// bodyGone reports whether a failed cache-body read means the body is genuinely
-// missing or inconsistent — the orphaned-metadata case, where invalidating the meta
-// is what lets the entry heal (and unblocks the GetMeta(!found)-gated re-warm).
+// bodyGone reports whether a failed cache-body read should invalidate the metadata
+// that pointed at it, letting the orphaned entry heal (and unblocking the
+// GetMeta(!found)-gated re-warm).
 //
-// It deliberately returns false for every other failure. A read can also fail
-// transiently — most commonly a canceled context when the client disconnects
-// mid-stream, or an I/O error — and in those cases the cached body may be perfectly
-// valid. Evicting on those would let a burst of client disconnects tombstone hot
-// entries and force needless upstream refetches, so transient errors leave the
-// entry alone.
+// It is deliberately a denylist of transient errors rather than an allowlist of
+// "body missing" ones. The cache signals an unusable body in more ways than can be
+// reliably enumerated — not-found, a stream that ends with no bytes (io.EOF), an
+// out-of-range read against a body shorter than its metadata claims (ocache returns
+// InvalidArgument) — and missing any one of them lets metadata outlive its body, so
+// every request re-probes, fails, and forwards upstream until the metadata TTL
+// expires (up to 24h). That cold-miss loop is the severe, persistent failure.
+//
+// The errors that must NOT evict are the transient ones, where the cached body is
+// probably fine and we merely could not finish reading it — overwhelmingly a
+// canceled context from a client that disconnected mid-stream (in cluster mode the
+// read is routed over gRPC, so it can arrive as a status code instead of a plain
+// context error), or a briefly unreachable peer. Those leave the entry alone.
+// Anything else heals the entry; the worst case is one extra miss on a rare I/O
+// error, which repopulates immediately — a far better trade than a 24h loop.
 func bodyGone(err error) bool {
-	return errors.Is(err, cache.ErrNotFound) || errors.Is(err, errCacheBodyEmpty)
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Canceled, codes.DeadlineExceeded, codes.Unavailable:
+			return false
+		}
+	}
+	return true
 }
 
 // cacheWriteTimeoutForSize returns a timeout scaled to contentLength.

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -65,6 +65,24 @@ const (
 // success or a failure.
 var errCachePopulateDeclined = errors.New("cache populate declined: concurrent write limit reached")
 
+// errCacheBodyEmpty marks a cached entry whose metadata claims a non-zero body but
+// whose body read returned no bytes — an inconsistent entry, like a missing body.
+var errCacheBodyEmpty = errors.New("cache body empty")
+
+// bodyGone reports whether a failed cache-body read means the body is genuinely
+// missing or inconsistent — the orphaned-metadata case, where invalidating the meta
+// is what lets the entry heal (and unblocks the GetMeta(!found)-gated re-warm).
+//
+// It deliberately returns false for every other failure. A read can also fail
+// transiently — most commonly a canceled context when the client disconnects
+// mid-stream, or an I/O error — and in those cases the cached body may be perfectly
+// valid. Evicting on those would let a burst of client disconnects tombstone hot
+// entries and force needless upstream refetches, so transient errors leave the
+// entry alone.
+func bodyGone(err error) bool {
+	return errors.Is(err, cache.ErrNotFound) || errors.Is(err, errCacheBodyEmpty)
+}
+
 // cacheWriteTimeoutForSize returns a timeout scaled to contentLength.
 // Returns at least cacheWriteTimeout (60s), scaling up for large objects.
 func cacheWriteTimeoutForSize(contentLength int64) time.Duration {

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -124,15 +124,20 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				// serve the range from the cached object
 				if rangeHeader != "" {
 					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Serving range from cached full object")
-					if served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start); served {
+					served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+					if served {
 						return rangeErr
 					}
-					// Cached metadata survived but its versioned body is gone. Invalidate
-					// the orphaned meta so the background re-warm below is not blocked by
-					// its GetMeta(!found) gate — otherwise every range read for this key
-					// would forward to upstream until the meta TTL expires (cold-miss loop).
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body unavailable - invalidating orphaned meta and forwarding with background cache")
-					s.cache.Delete(context.Background(), bucket, key)
+					// Only invalidate when the body is genuinely gone: the metadata is then
+					// orphaned, and clearing it both heals the entry and unblocks the
+					// background re-warm below (gated on GetMeta(!found)) — otherwise every
+					// range read for this key forwards upstream until the meta TTL expires
+					// (cold-miss loop). A transient failure (e.g. the client disconnected
+					// mid-probe) leaves the still-valid entry cached.
+					if bodyGone(rangeErr) {
+						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body missing - invalidating orphaned meta and forwarding with background cache")
+						s.cache.Delete(context.Background(), bucket, key)
+					}
 					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
 				}
 
@@ -164,14 +169,16 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 
 				// Serve full response from cache
 				if cacheBodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); cacheBodyErr != nil {
-					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, invalidating orphaned meta and falling through to upstream")
-					// Metadata survived but its versioned body is gone. Invalidate the
-					// orphaned meta (same as the range and revalidation paths) so this
-					// does not become a meta-hit/body-miss loop that repeats the failed
-					// cache read on every request before refetching from upstream.
-					// serveFromCache errored before committing headers, so falling
-					// through to the miss path below is safe.
-					s.cache.Delete(context.Background(), bucket, key)
+					log.Warn().Err(cacheBodyErr).Str("bucket", bucket).Str("key", key).Msg("Cache body unavailable, falling through to upstream")
+					// Invalidate only when the body is genuinely gone: the metadata is then
+					// orphaned, and clearing it stops a meta-hit/body-miss loop that repeats
+					// the failed cache read on every request before refetching. A transient
+					// failure (e.g. the client disconnected mid-read) must not evict a
+					// still-valid hot entry. serveFromCache errors before committing
+					// headers, so falling through to the miss path below is safe either way.
+					if bodyGone(cacheBodyErr) {
+						s.cache.Delete(context.Background(), bucket, key)
+					}
 					// Fall through to cache miss path
 				} else {
 					return nil
@@ -638,7 +645,10 @@ func (s *Service) serveRangeFromCache(
 		log.Debug().Err(readErr).Str("bucket", bucket).Str("key", key).
 			Int64("start", rng.start).Int64("end", rng.end).
 			Msg("Range cache body unavailable before headers - falling through to upstream")
-		return false, nil
+		// Report the underlying error, not just served=false: the caller uses it to
+		// tell a genuinely-missing body (invalidate the orphaned meta) from a
+		// transient failure like a canceled client (leave the entry alone).
+		return false, readErr
 	}
 
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -294,7 +294,7 @@ func (s *Service) serveFromCache(
 		if bodyErr != nil {
 			return fmt.Errorf("cache body read failed: %w", bodyErr)
 		}
-		return fmt.Errorf("cache body empty for %s/%s: %w", bucket, key, errCacheBodyEmpty)
+		return fmt.Errorf("cache body empty for %s/%s", bucket, key)
 	}
 
 	// Large objects: stream via pipe

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -54,7 +54,7 @@ func (s *Service) revalidateAndServe(
 		}
 		// No stale bytes available (versioned body gone) and nothing written yet —
 		// last-resort direct fetch so the client gets a real response.
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, staleErr, start)
 	}
 	defer resp.Body.Close()
 
@@ -72,7 +72,7 @@ func (s *Service) revalidateAndServe(
 		// returns the correct 206; this unifies the full-object and range paths.
 		log.Warn().Err(revalErr).Str("bucket", bucket).Str("key", key).
 			Msg("Revalidation 304 cache body unavailable, fetching from upstream")
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, revalErr, start)
 	case http.StatusOK:
 		// Full-object response (no range or upstream ignored range)
 		return s.handleRevalidation200(ctx, w, bucket, key, resp, start)
@@ -93,7 +93,7 @@ func (s *Service) revalidateAndServe(
 			metrics.RecordRevalidationStaleServed()
 			return staleErr
 		}
-		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, start)
+		return s.forwardAfterCacheMiss(ctx, w, r, bucket, key, staleErr, start)
 	}
 }
 
@@ -103,13 +103,17 @@ func (s *Service) revalidateAndServe(
 // survived). No response headers have been written yet, so this is safe for both
 // full-object and range requests — the Range header on r makes upstream return
 // the correct 206.
-func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, start time.Time) error {
-	// Invalidate the orphaned metadata whose body was unresolvable. Without this
-	// the meta entry survives and every subsequent request is a meta-hit whose
-	// body probe fails and re-forwards to upstream — a persistent cold-miss loop,
+// bodyErr is why the cache could not serve; it decides whether the metadata is
+// invalidated (see bodyGone).
+func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, bodyErr error, start time.Time) error {
+	// Invalidate the metadata only when its body is genuinely gone. Otherwise the
+	// meta entry survives and every subsequent request is a meta-hit whose body
+	// probe fails and re-forwards to upstream — a persistent cold-miss loop,
 	// because the normal re-warm paths are gated on the metadata being absent.
 	// Deleting it makes the next request a clean miss that repopulates the cache.
-	if s.cache.IsEnabled() {
+	// A transient failure (e.g. a canceled context from a disconnected client) must
+	// not evict a still-valid entry, so bodyGone gates the delete.
+	if s.cache.IsEnabled() && bodyGone(bodyErr) {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 	w.Header().Set(XCacheHeader, XCacheMiss)
@@ -290,7 +294,7 @@ func (s *Service) serveFromCache(
 		if bodyErr != nil {
 			return fmt.Errorf("cache body read failed: %w", bodyErr)
 		}
-		return fmt.Errorf("cache body empty for %s/%s", bucket, key)
+		return fmt.Errorf("cache body empty for %s/%s: %w", bucket, key, errCacheBodyEmpty)
 	}
 
 	// Large objects: stream via pipe

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -407,6 +407,15 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 // copyObjectSucceeded reports whether a captured CopyObject response indicates the
 // copy actually happened: a 2xx status whose body is not an S3 <Error> document
 // (S3 can return 200 OK with an error body for copies that fail mid-operation).
+//
+// It deliberately does NOT gate on capture.Complete. The two ways to be wrong are
+// not symmetric: treating a failed copy as successful only re-invalidates a
+// destination that didn't change (an extra cache miss), while treating a successful
+// copy as failed skips the invalidation and can leave a racing refill of the OLD
+// destination cached — serving stale data. So an unconfirmable outcome must be
+// assumed successful. An incomplete capture still detects a failure whenever the
+// <Error> root element was captured (isS3ErrorBody only reads the first element);
+// only a body truncated before that root reads as success, which is the safe side.
 func copyObjectSucceeded(capture *ResponseCapture) bool {
 	if capture == nil || capture.StatusCode < 200 || capture.StatusCode >= 300 {
 		return false


### PR DESCRIPTION
## 1. Cache wiped on transient body errors (fixed)

The orphaned-meta invalidation ran on **every** failed cache body read, not only when the body was missing. `serveRangeFromCache` reported `served=false` for *any* probe error and **discarded the cause**, so callers deleted the metadata unconditionally. A client disconnecting mid-probe (canceled context) or a transient I/O error would tombstone a **still-valid hot entry**, forcing needless upstream refetches — under a burst of disconnects this can wipe hot keys.

**Fix:** `serveRangeFromCache` now returns the underlying probe error instead of `nil`, and a new `bodyGone(err)` predicate gates every invalidation site (range path, full-object path, `forwardAfterCacheMiss`). Only `cache.ErrNotFound` and the new `errCacheBodyEmpty` sentinel — the genuinely orphaned-metadata cases the invalidation exists to heal — evict. Canceled contexts and I/O errors leave the entry alone.

Adds `TestBodyGone` (missing/empty ⇒ evict; canceled/deadline/io-error ⇒ don't).

## 2. Copy success ignores incomplete capture (documented, behavior intentionally unchanged)

I looked at this closely and **did not change the behavior**, because the suggested direction would trade a perf issue for a correctness bug. The two failure modes are **not symmetric**:

- Treating a **failed** copy as successful ⇒ re-invalidates a destination that didn't change ⇒ **an extra cache miss** (perf only).
- Treating a **successful** copy as failed ⇒ skips invalidation ⇒ a racing refill of the **old** destination stays cached ⇒ **stale data** (correctness).

So gating on `capture.Complete` (i.e. treating an incomplete capture as "not succeeded") would risk serving stale data whenever a *successful* copy's capture was truncated. An unconfirmable outcome must be assumed successful.

Also worth noting the flagged window is narrower than it looks: `isS3ErrorBody` only reads the **first** start element, so an incomplete capture still detects a failure whenever the `<Error>` root was captured. Only a body truncated *before* the root reads as success — which is the safe side.

Added a comment recording this reasoning so it isn't re-litigated.

Build, all unit suites, race, integration, and lint pass locally.

Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation semantics on GET/revalidation paths; incorrect classification could either prolong orphaned-meta loops or evict valid entries, but the change is narrow, tested, and defaults to healing on ambiguous errors.
> 
> **Overview**
> Stops **unconditional metadata deletion** when a cache body read fails. Previously any probe failure (including client disconnect / canceled context) could evict a still-valid hot entry and force repeated upstream fetches.
> 
> Adds **`bodyGone(err)`**, a denylist of transient failures (`context.Canceled`, `DeadlineExceeded`, gRPC `Canceled` / `DeadlineExceeded` / `Unavailable`). Everything else is treated as a genuinely missing or inconsistent body and triggers heal-by-delete. **`serveRangeFromCache`** now returns the underlying probe error instead of `nil`, so callers can distinguish transient vs orphaned-meta cases.
> 
> **Invalidation is gated** on `bodyGone` for range hits, full-object cache serves, and **`forwardAfterCacheMiss`** (revalidation / stale fallbacks). Orphaned-meta healing still runs for not-found, EOF, invalid range, empty body, etc.
> 
> Adds **`TestBodyGone`** and **`TestServeRangeFromCache_EmptyBodyReportsGone`**. Documents why **`copyObjectSucceeded`** does not require `capture.Complete` (stale-data risk vs extra miss); behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15bfc6193dbc74dc3451802fc62b436184e222d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->