### PR TITLE
fix: tighten read-after-write by stamping writeStartTime before the upstream read

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -22,10 +22,11 @@ var ErrCacheDisabled = errors.New("cache is disabled")
 
 // Cache wraps ocache client for TAG.
 type Cache struct {
-	client     cacheclient.CacheClient
-	defaultTTL int64 // seconds
-	enabled    bool
-	closed     bool
+	client       cacheclient.CacheClient
+	defaultTTL   int64 // seconds
+	tombstoneTTL int64 // seconds; must outlive the longest racing cache-populate
+	enabled      bool
+	closed       bool
 }
 
 // NewCacheWithClient creates a cache with an injected client.
@@ -33,16 +34,19 @@ type Cache struct {
 func NewCacheWithClient(client cacheclient.CacheClient, cfg *config.CacheConfig) *Cache {
 	ttl := int64(config.DefaultCacheTTL.Seconds())
 	enabled := true // Default to enabled
+	var sizeThreshold int64
 	if cfg != nil {
 		if cfg.TTL > 0 {
 			ttl = int64(cfg.TTL.Seconds())
 		}
 		enabled = cfg.IsEnabled()
+		sizeThreshold = cfg.SizeThreshold
 	}
 	return &Cache{
-		client:     client,
-		defaultTTL: ttl,
-		enabled:    enabled,
+		client:       client,
+		defaultTTL:   ttl,
+		tombstoneTTL: TombstoneTTLSeconds(sizeThreshold),
+		enabled:      enabled,
 	}
 }
 
@@ -50,7 +54,8 @@ func NewCacheWithClient(client cacheclient.CacheClient, cfg *config.CacheConfig)
 // All operations return successfully with "not found" or nil results.
 func NewDisabledCache() *Cache {
 	return &Cache{
-		enabled: false,
+		enabled:      false,
+		tombstoneTTL: MinTombstoneTTLSeconds,
 	}
 }
 
@@ -386,9 +391,42 @@ func (c *Cache) GetRangeStream(ctx context.Context, bucket, key, etag string, st
 // Tombstone methods for cache invalidation
 // ============================================================================
 
-// tombstoneTTL is the TTL for tombstone entries (60 seconds).
-// Tombstones only need to outlive in-flight cache writes.
-const tombstoneTTL = 60
+const (
+	// MinTombstoneTTLSeconds is the floor for how long an invalidation tombstone
+	// lives (10 minutes). It comfortably exceeds a small object's populate.
+	MinTombstoneTTLSeconds = 600
+
+	// tombstoneWriteThroughput mirrors the conservative streaming-write throughput
+	// the proxy assumes when it sizes a cache-populate timeout (5 MB/s). Kept in
+	// sync by TestTombstoneTTLCoversPopulateWindow in the proxy package.
+	tombstoneWriteThroughput = 5 * 1024 * 1024
+
+	// tombstoneSafetyFactor pads the derived window to cover the upstream fetch
+	// that precedes the write, plus scheduling slack.
+	tombstoneSafetyFactor = 2
+)
+
+// TombstoneTTLSeconds returns how long an invalidation tombstone must live for a
+// given cache size threshold.
+//
+// A tombstone's whole job is to outlive any cache-populate that could race it: a
+// populate is only compared against the tombstone immediately before its metadata
+// write, so if the tombstone expires first the guard reads zero and the racing
+// (stale) write proceeds — silently resurrecting invalidated content.
+//
+// The longest populate is bounded by the upstream fetch plus the streaming write of
+// the largest cacheable object, so this is derived from sizeThreshold rather than
+// fixed: raising cache.size_threshold must not silently reintroduce that race.
+func TombstoneTTLSeconds(sizeThreshold int64) int64 {
+	ttl := int64(MinTombstoneTTLSeconds)
+	if sizeThreshold > 0 {
+		derived := (sizeThreshold / tombstoneWriteThroughput) * tombstoneSafetyFactor
+		if derived > ttl {
+			ttl = derived
+		}
+	}
+	return ttl
+}
 
 // WriteTombstone writes an invalidation marker for a key.
 // The value is the timestamp as 8 bytes (int64 big-endian).
@@ -401,7 +439,7 @@ func (c *Cache) WriteTombstone(ctx context.Context, bucket, key string) error {
 	ts := time.Now().UnixNano()
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, uint64(ts))
-	return c.client.Put(ctx, tombKey, data, tombstoneTTL)
+	return c.client.Put(ctx, tombKey, data, c.tombstoneTTL)
 }
 
 // GetTombstoneTimestamp retrieves the tombstone timestamp for a key.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -396,14 +396,26 @@ const (
 	// lives (10 minutes). It comfortably exceeds a small object's populate.
 	MinTombstoneTTLSeconds = 600
 
+	// The constants below mirror the proxy's cache-populate timeouts so the TTL can
+	// model the same window. They are kept honest by
+	// TestTombstoneTTLCoversPopulateWindow in the proxy package, which sweeps
+	// thresholds and fails if either side drifts.
+
 	// tombstoneWriteThroughput mirrors the conservative streaming-write throughput
-	// the proxy assumes when it sizes a cache-populate timeout (5 MB/s). Kept in
-	// sync by TestTombstoneTTLCoversPopulateWindow in the proxy package.
+	// the proxy assumes when sizing a cache-populate timeout (proxy:
+	// minCacheWriteThroughput, 5 MB/s).
 	tombstoneWriteThroughput = 5 * 1024 * 1024
 
-	// tombstoneSafetyFactor pads the derived window to cover the upstream fetch
-	// that precedes the write, plus scheduling slack.
-	tombstoneSafetyFactor = 2
+	// tombstoneMinWriteSeconds mirrors the proxy's floor on that write timeout
+	// (proxy: cacheWriteTimeout, 60s).
+	tombstoneMinWriteSeconds = 60
+
+	// tombstoneFetchSeconds mirrors the upstream fetch that precedes the write
+	// (proxy: backgroundFetchTimeout, 5m).
+	tombstoneFetchSeconds = 300
+
+	// tombstoneMarginSeconds is slack on top of the modeled window.
+	tombstoneMarginSeconds = 300
 )
 
 // TombstoneTTLSeconds returns how long an invalidation tombstone must live for a
@@ -414,18 +426,24 @@ const (
 // write, so if the tombstone expires first the guard reads zero and the racing
 // (stale) write proceeds — silently resurrecting invalidated content.
 //
-// The longest populate is bounded by the upstream fetch plus the streaming write of
+// The longest populate is bounded by the upstream fetch PLUS the streaming write of
 // the largest cacheable object, so this is derived from sizeThreshold rather than
 // fixed: raising cache.size_threshold must not silently reintroduce that race.
+//
+// The derivation mirrors that window's shape — write + fetch + margin — rather than
+// scaling the write time by a factor. That matters: a multiplicative approximation
+// (e.g. 2 x write) grows on a different curve than the additive window and crosses
+// it, collapsing the margin to zero where write time approaches the fetch bound
+// (~1.5 GiB) and silently reopening the race. Modeling the same shape keeps a
+// constant margin at every threshold.
 func TombstoneTTLSeconds(sizeThreshold int64) int64 {
-	ttl := int64(MinTombstoneTTLSeconds)
+	write := int64(tombstoneMinWriteSeconds)
 	if sizeThreshold > 0 {
-		derived := (sizeThreshold / tombstoneWriteThroughput) * tombstoneSafetyFactor
-		if derived > ttl {
-			ttl = derived
+		if w := sizeThreshold / tombstoneWriteThroughput; w > write {
+			write = w
 		}
 	}
-	return ttl
+	return max(write+tombstoneFetchSeconds+tombstoneMarginSeconds, MinTombstoneTTLSeconds)
 }
 
 // WriteTombstone writes an invalidation marker for a key.

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -162,3 +162,31 @@ func TestETagVersionedBody_EmptyETagIsNotCached(t *testing.T) {
 		t.Error("empty-ETag object should not be cached (body present)")
 	}
 }
+
+// A tombstone must outlive any cache-populate that could race it: the populate is
+// only compared against the tombstone right before its metadata write, so an
+// expired tombstone reads as zero and lets the stale write through. The TTL is
+// therefore derived from the size threshold, not fixed — raising size_threshold
+// must not silently shorten the guard relative to the write it has to outlive.
+func TestTombstoneTTLSeconds(t *testing.T) {
+	// Small/unset thresholds still get the floor.
+	if got := TombstoneTTLSeconds(0); got != MinTombstoneTTLSeconds {
+		t.Errorf("TombstoneTTLSeconds(0) = %d, want floor %d", got, MinTombstoneTTLSeconds)
+	}
+	if got := TombstoneTTLSeconds(1024); got != MinTombstoneTTLSeconds {
+		t.Errorf("TombstoneTTLSeconds(1KiB) = %d, want floor %d", got, MinTombstoneTTLSeconds)
+	}
+	// The 60s that shipped before was far shorter than a large object's write.
+	if MinTombstoneTTLSeconds <= 60 {
+		t.Errorf("floor %d is not meaningfully above the old 60s tombstone TTL", MinTombstoneTTLSeconds)
+	}
+	// A large threshold scales the TTL past the floor.
+	big := int64(10 * 1024 * 1024 * 1024) // 10 GiB
+	if got := TombstoneTTLSeconds(big); got <= MinTombstoneTTLSeconds {
+		t.Errorf("TombstoneTTLSeconds(10GiB) = %d, want > floor %d (must scale with size_threshold)", got, MinTombstoneTTLSeconds)
+	}
+	// Monotonic in the threshold.
+	if TombstoneTTLSeconds(big) <= TombstoneTTLSeconds(big/4) {
+		t.Error("TombstoneTTLSeconds must be non-decreasing in size_threshold")
+	}
+}

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -169,23 +169,31 @@ func TestETagVersionedBody_EmptyETagIsNotCached(t *testing.T) {
 // therefore derived from the size threshold, not fixed — raising size_threshold
 // must not silently shorten the guard relative to the write it has to outlive.
 func TestTombstoneTTLSeconds(t *testing.T) {
-	// Small/unset thresholds still get the floor.
-	if got := TombstoneTTLSeconds(0); got != MinTombstoneTTLSeconds {
-		t.Errorf("TombstoneTTLSeconds(0) = %d, want floor %d", got, MinTombstoneTTLSeconds)
+	// Never below the floor, and always well past the fixed 60s that shipped before
+	// (which was far shorter than a large object's write).
+	if got := TombstoneTTLSeconds(0); got < MinTombstoneTTLSeconds {
+		t.Errorf("TombstoneTTLSeconds(0) = %d, want >= floor %d", got, MinTombstoneTTLSeconds)
 	}
-	if got := TombstoneTTLSeconds(1024); got != MinTombstoneTTLSeconds {
-		t.Errorf("TombstoneTTLSeconds(1KiB) = %d, want floor %d", got, MinTombstoneTTLSeconds)
-	}
-	// The 60s that shipped before was far shorter than a large object's write.
 	if MinTombstoneTTLSeconds <= 60 {
 		t.Errorf("floor %d is not meaningfully above the old 60s tombstone TTL", MinTombstoneTTLSeconds)
 	}
-	// A large threshold scales the TTL past the floor.
-	big := int64(10 * 1024 * 1024 * 1024) // 10 GiB
-	if got := TombstoneTTLSeconds(big); got <= MinTombstoneTTLSeconds {
-		t.Errorf("TombstoneTTLSeconds(10GiB) = %d, want > floor %d (must scale with size_threshold)", got, MinTombstoneTTLSeconds)
+
+	// The TTL must track the write time ADDITIVELY. Doubling the threshold must add
+	// roughly the extra write time, not double the whole TTL: a multiplicative curve
+	// crosses the additive populate window and collapses the margin (see
+	// TestTombstoneTTLCoversPopulateWindow).
+	const gib = int64(1) << 30
+	d2, d4 := TombstoneTTLSeconds(2*gib), TombstoneTTLSeconds(4*gib)
+	extraWrite := (4*gib)/tombstoneWriteThroughput - (2*gib)/tombstoneWriteThroughput
+	if d4-d2 != extraWrite {
+		t.Errorf("TTL grew by %ds when the threshold went 2GiB->4GiB; want the added write time %ds (TTL must be additive in write time)", d4-d2, extraWrite)
 	}
-	// Monotonic in the threshold.
+
+	// Monotonic and scaling past the floor for large thresholds.
+	big := 10 * gib
+	if TombstoneTTLSeconds(big) <= MinTombstoneTTLSeconds {
+		t.Errorf("TombstoneTTLSeconds(10GiB) = %d, want > floor %d (must scale with size_threshold)", TombstoneTTLSeconds(big), MinTombstoneTTLSeconds)
+	}
 	if TombstoneTTLSeconds(big) <= TombstoneTTLSeconds(big/4) {
 		t.Error("TombstoneTTLSeconds must be non-decreasing in size_threshold")
 	}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -133,6 +133,7 @@ func (s *Service) setupCacheListener(
 	broadcaster *broadcast.Broadcaster,
 	slotHeld bool,
 	weight int64,
+	writeStartTime int64,
 ) (*io.PipeWriter, chan error) {
 	// Bound concurrent cache-populate operations. When the limit is saturated,
 	// skip caching entirely: the object is still served/forwarded from upstream,
@@ -150,9 +151,6 @@ func (s *Service) setupCacheListener(
 			return nil, nil
 		}
 	}
-
-	// Record when this write started - used to check against tombstones
-	writeStartTime := time.Now().UnixNano()
 
 	listener := broadcaster.Subscribe()
 	if listener == nil {
@@ -349,6 +347,12 @@ func (s *Service) fetchFullObjectToCache(
 		}
 	}()
 
+	// Stamp the cache-write start BEFORE the upstream request, for the same reason
+	// as the inline path: a timestamp taken after the response leaves the whole
+	// round-trip unguarded, letting an invalidation that landed mid-fetch look older
+	// than our write and pass the tombstone check.
+	writeStartTime := time.Now().UnixNano()
+
 	// Execute full object request (no Range header)
 	resp, err := s.forwarder.DoFullObjectRequest(ctx, bucket, key, accessKey, secretKey)
 	if err != nil {
@@ -380,7 +384,7 @@ func (s *Service) fetchFullObjectToCache(
 	// Hand the reserved slot to the cache listener (streams to cache via pipe).
 	// Ownership of releasing the slot transfers to setupCacheListener, so drop
 	// our own release regardless of the result.
-	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster, true, weight)
+	cachePipeWriter, cacheErrCh := s.setupCacheListener(ctx, bucket, key, broadcaster, true, weight, writeStartTime)
 	slotOwned = false
 	if cachePipeWriter == nil {
 		// No listener could be created; nothing to populate.

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -319,6 +319,18 @@ func (s *Service) streamFromUpstream(
 	bucket, key, accessKey, secretKey string,
 	broadcaster *broadcast.Broadcaster,
 ) error {
+	// Stamp the cache-write start BEFORE issuing the upstream request, not after
+	// its headers arrive. The tombstone guard compares this against any invalidation
+	// that landed while we were fetching, and upstream takes its read snapshot at
+	// some point after we send. Stamping after the response would leave the whole
+	// upstream round-trip unguarded: a PUT that lands in that window writes a
+	// tombstone OLDER than our timestamp, the guard passes, and we cache the
+	// pre-PUT body we just read — stale. Stamping first makes the timestamp strictly
+	// earlier than the read snapshot, so any racing invalidation is provably newer
+	// and blocks the write. The cost is skipping an occasional still-fresh populate
+	// (a miss), never serving stale.
+	writeStartTime := time.Now().UnixNano()
+
 	// Execute upstream request
 	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
 	if err != nil {
@@ -340,7 +352,7 @@ func (s *Service) streamFromUpstream(
 		// Reserve against the memory budget by the object's actual size (capped at
 		// the buffer ceiling), so small objects don't each reserve the worst case.
 		weight := s.populateWeight(resp.ContentLength)
-		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false, weight)
+		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false, weight, writeStartTime)
 	}
 
 	// If an anonymous GET succeeded and Tigris didn't set an explicit per-object ACL,

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -26,6 +26,8 @@ type mockForwarder struct {
 	forwardFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
 	// Optional ForwardWithCapture implementation for capture-gated tests
 	captureFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error)
+	// Optional DoRequestWithCreds implementation for upstream-fetch tests
+	doRequestFunc func(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error)
 }
 
 func (m *mockForwarder) Forward(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
@@ -47,6 +49,9 @@ func (m *mockForwarder) ValidateAndGetCredentials(r *http.Request) (AuthResult, 
 }
 
 func (m *mockForwarder) DoRequestWithCreds(ctx context.Context, r *http.Request, accessKey, secretKey string) (*http.Response, error) {
+	if m.doRequestFunc != nil {
+		return m.doRequestFunc(ctx, r, accessKey, secretKey)
+	}
 	return nil, nil
 }
 

--- a/proxy/tombstone_race_test.go
+++ b/proxy/tombstone_race_test.go
@@ -1,0 +1,127 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// metaCached polls for up to d, returning true as soon as the key's metadata is
+// visible. Populates finish on a background goroutine, so tests poll rather than
+// sleep; a negative assertion must exhaust d to be meaningful.
+func metaCached(c *cache.Cache, bucket, key string, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if _, found, _ := c.GetMeta(context.Background(), bucket, key); found {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestStreamFromUpstream_TombstoneDuringFetchBlocksPopulate covers issue #97: the
+// cache-write timestamp must be stamped BEFORE the upstream request, not after its
+// headers arrive.
+//
+// Upstream takes its read snapshot some time after we send. If an invalidation
+// (a racing PUT/DELETE) lands during that round-trip, a timestamp stamped after the
+// response is NEWER than the tombstone, the guard `tombTs >= writeStartTime` is
+// false, and the pre-invalidation body we just read gets cached — stale. Stamping
+// before the request makes our timestamp strictly earlier than the read snapshot,
+// so any racing invalidation is provably newer and blocks the write.
+func TestStreamFromUpstream_TombstoneDuringFetchBlocksPopulate(t *testing.T) {
+	const bucket, key = "b", "k"
+	const body = "pre-invalidation-body"
+
+	newResp := func() *http.Response {
+		h := http.Header{}
+		h.Set("ETag", `"e1"`)
+		h.Set("Content-Type", "text/plain")
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        h,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+		}
+	}
+
+	// Control: with no racing invalidation the object must actually be cached —
+	// otherwise the negative case below would pass for the wrong reason.
+	t.Run("no invalidation - populate succeeds", func(t *testing.T) {
+		mock := &mockForwarder{}
+		mock.doRequestFunc = func(ctx context.Context, r *http.Request, ak, sk string) (*http.Response, error) {
+			return newResp(), nil
+		}
+		svc, c := newTestService(mock, true)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
+		if err := svc.HandleGetObject(w, r); err != nil {
+			t.Fatalf("HandleGetObject: %v", err)
+		}
+		if !metaCached(c, bucket, key, 2*time.Second) {
+			t.Fatal("control: object should have been cached (test harness is not exercising the populate path)")
+		}
+	})
+
+	// The race: an invalidation lands while the upstream fetch is in flight.
+	t.Run("invalidation during fetch - populate blocked", func(t *testing.T) {
+		mock := &mockForwarder{}
+		var c *cache.Cache
+		mock.doRequestFunc = func(ctx context.Context, r *http.Request, ak, sk string) (*http.Response, error) {
+			// A PUT/DELETE lands upstream and invalidates while our GET is in flight.
+			// Our writeStartTime is stamped before this call, so this tombstone is newer.
+			if err := c.WriteTombstone(context.Background(), bucket, key); err != nil {
+				t.Errorf("WriteTombstone: %v", err)
+			}
+			return newResp(), nil
+		}
+		var svc *Service
+		svc, c = newTestService(mock, true)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
+		if err := svc.HandleGetObject(w, r); err != nil {
+			t.Fatalf("HandleGetObject: %v", err)
+		}
+		// The client still gets its bytes; only the populate is skipped.
+		if got := w.Body.String(); got != body {
+			t.Errorf("client body = %q, want %q", got, body)
+		}
+		if metaCached(c, bucket, key, 300*time.Millisecond) {
+			t.Error("stale populate was not blocked — writeStartTime must be stamped before the upstream read")
+		}
+	})
+}
+
+// TestTombstoneTTLCoversPopulateWindow is a cross-package drift guard for issue
+// #97[2]: a tombstone must outlive any populate that could race it. The populate
+// window is bounded by this package's timeouts, while the TTL is derived in the
+// cache package — this fails if either side moves and reopens the race.
+func TestTombstoneTTLCoversPopulateWindow(t *testing.T) {
+	for _, threshold := range []int64{
+		config.DefaultCacheSizeThreshold, // 1 GiB default
+		64 * 1024 * 1024,                 // small threshold
+		10 * 1024 * 1024 * 1024,          // raised threshold: TTL must scale with it
+	} {
+		ttl := time.Duration(cache.TombstoneTTLSeconds(threshold)) * time.Second
+
+		// Longest a populate can run before it checks the tombstone: the upstream
+		// fetch plus the streaming write of the largest cacheable object.
+		window := cacheWriteTimeoutForSize(threshold) + backgroundFetchTimeout
+		if ttl <= window {
+			t.Errorf("size_threshold=%d: tombstone TTL %v does not outlive the populate window %v — a tombstone can expire mid-write, letting a stale populate through",
+				threshold, ttl, window)
+		}
+	}
+}

--- a/proxy/tombstone_race_test.go
+++ b/proxy/tombstone_race_test.go
@@ -104,24 +104,51 @@ func TestStreamFromUpstream_TombstoneDuringFetchBlocksPopulate(t *testing.T) {
 	})
 }
 
-// TestTombstoneTTLCoversPopulateWindow is a cross-package drift guard for issue
-// #97[2]: a tombstone must outlive any populate that could race it. The populate
-// window is bounded by this package's timeouts, while the TTL is derived in the
-// cache package — this fails if either side moves and reopens the race.
-func TestTombstoneTTLCoversPopulateWindow(t *testing.T) {
-	for _, threshold := range []int64{
-		config.DefaultCacheSizeThreshold, // 1 GiB default
-		64 * 1024 * 1024,                 // small threshold
-		10 * 1024 * 1024 * 1024,          // raised threshold: TTL must scale with it
-	} {
-		ttl := time.Duration(cache.TombstoneTTLSeconds(threshold)) * time.Second
+// populateWindow is the longest a populate can run before it checks the tombstone:
+// the upstream fetch plus the streaming write of the largest cacheable object.
+func populateWindow(threshold int64) time.Duration {
+	return cacheWriteTimeoutForSize(threshold) + backgroundFetchTimeout
+}
 
-		// Longest a populate can run before it checks the tombstone: the upstream
-		// fetch plus the streaming write of the largest cacheable object.
-		window := cacheWriteTimeoutForSize(threshold) + backgroundFetchTimeout
+// TestTombstoneTTLCoversPopulateWindow is a cross-package drift guard for issue
+// #97[2]: a tombstone must outlive any populate that could race it, or it expires
+// mid-write, the guard reads zero, and a stale populate lands.
+//
+// It SWEEPS thresholds rather than spot-checking a few. The TTL and the window grow
+// on independent curves, so they can cross in a narrow band that hand-picked points
+// step right over — an earlier multiplicative TTL kept a healthy margin at 64 MiB,
+// 1 GiB and 10 GiB while collapsing to zero at ~1.5 GiB, exactly between the
+// samples.
+func TestTombstoneTTLCoversPopulateWindow(t *testing.T) {
+	const (
+		step = 16 * 1024 * 1024        // 16 MiB
+		max  = 24 * 1024 * 1024 * 1024 // sweep well past any realistic threshold
+	)
+
+	worstMargin := time.Duration(1<<62 - 1)
+	var worstAt int64
+	for size := int64(0); size <= max; size += step {
+		ttl := time.Duration(cache.TombstoneTTLSeconds(size)) * time.Second
+		window := populateWindow(size)
+		if margin := ttl - window; margin < worstMargin {
+			worstMargin, worstAt = margin, size
+		}
 		if ttl <= window {
-			t.Errorf("size_threshold=%d: tombstone TTL %v does not outlive the populate window %v — a tombstone can expire mid-write, letting a stale populate through",
-				threshold, ttl, window)
+			t.Fatalf("size_threshold=%d (%.2f GiB): tombstone TTL %v does not outlive the populate window %v — a tombstone can expire mid-write, letting a stale populate through",
+				size, float64(size)/(1<<30), ttl, window)
+		}
+	}
+	t.Logf("smallest margin over the sweep: %v at size_threshold=%.2f GiB", worstMargin, float64(worstAt)/(1<<30))
+
+	// Explicitly pin the band where a multiplicative TTL used to collapse, and the
+	// configured default.
+	for _, size := range []int64{
+		config.DefaultCacheSizeThreshold,
+		300 * 5 * 1024 * 1024, // write time == the 300s fetch bound: the old crossing point
+	} {
+		ttl := time.Duration(cache.TombstoneTTLSeconds(size)) * time.Second
+		if window := populateWindow(size); ttl <= window {
+			t.Errorf("size_threshold=%d: TTL %v <= window %v", size, ttl, window)
 		}
 	}
 }


### PR DESCRIPTION
Implements **A + B** from #97. Both were pre-existing holes in the tombstone guard, not regressions.

## [A] `writeStartTime` was stamped after the upstream read

The guard is `tombTs >= writeStartTime`, but upstream takes its read snapshot *after* we send. Stamping when the headers arrive left the **entire round-trip unguarded**:

```
T_send   GET sent
T_snap   upstream snapshot        -> returns PRE-PUT data
T_put    a PUT lands upstream
T_tomb   its tombstone written    <- inside our upstream latency
T_hdr    headers arrive           -> writeStartTime stamped HERE
```
`T_tomb < T_hdr` ⇒ guard is **false** ⇒ we cache the pre-PUT body we just read. Stale, for the full cache TTL. The window is the GET's upstream latency — not microseconds.

**Fix:** stamp before issuing the request; thread it into `setupCacheListener` (inline GET + background warm). Now `T_ws < T_snap`, so:
- read pre-PUT data ⇒ `T_ws < T_snap < T_put < T_tomb` ⇒ guard fires ⇒ **stale write always skipped** ✅
- read fresh data ⇒ may skip a populate ⇒ **a cache miss, never staleness**

A deliberate one-directional trade: an occasional self-healing miss instead of a correctness hole.

**Intentionally untouched:** `handleRevalidation200` stamps *after* its own `Delete` so its own tombstone doesn't block its write; stamping earlier would make every revalidation-200 skip its cache update. That sub-case needs its own design and stays open on #97.

## [B] Tombstone TTL was ~5x too short

Fixed `60s`, while a populate runs up to `cacheWriteTimeoutForSize(size_threshold)` (**205s** for 1 GiB) plus a fetch up to `backgroundFetchTimeout` (**300s**). The tombstone expired mid-write ⇒ guard read zero ⇒ stale write proceeded. Fix [A] *widens* that window (it now includes the round-trip), so this had to move with it.

TTL is now **derived from `size_threshold`** (floor 10 min), so raising `size_threshold` can't silently reintroduce the race. Lengthening is nearly free: a tombstone only blocks writes whose `writeStartTime` precedes it, so later writes are never blocked — cost is an 8-byte entry living longer.

## Tests

- **`TestStreamFromUpstream_TombstoneDuringFetchBlocksPopulate`** — drives a real GET whose upstream fetch invalidates mid-flight; asserts the populate is blocked *and* the client still gets its bytes, with a control proving the harness caches when there's no race. **Verified it fails when the old stamp order is reintroduced** (`stale populate was not blocked`) — it genuinely catches the bug.
- **`TestTombstoneTTLCoversPopulateWindow`** — cross-package drift guard: TTL must outlive `cacheWriteTimeoutForSize + backgroundFetchTimeout` across thresholds, so moving either side can't silently reopen the race.
- **`TestTombstoneTTLSeconds`** — floor, scaling, monotonicity.

Build, all unit suites, race, integration, and lint pass locally.

Refs #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core cache invalidation and populate correctness; mistakes could serve stale data for the full object TTL, though behavior is tightened and covered by new race/TTL tests.
> 
> **Overview**
> Closes two tombstone-guard holes that could **cache stale object bodies** after a racing PUT/DELETE (#97).
> 
> **`writeStartTime` before upstream:** Inline GET populates and background warms now record the cache-write start **before** the upstream request and pass it into `setupCacheListener`. Invalidations during the fetch produce tombstones newer than the stamp, so `PutWithMetaStreamTombstoneAware` skips the metadata write instead of caching pre-invalidation bytes. Clients still get the streamed response; only populate may be skipped (extra miss, not staleness).
> 
> **Tombstone TTL from `size_threshold`:** Invalidation markers no longer use a fixed 60s TTL. `TombstoneTTLSeconds` derives lifetime from `cache.size_threshold` (10-minute floor, scaled by assumed 5 MB/s write throughput × safety factor) so tombstones outlive long populates and raising the threshold does not shorten the guard mid-write.
> 
> **Tests:** Integration-style GET test with mid-fetch tombstone, cross-package TTL vs populate-window check, and unit tests for TTL scaling/monotonicity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48cb11c7497b6e343e1a7b80755468d5a7b626f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->