### PR TITLE
fix: invalidate read cache on CompleteMultipartUpload

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -289,15 +290,25 @@ func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w i
 
 // DeleteWithMeta removes both metadata and body from cache.
 // Writes a tombstone first to prevent in-flight cache writes from completing.
+//
+// Both steps are attempted even if the first fails (best-effort invalidation), but a
+// genuine backend failure of either is returned so callers don't report a successful
+// invalidation while stale metadata is still readable. A not-found metadata delete is
+// success — the entry is already gone.
 func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	if !c.IsEnabled() {
 		return nil
 	}
 
-	// Write tombstone FIRST - prevents in-flight writes from completing
+	var errs []error
+
+	// Write tombstone FIRST - prevents in-flight writes from completing. A failure
+	// here leaves the invalidation incomplete (an in-flight populate could resurrect
+	// the entry), so it is a real failure — but still continue to the meta delete.
 	if err := c.WriteTombstone(ctx, bucket, key); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).
 			Msg("Failed to write tombstone (continuing with delete)")
+		errs = append(errs, fmt.Errorf("write tombstone: %w", err))
 	}
 
 	metaKey := MakeMetaKey(bucket, key)
@@ -310,6 +321,11 @@ func (c *Cache) DeleteWithMeta(ctx context.Context, bucket, key string) error {
 	// streaming that exact version.
 	if err := c.client.Delete(ctx, metaKey); err != nil && !isNotFoundError(err) {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta delete error")
+		errs = append(errs, fmt.Errorf("delete meta: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("Invalidated cache metadata (body ages out via TTL)")

--- a/cache/delete_error_test.go
+++ b/cache/delete_error_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/config"
+)
+
+// flakyClient wraps a real client and can inject failures into the two backend
+// operations DeleteWithMeta performs: Put (tombstone) and Delete (metadata).
+type flakyClient struct {
+	cacheclient.CacheClient
+	putErr    error // returned by Put (tombstone write) when non-nil
+	deleteErr error // returned by Delete (metadata delete) when non-nil
+}
+
+func (f *flakyClient) Put(ctx context.Context, key string, data []byte, ttlSeconds int64) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	return f.CacheClient.Put(ctx, key, data, ttlSeconds)
+}
+
+func (f *flakyClient) Delete(ctx context.Context, key string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	return f.CacheClient.Delete(ctx, key)
+}
+
+func newCacheWithClientForTest(t *testing.T, client cacheclient.CacheClient) *Cache {
+	t.Helper()
+	cfg := config.NewDefault()
+	return NewCacheWithClient(client, &cfg.Cache)
+}
+
+// A backend failure of either step must be reported so a caller cannot record a
+// successful invalidation while stale metadata is still readable.
+func TestDeleteWithMeta_PropagatesBackendFailures(t *testing.T) {
+	backendDown := errors.New("backend unavailable")
+
+	t.Run("tombstone write fails", func(t *testing.T) {
+		c := newCacheWithClientForTest(t, &flakyClient{CacheClient: cacheclient.NewMemoryCache(), putErr: backendDown})
+		if err := c.DeleteWithMeta(context.Background(), "b", "k"); err == nil {
+			t.Error("DeleteWithMeta returned nil when the tombstone write failed — invalidation was not actually complete")
+		}
+	})
+
+	t.Run("metadata delete fails", func(t *testing.T) {
+		c := newCacheWithClientForTest(t, &flakyClient{CacheClient: cacheclient.NewMemoryCache(), deleteErr: backendDown})
+		if err := c.DeleteWithMeta(context.Background(), "b", "k"); err == nil {
+			t.Error("DeleteWithMeta returned nil when the metadata delete failed — stale metadata may remain readable")
+		}
+	})
+}
+
+// A healthy invalidation of a present entry succeeds and actually removes the meta.
+func TestDeleteWithMeta_SuccessReturnsNil(t *testing.T) {
+	c := newCacheWithClientForTest(t, cacheclient.NewMemoryCache())
+	ctx := context.Background()
+
+	meta := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1"`, ContentLength: 2, StatusCode: 200}
+	if err := c.PutWithMeta(ctx, "b", "k", meta, []byte("v1"), 60); err != nil {
+		t.Fatalf("PutWithMeta: %v", err)
+	}
+	if err := c.DeleteWithMeta(ctx, "b", "k"); err != nil {
+		t.Errorf("DeleteWithMeta of a healthy entry returned %v, want nil", err)
+	}
+	if _, found, _ := c.GetMeta(ctx, "b", "k"); found {
+		t.Error("metadata still present after a successful DeleteWithMeta")
+	}
+}
+
+// Deleting metadata that is already gone is a successful invalidation, not a failure:
+// the goal state (no cached meta) already holds.
+func TestDeleteWithMeta_NotFoundIsSuccess(t *testing.T) {
+	c := newCacheWithClientForTest(t, &flakyClient{
+		CacheClient: cacheclient.NewMemoryCache(),
+		deleteErr:   errors.New("key not found"),
+	})
+	if err := c.DeleteWithMeta(context.Background(), "b", "missing"); err != nil {
+		t.Errorf("DeleteWithMeta returned %v for an already-absent entry, want nil (not-found is success)", err)
+	}
+}

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -101,8 +101,7 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
 			requestedCounts = make(map[string]int)
 			for _, obj := range deleteReq.Objects {
-				s.cache.Delete(context.Background(), bucket, obj.Key)
-				metrics.RecordCacheOperation("delete", "success")
+				s.invalidateObject(context.Background(), bucket, obj.Key)
 				requestedCounts[obj.Key]++
 				log.Debug().
 					Str("bucket", bucket).

--- a/proxy/multipart_complete_test.go
+++ b/proxy/multipart_complete_test.go
@@ -1,0 +1,146 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+const (
+	mpBucket = "mp-bucket"
+	mpKey    = "mymultipart"
+	mpUpload = "upload-123"
+)
+
+func completeMultipartRequest() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/"+mpBucket+"/"+mpKey+"?uploadId="+mpUpload, nil)
+}
+
+// completion result body (a genuine success — not an <Error> document).
+var mpSuccessBody = []byte(`<CompleteMultipartUploadResult><ETag>"new-etag"</ETag></CompleteMultipartUploadResult>`)
+
+func seedStale(t *testing.T, c *cache.Cache) {
+	t.Helper()
+	meta := &cache.CachedObjectMeta{Bucket: mpBucket, Key: mpKey, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+	if err := c.PutWithMeta(context.Background(), mpBucket, mpKey, meta, []byte("stale"), 60); err != nil {
+		t.Fatalf("seed stale object: %v", err)
+	}
+}
+
+func staleCached(c *cache.Cache) bool {
+	_, found, _ := c.GetMeta(context.Background(), mpBucket, mpKey)
+	return found
+}
+
+// The core of issue #110: completing a multipart upload overwrites the object, so a
+// previously cached version must not survive to be served on a later GET. A GET that
+// raced the in-flight completion can also re-cache the pre-overwrite object; a
+// successful completion must re-invalidate it (read-after-write).
+func TestHandleCompleteMultipartUpload_SuccessInvalidatesOverwrittenObject(t *testing.T) {
+	var c *cache.Cache
+	repopulateThenSucceed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		// Racing GET re-caches the pre-overwrite object mid-completion.
+		meta := &cache.CachedObjectMeta{Bucket: mpBucket, Key: mpKey, ETag: `"stale"`, ContentLength: 5, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), mpBucket, mpKey, meta, []byte("stale"), 60)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(mpSuccessBody)
+		return &ResponseCapture{StatusCode: http.StatusOK, Headers: http.Header{}, Body: mpSuccessBody, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThenSucceed}, true)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleCompleteMultipartUpload(w, completeMultipartRequest()); err != nil {
+		t.Fatalf("HandleCompleteMultipartUpload: %v", err)
+	}
+	if staleCached(c) {
+		t.Error("pre-overwrite object still cached after a successful completion — read-after-write invalidation missing")
+	}
+}
+
+// A completion that fails as 200 OK with an <Error> body did not overwrite the
+// object, so a racing refill of the still-current object must survive — mirroring
+// CopyObject's 200-with-error-body handling.
+func TestHandleCompleteMultipartUpload_200ErrorBodyKeepsRacingRefill(t *testing.T) {
+	var c *cache.Cache
+	errorBody := []byte(`<Error><Code>InternalError</Code></Error>`)
+	repopulateThen200Error := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		meta := &cache.CachedObjectMeta{Bucket: mpBucket, Key: mpKey, ETag: `"refill"`, ContentLength: 6, StatusCode: 200}
+		_ = c.PutWithMeta(context.Background(), mpBucket, mpKey, meta, []byte("refill"), 60)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(errorBody)
+		return &ResponseCapture{StatusCode: http.StatusOK, Headers: http.Header{}, Body: errorBody, Complete: true}, nil
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: repopulateThen200Error}, true)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleCompleteMultipartUpload(w, completeMultipartRequest()); err != nil {
+		t.Fatalf("HandleCompleteMultipartUpload: %v", err)
+	}
+	if !staleCached(c) {
+		t.Error("racing refill discarded after a 200-with-error-body completion — that completion did not overwrite the object")
+	}
+
+	// A failed completion must not be cached as a successful idempotent replay.
+	if _, found, _ := c.GetCompletion(context.Background(), mpBucket, mpKey, mpUpload); found {
+		t.Error("200-with-error-body completion was cached as a successful completion — an idempotent replay would return the error as success")
+	}
+}
+
+// The pre-forward invalidation must fire even when the forward itself errors out:
+// the object may already have been overwritten upstream, so a stale cached copy must
+// not be left behind. This isolates the before-forward invalidation from the
+// after-forward one (which does not run when the forward returns an error).
+func TestHandleCompleteMultipartUpload_InvalidatesBeforeForward(t *testing.T) {
+	var c *cache.Cache
+	forwardErr := errors.New("upstream unreachable")
+	failForward := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		return nil, forwardErr
+	}
+
+	var svc *Service
+	svc, c = newTestService(&mockForwarder{captureFunc: failForward}, true)
+	seedStale(t, c)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleCompleteMultipartUpload(w, completeMultipartRequest()); !errors.Is(err, forwardErr) {
+		t.Fatalf("HandleCompleteMultipartUpload err = %v, want %v", err, forwardErr)
+	}
+	if staleCached(c) {
+		t.Error("stale object survived a completion whose forward errored — pre-forward invalidation missing")
+	}
+}
+
+// A successful completion is cached for idempotent replay: a second call with the
+// same uploadId must return the stored response without forwarding upstream again.
+func TestHandleCompleteMultipartUpload_SuccessCachedForIdempotentReplay(t *testing.T) {
+	var forwards int
+	succeed := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		forwards++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(mpSuccessBody)
+		return &ResponseCapture{StatusCode: http.StatusOK, Headers: http.Header{}, Body: mpSuccessBody, Complete: true}, nil
+	}
+
+	svc, _ := newTestService(&mockForwarder{captureFunc: succeed}, true)
+
+	for i := range 2 {
+		w := httptest.NewRecorder()
+		if err := svc.HandleCompleteMultipartUpload(w, completeMultipartRequest()); err != nil {
+			t.Fatalf("HandleCompleteMultipartUpload call %d: %v", i, err)
+		}
+		if got := w.Body.Bytes(); string(got) != string(mpSuccessBody) {
+			t.Errorf("call %d body = %q, want %q", i, got, mpSuccessBody)
+		}
+	}
+	if forwards != 1 {
+		t.Errorf("upstream forwarded %d times; the second identical completion must be served from the idempotency cache", forwards)
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -231,10 +231,7 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 
 	// Invalidate cache BEFORE forwarding to ensure consistency
 	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
-	if s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
-		metrics.RecordCacheOperation("delete", "success")
-	}
+	s.invalidateObject(context.Background(), bucket, key)
 
 	// Forward to Tigris, recording the upstream status.
 	rec := &statusRecorder{ResponseWriter: w}
@@ -272,10 +269,7 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 
 	// Invalidate cache BEFORE forwarding to ensure consistency
 	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
-	if s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
-		metrics.RecordCacheOperation("delete", "success")
-	}
+	s.invalidateObject(context.Background(), bucket, key)
 
 	// Forward to upstream, recording the upstream status.
 	rec := &statusRecorder{ResponseWriter: w}
@@ -424,6 +418,23 @@ func s3WriteSucceeded(capture *ResponseCapture) bool {
 	return !isS3ErrorBody(capture.Body)
 }
 
+// invalidateObject removes an object's cached metadata (writing a tombstone) and
+// records the true outcome of the attempt. A failed backend invalidation is recorded
+// as an error rather than success: a false-green delete metric would hide the very
+// read-after-write hazard the invalidation exists to prevent, since the stale entry
+// is still in place. It is a no-op when the cache is disabled.
+func (s *Service) invalidateObject(ctx context.Context, bucket, key string) {
+	if !s.cache.IsEnabled() {
+		return
+	}
+	if err := s.cache.Delete(ctx, bucket, key); err != nil {
+		metrics.RecordCacheOperation("delete", "error")
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache invalidation failed")
+		return
+	}
+	metrics.RecordCacheOperation("delete", "success")
+}
+
 // HandlePassthrough handles requests that are passed through without caching.
 func (s *Service) HandlePassthrough(w http.ResponseWriter, r *http.Request) error {
 	return s.forwarder.Forward(r.Context(), w, r)
@@ -460,10 +471,7 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 	// upload overwrites the object, so any previously cached version is now stale;
 	// like PutObject/DeleteObject/CopyObject, invalidate up front so a forward that
 	// succeeds but whose post-invalidation fails can't leave stale data served.
-	if s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
-		metrics.RecordCacheOperation("delete", "success")
-	}
+	s.invalidateObject(context.Background(), bucket, key)
 
 	// Forward to upstream with response capture
 	capture, err := s.forwarder.ForwardWithCapture(ctx, w, r)

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -397,26 +397,27 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	// blocks that stale repopulation.
 	// Gated on a confirmed-successful copy: a rejected copy leaves the destination
 	// unchanged, so re-invalidating would only discard a valid racing refill.
-	if err == nil && copyObjectSucceeded(capture) && s.cache.IsEnabled() {
+	if err == nil && s3WriteSucceeded(capture) && s.cache.IsEnabled() {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
 
 	return err
 }
 
-// copyObjectSucceeded reports whether a captured CopyObject response indicates the
-// copy actually happened: a 2xx status whose body is not an S3 <Error> document
-// (S3 can return 200 OK with an error body for copies that fail mid-operation).
+// s3WriteSucceeded reports whether a captured mutation response indicates the write
+// actually happened: a 2xx status whose body is not an S3 <Error> document. Both
+// CopyObject and CompleteMultipartUpload can return 200 OK with an error body for an
+// operation that failed mid-flight, so status alone is not enough.
 //
 // It deliberately does NOT gate on capture.Complete. The two ways to be wrong are
-// not symmetric: treating a failed copy as successful only re-invalidates a
-// destination that didn't change (an extra cache miss), while treating a successful
-// copy as failed skips the invalidation and can leave a racing refill of the OLD
-// destination cached — serving stale data. So an unconfirmable outcome must be
-// assumed successful. An incomplete capture still detects a failure whenever the
-// <Error> root element was captured (isS3ErrorBody only reads the first element);
-// only a body truncated before that root reads as success, which is the safe side.
-func copyObjectSucceeded(capture *ResponseCapture) bool {
+// not symmetric: treating a failed write as successful only re-invalidates an object
+// that didn't change (an extra cache miss), while treating a successful write as
+// failed skips the invalidation and can leave a racing refill of the OLD object
+// cached — serving stale data. So an unconfirmable outcome must be assumed
+// successful. An incomplete capture still detects a failure whenever the <Error>
+// root element was captured (isS3ErrorBody only reads the first element); only a body
+// truncated before that root reads as success, which is the safe side.
+func s3WriteSucceeded(capture *ResponseCapture) bool {
 	if capture == nil || capture.StatusCode < 200 || capture.StatusCode >= 300 {
 		return false
 	}
@@ -438,7 +439,10 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Str("uploadId", uploadId).Msg("HandleCompleteMultipartUpload")
 
-	// Check ocache first for idempotent completion (works across TAG pods)
+	// Check ocache first for idempotent completion (works across TAG pods).
+	// A replay returns the already-completed response without touching upstream and
+	// without changing the object, so it needs no read-cache invalidation — the first
+	// completion (below) already invalidated it.
 	if s.cache.IsEnabled() {
 		entry, found, err := s.cache.GetCompletion(ctx, bucket, key, uploadId)
 		if err == nil && found {
@@ -452,15 +456,36 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	// Invalidate the object's read cache BEFORE forwarding. Completing a multipart
+	// upload overwrites the object, so any previously cached version is now stale;
+	// like PutObject/DeleteObject/CopyObject, invalidate up front so a forward that
+	// succeeds but whose post-invalidation fails can't leave stale data served.
+	if s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+		metrics.RecordCacheOperation("delete", "success")
+	}
+
 	// Forward to upstream with response capture
 	capture, err := s.forwarder.ForwardWithCapture(ctx, w, r)
 	if err != nil {
 		return err
 	}
 
-	// Cache successful completions (2xx status codes) in ocache
-	// Only cache if the body was fully captured to avoid storing corrupted responses
-	if capture.StatusCode >= 200 && capture.StatusCode < 300 && capture.Complete {
+	// Re-invalidate AFTER upstream confirms the completion, for the same
+	// read-after-write reason as HandlePutObject: a GET racing the in-flight
+	// completion may have re-cached the pre-overwrite object; this second tombstone
+	// blocks that stale repopulation. Gated on a confirmed-successful completion
+	// (2xx and not a 200-with-<Error> body) so a failed completion, which leaves the
+	// object unchanged, doesn't discard a valid racing refill.
+	completed := s3WriteSucceeded(capture)
+	if completed && s.cache.IsEnabled() {
+		s.cache.Delete(context.Background(), bucket, key)
+	}
+
+	// Cache successful completions in ocache for idempotent replays. Only cache a
+	// genuine success (not a 200-with-<Error> body) that was fully captured, so we
+	// never replay a corrupted or error response as a successful completion.
+	if completed && capture.Complete {
 		if cacheErr := s.cache.PutCompletion(ctx, bucket, key, uploadId, capture.StatusCode, capture.Headers, capture.Body); cacheErr != nil {
 			log.Debug().Err(cacheErr).Msg("Failed to cache completion response")
 			// Don't fail the request if caching fails


### PR DESCRIPTION
Closes #110.

## Problem

`HandleCompleteMultipartUpload` was the only object-mutating path that never invalidated the object's **read** cache — it forwarded to upstream and cached the completion response for idempotent replays, but wrote no tombstone and deleted no meta. Completing a multipart upload overwrites the object, so a previously cached version survived and a later GET could serve the **old** bytes.

Surfaced (intermittently) by the ceph s3-test `test_multipart_upload_overwrite_existing_object`: after overwriting a 5 MiB object with a 10 MiB multipart upload, the GET returned the old 5 MiB object. Same class of read-after-write bug as #92 / #95 / #97, on the path they didn't cover.

## Fix

Mirror the `PutObject` / `DeleteObject` / `CopyObject` pattern in `HandleCompleteMultipartUpload`:

- **Invalidate before forwarding** so a forward that succeeds but whose post-invalidation fails can't leave stale data served.
- **Re-invalidate after a confirmed-successful completion** so a GET that raced the in-flight completion and re-cached the pre-overwrite object is dropped.
- The **idempotent-replay path** (completion served from the completion cache) changes nothing about the object and needs no invalidation — the first completion already invalidated it.

CompleteMultipartUpload shares CopyObject's "200 OK with `<Error>` body" failure mode, so the re-invalidation is gated on the same success check. Renamed `copyObjectSucceeded` → `s3WriteSucceeded` now that both paths use it. As a corollary, the completion is only cached for idempotent replay on a genuine success — previously a 200-with-error-body would have been stored and replayed as success.

## Tests

`proxy/multipart_complete_test.go`:
- success invalidates the overwritten object (incl. a racing mid-completion refill)
- 200-with-`<Error>` body keeps a racing refill and is not cached as a successful completion
- pre-forward invalidation fires even when the forward errors
- a successful completion is still cached for idempotent replay (second identical call served without re-forwarding)

`make lint`, `make test-proxy`, `make test-cache` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cache consistency on object-mutation paths (multipart complete, bulk delete, invalidation metrics); incorrect gating on `s3WriteSucceeded` could still serve stale data or drop valid cache entries.
> 
> **Overview**
> Fixes read-after-write staleness when **CompleteMultipartUpload** overwrites an object: the handler now **invalidates read cache before forwarding** and **re-invalidates after a confirmed success**, matching Put/Delete/Copy. Idempotent completion replays from the completion cache still skip invalidation.
> 
> **`s3WriteSucceeded`** (renamed from `copyObjectSucceeded`) gates post-write invalidation and completion idempotency caching for both Copy and multipart complete, so **200 OK with an S3 `<Error>` body** is not treated as a successful write and is not stored for replay.
> 
> **`invalidateObject`** centralizes pre-forward invalidation for Put, Delete, bulk delete, and multipart complete; **delete metrics record error** when the cache backend fails instead of always reporting success.
> 
> **`DeleteWithMeta`** still runs tombstone + meta delete best-effort but **returns joined errors** when either backend step fails (not-found meta delete remains success). New cache and proxy tests cover failure propagation and multipart invalidation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddcd52e4b9965a32294f1b81049e797be0da64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->