### PR TITLE
chore: bump pinned versions to v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.11.1/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.12.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/deploy/docker/docker-compose-cluster.release.yml
+++ b/deploy/docker/docker-compose-cluster.release.yml
@@ -12,7 +12,7 @@
 #   docker compose -f docker-compose-cluster.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
 # All nodes share this variable, so the cluster stays on a single version.
 
 x-tag-common: &tag-common

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -11,7 +11,7 @@
 #   docker compose -f docker-compose.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
 
 services:
   tag:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.1
+    newTag: v1.12.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.11.1
+          image: tigrisdata/tag:v1.12.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TAG_VERSION="${TAG_VERSION:-v1.11.1}"
+TAG_VERSION="${TAG_VERSION:-v1.12.0}"
 TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
-TAG_VERSION="${TAG_VERSION:-v1.11.1}"
+TAG_VERSION="${TAG_VERSION:-v1.12.0}"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.1
+    newTag: v1.12.0
 ```
 
 ## Production Considerations

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -9,7 +9,7 @@ Two sets of Compose files ship in this repo:
 - **`docker/docker-compose.yml`** / **`docker/docker-compose-cluster.yml`** — package a locally built binary into the image via the local `Dockerfile`. Use these for local development against source. The `Dockerfile` does not compile TAG; it copies a pre-built **Linux** binary from `docker/bin/<arch>/tag` (`<arch>` is `amd64` or `arm64`), so you must stage that binary before building — see [Building the local image](#building-the-local-image) below.
 - **`deploy/docker/docker-compose.release.yml`** / **`deploy/docker/docker-compose-cluster.release.yml`** — pull the published `tigrisdata/tag` image. Use these to run a released version without building anything, e.g. `docker compose -f docker-compose.release.yml up -d`.
 
-The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.11.1`) in your `.env`.
+The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.12.0`) in your `.env`.
 
 ### Building the local image
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.11.1
+    image: tigrisdata/tag:v1.12.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
v1.12.0 is released. Bumps all pinned image/version references from `v1.11.1` → `v1.12.0` so deployments and docs point at the current release (matching the `v1.11.1` bump in #105).

Updated:
- **deploy/kubernetes/base** — `statefulset.yaml` image + `kustomization.yaml` `newTag`
- **deploy/native** — `install.sh` / `run.sh` default `TAG_VERSION`
- **deploy/docker** — `*.release.yml` `TAG_VERSION` examples
- **docs** — `deploy.md` / `docker.md` / `tls.md` image/tag examples
- **README** — `install.sh` release URL

Left unchanged: the `v1.10.0` in `.github/workflows/t3-upload-release.yaml`, which is illustrative help text for a workflow-dispatch input (not a pin).

v1.12.0 contents: CompleteMultipartUpload cache invalidation (#111), ocache v1.8.0 + FIFO eviction + `tag_cache_size_bytes` (#112), cache-warm-on-write (#113/#115), and the anonymous public-read background-fetch P1 fix (#116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and default version pins only; no code or behavioral changes.
> 
> **Overview**
> Updates every **pinned** `v1.11.1` reference to **`v1.12.0`** so install paths, Compose/Kubernetes manifests, and docs match the current release.
> 
> **Kubernetes** — `deploy/kubernetes/base/statefulset.yaml` container image and `kustomization.yaml` `newTag`.
> 
> **Native** — default `TAG_VERSION` in `deploy/native/install.sh` and `run.sh`.
> 
> **Docker** — `TAG_VERSION` examples in `deploy/docker/docker-compose.release.yml` and `docker-compose-cluster.release.yml`.
> 
> **Docs & README** — image/tag examples in `docs/deploy.md`, `docs/docker.md`, `docs/tls.md`, and the versioned `install.sh` URL in `README.md`.
> 
> No application or runtime logic changes; illustrative workflow text (e.g. `v1.10.0` in CI) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd785c0c3a3409ab1bfea73cb079efec9d2e068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->