### PR TITLE
Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.11.1/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.12.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/config/config.go
+++ b/config/config.go
@@ -372,6 +372,11 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Upstream.Endpoint = endpoint
 	}
 
+	// Override upstream region (SigV4 signing scope) from environment
+	if region := os.Getenv("TAG_UPSTREAM_REGION"); region != "" {
+		cfg.Upstream.Region = region
+	}
+
 	// Override upstream HTTP connection pool size from environment
 	if poolSize := os.Getenv("TAG_MAX_IDLE_CONNS_PER_HOST"); poolSize != "" {
 		if size, err := strconv.Atoi(poolSize); err == nil && size > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,6 +135,7 @@ log:
 
 	// Set environment variables
 	t.Setenv("TAG_UPSTREAM_ENDPOINT", "https://t3.storage.dev")
+	t.Setenv("TAG_UPSTREAM_REGION", "us-west-2")
 	t.Setenv("TAG_CACHE_NODE_ID", "env-node-1")
 	t.Setenv("TAG_CACHE_DISK_PATH", "/env/cache/path")
 	t.Setenv("TAG_CACHE_SEED_NODES", "env-node-0:7000,env-node-1:7000")
@@ -148,6 +149,9 @@ log:
 	// Verify env overrides
 	if cfg.Upstream.Endpoint != "https://t3.storage.dev" {
 		t.Errorf("Upstream.Endpoint = %q, want https://t3.storage.dev", cfg.Upstream.Endpoint)
+	}
+	if cfg.Upstream.Region != "us-west-2" {
+		t.Errorf("Upstream.Region = %q, want us-west-2 (TAG_UPSTREAM_REGION override)", cfg.Upstream.Region)
 	}
 	if cfg.Cache.NodeID != "env-node-1" {
 		t.Errorf("Cache.NodeID = %q, want env-node-1", cfg.Cache.NodeID)

--- a/deploy/docker/docker-compose-cluster.release.yml
+++ b/deploy/docker/docker-compose-cluster.release.yml
@@ -12,7 +12,7 @@
 #   docker compose -f docker-compose-cluster.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
 # All nodes share this variable, so the cluster stays on a single version.
 
 x-tag-common: &tag-common

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -11,7 +11,7 @@
 #   docker compose -f docker-compose.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.11.1) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
 
 services:
   tag:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.1
+    newTag: v1.12.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.11.1
+          image: tigrisdata/tag:v1.12.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TAG_VERSION="${TAG_VERSION:-v1.11.1}"
+TAG_VERSION="${TAG_VERSION:-v1.12.0}"
 TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
-TAG_VERSION="${TAG_VERSION:-v1.11.1}"
+TAG_VERSION="${TAG_VERSION:-v1.12.0}"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `AWS_ACCESS_KEY_ID`               | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
 | `AWS_SECRET_ACCESS_KEY`           | S3 secret key for authentication                                                | (required)               |
 | `TAG_UPSTREAM_ENDPOINT`           | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
+| `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                         | `auto`                   |
 | `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
 | `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
 | `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.1
+    newTag: v1.12.0
 ```
 
 ## Production Considerations

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -9,7 +9,7 @@ Two sets of Compose files ship in this repo:
 - **`docker/docker-compose.yml`** / **`docker/docker-compose-cluster.yml`** — package a locally built binary into the image via the local `Dockerfile`. Use these for local development against source. The `Dockerfile` does not compile TAG; it copies a pre-built **Linux** binary from `docker/bin/<arch>/tag` (`<arch>` is `amd64` or `arm64`), so you must stage that binary before building — see [Building the local image](#building-the-local-image) below.
 - **`deploy/docker/docker-compose.release.yml`** / **`deploy/docker/docker-compose-cluster.release.yml`** — pull the published `tigrisdata/tag` image. Use these to run a released version without building anything, e.g. `docker compose -f docker-compose.release.yml up -d`.
 
-The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.11.1`) in your `.env`.
+The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.12.0`) in your `.env`.
 
 ### Building the local image
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.11.1
+    image: tigrisdata/tag:v1.12.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly version bumps and a small, tested env override for an already-configurable signing region; no auth logic changes beyond reading the override.
> 
> **Overview**
> **Release v1.12.0** — Pinned version strings move from `v1.11.1` to `v1.12.0` in README install examples, native `install.sh`/`run.sh` defaults, Docker Compose release comments, Kubernetes `kustomization.yaml` and StatefulSet image tags, and related deployment/TLS docs.
> 
> **Configuration** — Operators can set **`TAG_UPSTREAM_REGION`** to override `upstream.region` (SigV4 signing scope) at runtime, alongside the existing YAML field; behavior is covered by `TestLoad_EnvOverrides` and documented in `docs/configuration.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41d8109786355a56fb492161838099daa7e6085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->