### PR TITLE
chore: bump pinned versions to v1.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.11.0/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.11.1/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/deploy/docker/docker-compose-cluster.release.yml
+++ b/deploy/docker/docker-compose-cluster.release.yml
@@ -12,7 +12,7 @@
 #   docker compose -f docker-compose-cluster.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.9.4) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
 # All nodes share this variable, so the cluster stays on a single version.
 
 x-tag-common: &tag-common

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -11,7 +11,7 @@
 #   docker compose -f docker-compose.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.9.4) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
 
 services:
   tag:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.0
+    newTag: v1.11.1

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.11.0
+          image: tigrisdata/tag:v1.11.1
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TAG_VERSION="${TAG_VERSION:-v1.9.4}"
+TAG_VERSION="${TAG_VERSION:-v1.11.1}"
 TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
-TAG_VERSION="${TAG_VERSION:-v1.9.4}"
+TAG_VERSION="${TAG_VERSION:-v1.11.1}"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.0
+    newTag: v1.11.1
 ```
 
 ## Production Considerations

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -9,7 +9,7 @@ Two sets of Compose files ship in this repo:
 - **`docker/docker-compose.yml`** / **`docker/docker-compose-cluster.yml`** — package a locally built binary into the image via the local `Dockerfile`. Use these for local development against source. The `Dockerfile` does not compile TAG; it copies a pre-built **Linux** binary from `docker/bin/<arch>/tag` (`<arch>` is `amd64` or `arm64`), so you must stage that binary before building — see [Building the local image](#building-the-local-image) below.
 - **`deploy/docker/docker-compose.release.yml`** / **`deploy/docker/docker-compose-cluster.release.yml`** — pull the published `tigrisdata/tag` image. Use these to run a released version without building anything, e.g. `docker compose -f docker-compose.release.yml up -d`.
 
-The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.9.4`) in your `.env`.
+The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.11.1`) in your `.env`.
 
 ### Building the local image
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.11.0
+    image: tigrisdata/tag:v1.11.1
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Why this matters (not cosmetic)

v1.11.1 is released and carries the fixes the pinned versions lack:

| Pinned version | #72 bounds | **#99 OOM fix** | **#95 (#92 truncation fix)** |
|---|---|---|---|
| `v1.9.4` — native install.sh / run.sh default | YES | **NO** | **NO** |
| `v1.11.0` — k8s manifests, README install URL | YES | **NO** | **NO** |
| `v1.11.1` — released | YES | YES | YES |

- **`deploy/kubernetes/base` pinned `v1.11.0`** — the exact build that OOM'd in prod (#98: cache-populate memory blowup → `/health` liveness restarts → 503s) and that still carries the #92 truncation bug. Deploying from these manifests **redeploys the broken build** — including if we re-onboard the workload that was routed off TAG during that incident.
- **`deploy/native/install.sh` / `run.sh` defaulted to `v1.9.4`** — three releases stale, also missing both fixes.
- **README's install URL** pointed at `v1.11.0`.

## Changes

Every pin and doc example → `v1.11.1`:
- **k8s:** `kustomization.yaml` `newTag`, `statefulset.yaml` `image`
- **native:** `install.sh`, `run.sh` `TAG_VERSION` defaults
- **README:** install.sh URL
- **docs:** `tls.md` image, `deploy.md` newTag, `docker.md` TAG_VERSION example
- **deploy/docker:** `TAG_VERSION` examples in the `*.release.yml` comments

Unchanged (correct as-is): the release compose files still default to `${TAG_VERSION:-latest}`, and `docker/` still builds from source for local dev.

## Verification

- `v1.11.1` contains #72, #95 and #99 (`git merge-base --is-ancestor`)
- Image exists on Docker Hub, pushed `2026-07-16T21:19:02Z`
- `tag-releases.t3.storage.dev/v1.11.1/install.sh` → **200**
- `kubectl kustomize deploy/kubernetes/base` renders `tigrisdata/tag:v1.11.1`
- `bash -n` clean on both native scripts

## Follow-up worth considering

These pins have now drifted twice (v1.9.4 → v1.11.0 → v1.11.1) and drift silently — the manifests kept pointing at a known-bad build after the fix shipped. Worth automating the bump in the release workflow (or asserting it in CI) so a release can't leave the deploy manifests behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-pin updates only; no application code or runtime logic changes.
> 
> **Overview**
> **Pins every shipped deploy path and doc example to `v1.11.1`**, replacing older defaults that still pointed at builds missing the cache-populate OOM fix (#99) and truncation fix (#95).
> 
> Kubernetes **base** manifests (`kustomization.yaml` `newTag` and `statefulset.yaml` image) move from `v1.11.0` to `v1.11.1`. **Native** `install.sh` and `run.sh` default `TAG_VERSION` jumps from `v1.9.4` to `v1.11.1`. **README** install URL, **docs** (`deploy.md`, `docker.md`, `tls.md`), and **Docker release compose** comment examples are updated to match.
> 
> Runtime behavior is unchanged: release Compose still uses `tigrisdata/tag:${TAG_VERSION:-latest}`; only documented/example pins and k8s/native defaults change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b415147c86b91878641204feb7549f01458bf45f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->