### PR TITLE
feat: add TAG_UPSTREAM_REGION env override

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -372,6 +372,11 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Upstream.Endpoint = endpoint
 	}
 
+	// Override upstream region (SigV4 signing scope) from environment
+	if region := os.Getenv("TAG_UPSTREAM_REGION"); region != "" {
+		cfg.Upstream.Region = region
+	}
+
 	// Override upstream HTTP connection pool size from environment
 	if poolSize := os.Getenv("TAG_MAX_IDLE_CONNS_PER_HOST"); poolSize != "" {
 		if size, err := strconv.Atoi(poolSize); err == nil && size > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,6 +135,7 @@ log:
 
 	// Set environment variables
 	t.Setenv("TAG_UPSTREAM_ENDPOINT", "https://t3.storage.dev")
+	t.Setenv("TAG_UPSTREAM_REGION", "us-west-2")
 	t.Setenv("TAG_CACHE_NODE_ID", "env-node-1")
 	t.Setenv("TAG_CACHE_DISK_PATH", "/env/cache/path")
 	t.Setenv("TAG_CACHE_SEED_NODES", "env-node-0:7000,env-node-1:7000")
@@ -148,6 +149,9 @@ log:
 	// Verify env overrides
 	if cfg.Upstream.Endpoint != "https://t3.storage.dev" {
 		t.Errorf("Upstream.Endpoint = %q, want https://t3.storage.dev", cfg.Upstream.Endpoint)
+	}
+	if cfg.Upstream.Region != "us-west-2" {
+		t.Errorf("Upstream.Region = %q, want us-west-2 (TAG_UPSTREAM_REGION override)", cfg.Upstream.Region)
 	}
 	if cfg.Cache.NodeID != "env-node-1" {
 		t.Errorf("Cache.NodeID = %q, want env-node-1", cfg.Cache.NodeID)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `AWS_ACCESS_KEY_ID`               | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
 | `AWS_SECRET_ACCESS_KEY`           | S3 secret key for authentication                                                | (required)               |
 | `TAG_UPSTREAM_ENDPOINT`           | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
+| `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                         | `auto`                   |
 | `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
 | `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
 | `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |


### PR DESCRIPTION
The upstream region (SigV4 signing scope) could only be set via the config file's `upstream.region` — unlike the upstream endpoint, which has `TAG_UPSTREAM_ENDPOINT`. So env-var-driven deployments (Docker/k8s, where the docs lean on `TAG_*` vars) couldn't set the region without mounting a config file. That's a real limitation for non-Tigris S3 endpoints in signing mode that need a specific region.

## Change

Add `TAG_UPSTREAM_REGION`, applied with the same precedence as the other upstream env overrides (config file < env var < CLI). Default stays `auto` (correct for Tigris).

The region feeds `NewRequestSigner(endpoint, region)` → the SigV4 credential scope and signing-key derivation for TAG-initiated upstream requests (all requests in signing mode; background fetches / revalidation in transparent mode).

## Tests & docs

- Added the region assertion to the existing env-override test (`TAG_UPSTREAM_REGION=us-west-2`).
- Added the env var to `docs/configuration.md` (the config-file `upstream.region` was already documented).

`make build`, `lint`, `test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-layer change with no new validation; wrong region could cause upstream signature errors, same as misconfigured YAML.
> 
> **Overview**
> Adds **`TAG_UPSTREAM_REGION`** so the upstream SigV4 signing scope can be set from the environment, matching how **`TAG_UPSTREAM_ENDPOINT`** works. When set, it overrides YAML `upstream.region` during `applyEnvOverrides` (same precedence as other upstream env vars); unset leaves the existing default **`auto`**.
> 
> The env-override test now asserts **`us-west-2`** when the var is set, and **`docs/configuration.md`** documents the new variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750a3876fcadddb5ae347408514545628590449a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->