### PR TITLE
fix: route post-write re-invalidations through invalidateObject

### DIFF
--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -124,8 +124,8 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	// key than upstream reported as errored. Counting by key (never matching version
 	// IDs) is robust to VersionId representation differences and to Quiet mode, and
 	// can never leave a truly-deleted object cached (a success is never an <Error>).
-	// A key whose entries ALL errored keeps its refill (it's still upstream). The
-	// metric is recorded once on the pre-forward invalidation above, not again here.
+	// A key whose entries ALL errored keeps its refill (it's still upstream).
+	// Routed through invalidateObject so a failed re-invalidation is recorded/logged.
 	if err == nil && capture != nil && capture.StatusCode >= 200 && capture.StatusCode < 300 && s.cache.IsEnabled() {
 		erroredCounts, parsed := erroredDeleteKeyCounts(capture.Body)
 		for key, reqN := range requestedCounts {
@@ -133,7 +133,7 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 			if parsed && reqN <= erroredCounts[key] {
 				continue // every requested entry for this key errored — object still present
 			}
-			s.cache.Delete(context.Background(), bucket, key)
+			s.invalidateObject(context.Background(), bucket, key)
 		}
 	}
 

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -244,10 +244,10 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// restoring read-after-write semantics.
 	// Gated on a 2xx: a rejected PUT leaves the object unchanged, so re-invalidating
 	// would only discard a valid racing refill and cause an unnecessary later miss.
-	// The metric is recorded once on the pre-forward invalidation above; this
-	// second Delete is the same logical invalidation, so it is not counted again.
+	// Routed through invalidateObject (like the pre-forward call) so a failure of this
+	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
+		s.invalidateObject(context.Background(), bucket, key)
 		s.warmOnWrite(r, bucket, key)
 	}
 
@@ -282,10 +282,10 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 	// tombstone blocks that stale repopulation.
 	// Gated on a 2xx: a rejected DELETE leaves the object present, so re-invalidating
 	// would only discard a valid racing refill and cause an unnecessary later miss.
-	// The metric is recorded once on the pre-forward invalidation above; this
-	// second Delete is the same logical invalidation, so it is not counted again.
+	// Routed through invalidateObject (like the pre-forward call) so a failure of this
+	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
+		s.invalidateObject(context.Background(), bucket, key)
 	}
 
 	status := "success"
@@ -377,7 +377,7 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	// Invalidate cache for destination object BEFORE forwarding to ensure consistency
 	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
 	if s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
+		s.invalidateObject(context.Background(), bucket, key)
 	}
 
 	// Forward to upstream, capturing the response so we can confirm the copy
@@ -393,7 +393,7 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	// Gated on a confirmed-successful copy: a rejected copy leaves the destination
 	// unchanged, so re-invalidating would only discard a valid racing refill.
 	if err == nil && s3WriteSucceeded(capture) && s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
+		s.invalidateObject(context.Background(), bucket, key)
 		s.warmOnWrite(r, bucket, key)
 	}
 
@@ -542,7 +542,7 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 	// object unchanged, doesn't discard a valid racing refill.
 	completed := s3WriteSucceeded(capture)
 	if completed && s.cache.IsEnabled() {
-		s.cache.Delete(context.Background(), bucket, key)
+		s.invalidateObject(context.Background(), bucket, key)
 		// Warm-on-write is the only way to make a multipart-completed object hot:
 		// TAG never sees its assembled body, so a write-through tee is impossible.
 		s.warmOnWrite(r, bucket, key)


### PR DESCRIPTION
Follow-up to #113, addressing two review comments about post-write cache invalidations still calling `cache.Delete` directly and discarding the error.

## Problem

The **post-forward re-invalidation** in `PutObject`, `DeleteObject`, `CopyObject`, `CompleteMultipartUpload`, and bulk `DeleteObjects` — plus `CopyObject`'s **pre-forward** invalidation — called `s.cache.Delete` directly and discarded its error. That post-forward invalidation is the read-after-write guard: when a GET refills the pre-mutation object while the write is in flight, it removes/tombstones that refill. If the cache backend rejects the delete, the failure was silent — stale metadata could stay readable with no error metric or debug log — while every other invalidation site had already been moved to `invalidateObject` (which records `("delete","error")` and logs on failure).

## Fix

Route all of them through `invalidateObject`, so a failed invalidation is always recorded and logged. This makes the pre/post and Copy paths consistent with `PutObject`/`DeleteObject`/`DeleteObjects`/`CompleteMultipartUpload`'s pre-forward calls.

Both the pre- and post-forward invalidations now record the delete metric. They are two real cache operations (two tombstone writes), and surfacing a failed read-after-write-critical re-invalidation matters more than avoiding a second successful-delete tick. The stale "recorded once / not counted again" comments are updated.

## Tests

No behavior change beyond error recording/logging; the existing re-invalidation functional tests (`reinvalidation_test.go`) still pass, and `invalidateObject`'s record-on-failure path is covered by the cache-layer `DeleteWithMeta` propagation tests. `make build`, `lint`, `test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-handling consistency only; invalidation semantics and gating on successful upstream writes are unchanged.
> 
> **Overview**
> **Post-forward cache tombstones** for write paths no longer call `cache.Delete` directly with ignored errors. `PutObject`, `DeleteObject`, `CopyObject` (pre- and post-forward), `CompleteMultipartUpload`, and bulk `DeleteObjects` now use **`invalidateObject`** for the read-after-write re-invalidation, matching the pre-forward invalidation sites.
> 
> Failed backend deletes are **recorded** (`delete` / `error` metrics) and **logged** instead of failing silently when a racing GET refill must be blocked. Comments are updated to note that pre- and post-forward invalidations are separate cache operations and both count toward delete metrics when successful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0725a7288b3d6e600653eac7a5881bd9a82d0b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->