### PR TITLE
fix: never mark a cache entry public-read from a signed background fetch (P1)

### DIFF
--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -317,10 +317,15 @@ func (s *Service) setupCacheListener(
 
 // fetchFullObjectToCache fetches the full object and caches it.
 // This makes a full-object request (no Range header) and streams directly to cache.
+// When anonymous is true the fetch is unsigned and, if it succeeds, the object is
+// cached as public-read. These are inseparable: public-read may be inferred ONLY
+// from a successful UNSIGNED read (which proves anonymous readability). A signed
+// fetch — which uses TAG's credentials and can read private objects — must never
+// mark an entry public-read, or a later anonymous request could be served a private
+// object from cache.
 func (s *Service) fetchFullObjectToCache(
 	ctx context.Context,
 	bucket, key, accessKey, secretKey string,
-	publicACL bool,
 	anonymous bool,
 	broadcaster *broadcast.Broadcaster,
 ) error {
@@ -409,10 +414,11 @@ func (s *Service) fetchFullObjectToCache(
 		return errCachePopulateDeclined
 	}
 
-	// If the original request was anonymous and succeeded, the object is publicly
-	// accessible. Tigris omits X-Amz-Acl for objects inheriting bucket-level access,
-	// so inject public-read to ensure the cached metadata allows anonymous reads.
-	if publicACL && resp.Header.Get("X-Amz-Acl") == "" {
+	// The unsigned fetch succeeded, so the object is anonymously readable. Tigris
+	// omits X-Amz-Acl for objects inheriting bucket-level access, so inject public-read
+	// to ensure the cached metadata allows anonymous reads. Gated on `anonymous`: a
+	// signed fetch can read private objects, so it must never mark an entry public.
+	if anonymous && resp.Header.Get("X-Amz-Acl") == "" {
 		resp.Header.Set("X-Amz-Acl", "public-read")
 	}
 
@@ -485,9 +491,11 @@ streamLoop:
 // starts a fetch; subsequent triggers while the fetch is in progress are no-ops.
 // This avoids broadcast.Manager's "no late joiners" policy which incorrectly
 // allows multiple fetches when the first has already started streaming.
-// When anonymous is true the fetch is issued without credentials (see
-// fetchFullObjectToCache); accessKey/secretKey are then ignored.
-func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, publicACL, anonymous bool) {
+// When anonymous is true the fetch is issued without credentials and, on success,
+// cached as public-read (see fetchFullObjectToCache); accessKey/secretKey are then
+// ignored. Pass anonymous=true exactly when the triggering request was anonymous, so
+// public-read is only ever inferred from a confirmed anonymous read.
+func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool) {
 	bcastKey := "bg:" + bucket + "/" + key
 
 	// Atomic check-and-set: if key exists, a fetch is already in progress
@@ -513,7 +521,7 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 		}
 		broadcaster := broadcast.NewBroadcaster(channelBuf)
 
-		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, publicACL, anonymous, broadcaster)
+		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, anonymous, broadcaster)
 
 		switch {
 		case errors.Is(err, errCachePopulateDeclined):

--- a/proxy/cold_owner_test.go
+++ b/proxy/cold_owner_test.go
@@ -45,6 +45,9 @@ func runFetchAndBroadcast(t *testing.T, doRequestErr error) *warmForwarder {
 
 	bcaster := broadcast.NewBroadcaster(broadcast.DefaultChannelBuffer)
 	req := httptest.NewRequest(http.MethodGet, "/cold-bucket/cold-key", nil)
+	// Authenticated request → the cold-owner warm uses a signed fetch
+	// (DoFullObjectRequest). An anonymous request would warm via an unsigned fetch.
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=access/20260101/us-east-1/s3/aws4_request, Signature=deadbeef")
 	w := httptest.NewRecorder()
 
 	_ = svc.fetchAndBroadcast(ctx, w, req, "cold-bucket", "cold-key", "access", "secret", bcaster, time.Now(), "MISS")

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -298,7 +298,7 @@ func (s *Service) fetchAndBroadcast(
 		if upErr := broadcaster.Error(); upErr == nil ||
 			errors.Is(upErr, context.Canceled) || errors.Is(upErr, context.DeadlineExceeded) {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), false)
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
 			}
 		}
 	}
@@ -739,7 +739,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 	if cacheable {
 		defer func() {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), false)
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
 			}
 		}()
 	}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -371,7 +371,7 @@ func (s *Service) handleRevalidation206Range(
 		totalSize <= s.config.Cache.SizeThreshold &&
 		s.cache.IsEnabled() &&
 		accessKey != "" && secretKey != "" {
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), false)
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
 	}
 
 	return copyErr

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -448,17 +448,18 @@ func (s *Service) invalidateObject(ctx context.Context, bucket, key string) {
 // Credentials and public-read handling depend on how the write was authenticated,
 // because a write proves nothing about who may READ the object:
 //
-//   - Authenticated write: warm with the write's credentials (TAG's own in
-//     transparent mode, the client's in signing mode) and publicACL=false. The cached
-//     entry serves authenticated reads; a signing-mode write-only client's warm will
-//     fail, exactly as its own read would.
-//   - Anonymous write: warm with an UNSIGNED (anonymous) fetch and publicACL=true. A
-//     successful anonymous write only proves public-WRITE, so we must not infer
-//     public-read from it. Instead the anonymous fetch itself is the probe: upstream
-//     returns 200 only if the object is genuinely publicly READABLE (then public-read
-//     is cached, so anonymous reads hit) and 403 otherwise (nothing is cached, so a
-//     private object in a public-write bucket is never exposed). This mirrors the read
-//     path, which likewise caches public-read only after a successful anonymous GET.
+//   - Authenticated write (anonymous=false): warm with the write's credentials
+//     (TAG's own in transparent mode, the client's in signing mode) via a signed
+//     fetch, which is never marked public-read. The cached entry serves authenticated
+//     reads; a signing-mode write-only client's warm will fail, exactly as its own
+//     read would.
+//   - Anonymous write (anonymous=true): warm with an UNSIGNED fetch. A successful
+//     anonymous write only proves public-WRITE, so we must not infer public-read from
+//     it. Instead the anonymous fetch itself is the probe: upstream returns 200 only if
+//     the object is genuinely publicly READABLE (then it is cached public-read, so
+//     anonymous reads hit) and 403 otherwise (nothing is cached, so a private object in
+//     a public-write bucket is never exposed). This mirrors the read path, which
+//     likewise caches public-read only after a successful anonymous read.
 //
 // Best-effort caveat: warms are keyed by bucket/key for dedup, so if any fetch for
 // this key is already in flight — a concurrent read-path warm, or the warm from a
@@ -478,7 +479,7 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 	// probe). See the doc comment: never infer public-read from a public write.
 	if hasNoAuthCredentials(r) {
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*publicACL*/, true /*anonymous*/)
+		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*anonymous*/)
 		return
 	}
 
@@ -487,7 +488,7 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 		return
 	}
 	metrics.WarmOnWriteTriggered.Inc()
-	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*publicACL*/, false /*anonymous*/)
+	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/tests/s3compat/sdk/public_access_test.go
+++ b/tests/s3compat/sdk/public_access_test.go
@@ -266,4 +266,22 @@ func TestSDK_PublicBucket_PrivateObjectDeniedAnonymously(t *testing.T) {
 		t.Errorf("Anonymous HEAD private-obj: must NOT get X-Cache HIT")
 	}
 	t.Logf("Anonymous HEAD private-obj: status=%d, X-Cache=%s", privHeadResp.StatusCode, privHeadResp.Header.Get("X-Cache"))
+
+	// The prior anonymous requests for private-obj must not have triggered a background
+	// fetch that read the object with TAG's credentials and cached it public-read. Wait
+	// for any such fetch to settle, then repeat: it must still be 403 and never a cache
+	// HIT. A regression here is a private object served to an anonymous reader.
+	time.Sleep(500 * time.Millisecond)
+	privResp2, err := globalEnv.DoRawGetUnauthenticated(bucket, "private-obj")
+	if err != nil {
+		t.Fatalf("Repeat anonymous GET private-obj failed: %v", err)
+	}
+	io.ReadAll(privResp2.Body)
+	privResp2.Body.Close()
+	if privResp2.StatusCode != http.StatusForbidden {
+		t.Errorf("Repeat anonymous GET private-obj: expected 403, got %d (private object leaked via a background fetch caching public-read)", privResp2.StatusCode)
+	}
+	if privResp2.Header.Get("X-Cache") == "HIT" {
+		t.Errorf("Repeat anonymous GET private-obj: X-Cache HIT — private object was cached as public-read")
+	}
 }

--- a/tests/s3compat/sdk/public_access_test.go
+++ b/tests/s3compat/sdk/public_access_test.go
@@ -268,20 +268,24 @@ func TestSDK_PublicBucket_PrivateObjectDeniedAnonymously(t *testing.T) {
 	t.Logf("Anonymous HEAD private-obj: status=%d, X-Cache=%s", privHeadResp.StatusCode, privHeadResp.Header.Get("X-Cache"))
 
 	// The prior anonymous requests for private-obj must not have triggered a background
-	// fetch that read the object with TAG's credentials and cached it public-read. Wait
-	// for any such fetch to settle, then repeat: it must still be 403 and never a cache
-	// HIT. A regression here is a private object served to an anonymous reader.
-	time.Sleep(500 * time.Millisecond)
-	privResp2, err := globalEnv.DoRawGetUnauthenticated(bucket, "private-obj")
-	if err != nil {
-		t.Fatalf("Repeat anonymous GET private-obj failed: %v", err)
-	}
-	io.ReadAll(privResp2.Body)
-	privResp2.Body.Close()
-	if privResp2.StatusCode != http.StatusForbidden {
-		t.Errorf("Repeat anonymous GET private-obj: expected 403, got %d (private object leaked via a background fetch caching public-read)", privResp2.StatusCode)
-	}
-	if privResp2.Header.Get("X-Cache") == "HIT" {
-		t.Errorf("Repeat anonymous GET private-obj: X-Cache HIT — private object was cached as public-read")
+	// fetch that read the object with TAG's credentials and cached it public-read. Such
+	// a fetch is asynchronous, so a single delayed check could race it and pass while
+	// the poisoned entry is still in flight. Instead poll: with the bug, once the entry
+	// is cached public-read EVERY subsequent anonymous GET leaks it, so any iteration in
+	// the window catches a 200/HIT. Without the bug, every iteration stays 403.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, err := globalEnv.DoRawGetUnauthenticated(bucket, "private-obj")
+		if err != nil {
+			t.Fatalf("Repeat anonymous GET private-obj failed: %v", err)
+		}
+		status := r.StatusCode
+		xcache := r.Header.Get("X-Cache")
+		io.ReadAll(r.Body)
+		r.Body.Close()
+		if status != http.StatusForbidden || xcache == "HIT" {
+			t.Fatalf("Anonymous GET private-obj returned status=%d X-Cache=%q — private object exposed to an anonymous reader (cached public-read)", status, xcache)
+		}
+		time.Sleep(100 * time.Millisecond) // pace the poll; the loop asserts every iteration
 	}
 }


### PR DESCRIPTION
Fixes a P1 security issue flagged in review on the read-path background fetch.

## Vulnerability

The read-path background-fetch callers (`get_object.go:301/742`, `revalidation.go:374`) passed `publicACL=hasNoAuthCredentials(r)` but `anonymous=false`. In transparent mode an anonymous request carries **TAG's proxy credentials**, so the background fetch ran **signed** — it could read a **private** object — and then, because `publicACL=true` for the anonymous request, marked the cached metadata **public-read**. A later anonymous request would then pass the `IsPublicRead` cache-authorization check and be served that private object from cache.

## Root cause & fix

`publicACL` and `anonymous` were separate parameters, but they must always be equal: **public-read may only ever be inferred from a successful UNSIGNED read** (which actually proves anonymous readability). Keeping them separate is what allowed the unsafe `signed fetch + mark public-read` combination.

Collapse them into a single `anonymous` flag threaded through `triggerBackgroundCacheFetch` / `fetchFullObjectToCache`, so the unsafe combination is impossible by construction:
- **Anonymous request** (`anonymous=true`): unsigned fetch → 200 caches public-read, 403 caches nothing.
- **Authenticated request** (`anonymous=false`): signed fetch, never marked public-read.

The read-path callers now pass `hasNoAuthCredentials(r)` (they previously passed a hardcoded `false` for the fetch mode).

## Tests

- Strengthened `TestSDK_PublicBucket_PrivateObjectDeniedAnonymously` with a repeat anonymous GET of the private object — directly catches a background fetch that cached a private object as public-read (a single GET wouldn't).
- The cold-owner warm unit test now uses an authenticated request so it exercises the signed-fetch path (an anonymous request now correctly routes to the unsigned fetch).
- Existing warm-on-write unit tests already cover the anonymous unsigned-fetch behavior (200 → public-read cached, 403 → not cached).

`make build`, `lint`, `test`, `test-integration` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cache authorization for background populates; incorrect behavior would leak private objects to anonymous clients, though the refactor makes the unsafe signed+public-read combination impossible by construction.
> 
> **Overview**
> Fixes a **P1 cache authorization bug** where background full-object warms could label entries **public-read** after a **signed** upstream read (using TAG credentials), letting later anonymous clients be served **private** objects from cache.
> 
> **`publicACL` and `anonymous` are merged into one `anonymous` flag** on `triggerBackgroundCacheFetch` / `fetchFullObjectToCache`. **Public-read is set only when `anonymous` is true** (unsigned fetch that proves anonymous readability). Signed warms never get public-read metadata.
> 
> Read-path triggers (`get_object`, revalidation) now pass **`hasNoAuthCredentials(r)`** instead of a hardcoded fetch mode plus a separate ACL flag. Warm-on-write uses the same single flag.
> 
> **Tests:** `TestSDK_PublicBucket_PrivateObjectDeniedAnonymously` polls repeat anonymous GETs to catch async background fetches that poison the cache; the cold-owner warm test uses an authenticated request so it exercises the signed-fetch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ca606bc7dbc497f139f855cad7e2f6b6a0c4ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->