### PR TITLE
fix: account for all cache hits/misses (single X-Cache + counter funnel)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -73,7 +73,14 @@ rate(tag_request_duration_seconds_sum[5m]) / rate(tag_request_duration_seconds_c
 
 **Type:** Counter
 
-Total number of cache hits.
+Total number of cache hits — every request served from cache, including
+range-from-cache hits and conditional 304 (Not Modified) responses. It is
+recorded in lockstep with the `X-Cache: HIT` response header.
+
+`tag_cache_hits_total` and `tag_cache_misses_total` count only `HIT` and `MISS`.
+`REVALIDATED` responses (object changed on upstream) are neither — they are tracked
+by the `tag_revalidations_*` metrics — and `BYPASS`/`DISABLED` requests are not
+counted at all.
 
 **Example queries:**
 
@@ -81,7 +88,7 @@ Total number of cache hits.
 # Cache hit rate
 rate(tag_cache_hits_total[5m])
 
-# Cache hit ratio
+# Cache hit ratio (of hit/miss decisions; excludes REVALIDATED)
 rate(tag_cache_hits_total[5m]) /
 (rate(tag_cache_hits_total[5m]) + rate(tag_cache_misses_total[5m]))
 ```

--- a/proxy/cache_status_test.go
+++ b/proxy/cache_status_test.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// writeCacheStatus is the single point that sets the X-Cache header and the
+// hit/miss counters, so they cannot drift. This pins the mapping: HIT -> hits,
+// MISS -> misses, and REVALIDATED/BYPASS/DISABLED -> neither (they set the header
+// only).
+func TestWriteCacheStatus_HeaderAndCounterInLockstep(t *testing.T) {
+	read := func(c prometheus.Counter) float64 {
+		t.Helper()
+		var m dto.Metric
+		if err := c.Write(&m); err != nil {
+			t.Fatalf("read counter: %v", err)
+		}
+		return m.GetCounter().GetValue()
+	}
+
+	cases := []struct {
+		status        string
+		wantHitDelta  float64
+		wantMissDelta float64
+	}{
+		{XCacheHit, 1, 0},
+		{XCacheMiss, 0, 1},
+		{XCacheRevalidated, 0, 0},
+		{XCacheBypass, 0, 0},
+		{XCacheDisabled, 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			hit0, miss0 := read(metrics.CacheHits), read(metrics.CacheMisses)
+
+			w := httptest.NewRecorder()
+			writeCacheStatus(w, tc.status)
+
+			if got := w.Header().Get(XCacheHeader); got != tc.status {
+				t.Errorf("X-Cache header = %q, want %q", got, tc.status)
+			}
+			if d := read(metrics.CacheHits) - hit0; d != tc.wantHitDelta {
+				t.Errorf("%s: cache-hits delta = %v, want %v", tc.status, d, tc.wantHitDelta)
+			}
+			if d := read(metrics.CacheMisses) - miss0; d != tc.wantMissDelta {
+				t.Errorf("%s: cache-misses delta = %v, want %v", tc.status, d, tc.wantMissDelta)
+			}
+		})
+	}
+}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -138,14 +138,14 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 						log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range cache body missing - invalidating orphaned meta and forwarding with background cache")
 						s.cache.Delete(context.Background(), bucket, key)
 					}
-					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
+					// Body genuinely gone for an otherwise-cacheable request → a miss.
+					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start, XCacheMiss)
 				}
 
 				// Check conditional request: If-None-Match
 				if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
-					metrics.RecordCacheHit()
 					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
-					w.Header().Set(XCacheHeader, XCacheHit)
+					writeCacheStatus(w, XCacheHit)
 					w.Header().Set("ETag", meta.ETag)
 					w.WriteHeader(http.StatusNotModified)
 					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
@@ -156,9 +156,8 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				if ifModifiedSince != "" {
 					if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
 						if !meta.IsModifiedSince(t) {
-							metrics.RecordCacheHit()
 							log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
-							w.Header().Set(XCacheHeader, XCacheHit)
+							writeCacheStatus(w, XCacheHit)
 							w.Header().Set("ETag", meta.ETag)
 							w.WriteHeader(http.StatusNotModified)
 							metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
@@ -185,29 +184,22 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				}
 			}
 		}
-		metrics.RecordCacheMiss()
 	}
 
-	// 3. Cache miss - handle differently for range requests vs full object requests
+	// 3. Cache miss — determine the X-Cache status once (DISABLED / BYPASS / MISS);
+	// the hit/miss counter is recorded where this status is written to the response,
+	// so bypassed/disabled requests are not counted as misses.
+	xCache := s.cacheMissStatus(bypassCache)
+
 	// Range requests: forward immediately + trigger background cache fetch
 	if rangeHeader != "" {
 		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Range request cache miss - forwarding with background cache")
-		return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start)
+		return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start, xCache)
 	}
 
 	// Full object request: use broadcast manager for streaming coalescing
 	bcastKey := makeBroadcastKey(bucket, key, rangeHeader)
 	broadcaster, isFirstCaller := s.broadcastManager.GetOrCreate(bcastKey)
-
-	// Determine X-Cache header value for this request
-	var xCache string
-	if !s.cache.IsEnabled() {
-		xCache = XCacheDisabled
-	} else if bypassCache {
-		xCache = XCacheBypass
-	} else {
-		xCache = XCacheMiss
-	}
 
 	// Update active broadcasts metric
 	metrics.SetActiveBroadcasts(s.broadcastManager.ActiveCount())
@@ -482,7 +474,7 @@ func (s *Service) writeChunksToResponse(
 		if len(chunk.Data) > 0 {
 			if !headersWritten {
 				copyHeaders(w.Header(), headers)
-				w.Header().Set(XCacheHeader, xCache)
+				writeCacheStatus(w, xCache)
 				w.WriteHeader(status)
 				headersWritten = true
 			}
@@ -505,7 +497,7 @@ func (s *Service) writeChunksToResponse(
 	// Zero-byte response or all-empty chunks: commit headers now
 	if !headersWritten {
 		copyHeaders(w.Header(), headers)
-		w.Header().Set(XCacheHeader, xCache)
+		writeCacheStatus(w, xCache)
 		w.WriteHeader(status)
 	}
 
@@ -617,7 +609,7 @@ func (s *Service) serveRangeFromCache(
 	ranges, parseErr := parseRangeHeader(rangeHeader, meta.ContentLength)
 	if parseErr != nil || len(ranges) == 0 {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
-		w.Header().Set(XCacheHeader, XCacheHit)
+		writeCacheStatus(w, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
 		return true, nil
@@ -627,7 +619,7 @@ func (s *Service) serveRangeFromCache(
 	if len(ranges) > 1 {
 		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Multi-range not supported from cache")
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
-		w.Header().Set(XCacheHeader, XCacheHit)
+		writeCacheStatus(w, XCacheHit)
 		s3err.WriteError(w, r, s3err.ErrInvalidRange)
 		metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
 		return true, nil
@@ -664,7 +656,7 @@ func (s *Service) serveRangeFromCache(
 	}
 
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
-	w.Header().Set(XCacheHeader, XCacheHit)
+	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
 
 	// Stream range from cache using counting writer to track actual bytes
@@ -700,6 +692,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 	r *http.Request,
 	bucket, key, accessKey, secretKey string,
 	startTime time.Time,
+	xCache string,
 ) error {
 	// Forward the Range request directly to client (low latency)
 	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
@@ -746,7 +739,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 
 	// Write response headers
 	copyHeaders(w.Header(), resp.Header)
-	w.Header().Set(XCacheHeader, XCacheMiss)
+	writeCacheStatus(w, xCache)
 	w.WriteHeader(resp.StatusCode)
 
 	// Stream Range response body to client.

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -116,7 +116,7 @@ func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWrit
 	if s.cache.IsEnabled() && bodyGone(bodyErr) {
 		s.cache.Delete(context.Background(), bucket, key)
 	}
-	w.Header().Set(XCacheHeader, XCacheMiss)
+	writeCacheStatus(w, XCacheMiss)
 	forwardErr := s.forwarder.Forward(ctx, w, r)
 	status := "success"
 	if forwardErr != nil {
@@ -189,7 +189,7 @@ func (s *Service) handleRevalidation200(
 
 	// Write response headers to client
 	copyHeaders(w.Header(), resp.Header)
-	w.Header().Set(XCacheHeader, XCacheRevalidated)
+	writeCacheStatus(w, XCacheRevalidated)
 	w.WriteHeader(resp.StatusCode)
 
 	if !shouldCache {
@@ -264,9 +264,8 @@ func (s *Service) serveFromCache(
 ) error {
 	// Zero-byte objects: no body to serve
 	if meta.ContentLength == 0 {
-		metrics.RecordCacheHit()
 		meta.WriteHeaders(w)
-		w.Header().Set(XCacheHeader, XCacheHit)
+		writeCacheStatus(w, XCacheHit)
 		w.WriteHeader(meta.StatusCode)
 		metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
 		return nil
@@ -279,9 +278,8 @@ func (s *Service) serveFromCache(
 
 		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, bodyBuf)
 		if bodyErr == nil && bodyBuf.Len() > 0 {
-			metrics.RecordCacheHit()
 			meta.WriteHeaders(w)
-			w.Header().Set(XCacheHeader, XCacheHit)
+			writeCacheStatus(w, XCacheHit)
 			w.WriteHeader(meta.StatusCode)
 			n, _ := w.Write(bodyBuf.Bytes())
 			metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
@@ -316,9 +314,8 @@ func (s *Service) serveFromCache(
 		return fmt.Errorf("cache body unavailable: %w", readErr)
 	}
 
-	metrics.RecordCacheHit()
 	meta.WriteHeaders(w)
-	w.Header().Set(XCacheHeader, XCacheHit)
+	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(meta.StatusCode)
 
 	cw := &countingWriter{w: w}
@@ -354,7 +351,7 @@ func (s *Service) handleRevalidation206Range(
 
 	// Stream range response to client
 	copyHeaders(w.Header(), resp.Header)
-	w.Header().Set(XCacheHeader, XCacheRevalidated)
+	writeCacheStatus(w, XCacheRevalidated)
 	w.WriteHeader(resp.StatusCode)
 
 	n, copyErr := io.Copy(w, resp.Body)
@@ -426,7 +423,7 @@ func (s *Service) revalidateAndServeHead(
 		io.Copy(io.Discard, resp.Body)
 
 		copyHeaders(w.Header(), resp.Header)
-		w.Header().Set(XCacheHeader, XCacheRevalidated)
+		writeCacheStatus(w, XCacheRevalidated)
 		w.WriteHeader(resp.StatusCode)
 		metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
 		return nil
@@ -450,9 +447,8 @@ func (s *Service) revalidateAndServeHead(
 		}
 	}
 
-	metrics.RecordCacheHit()
 	meta.WriteHeaders(w)
-	w.Header().Set(XCacheHeader, XCacheHit)
+	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(meta.StatusCode)
 	metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
 	return nil

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -25,6 +25,40 @@ const (
 	XCacheRevalidated = "REVALIDATED" // Object revalidated with upstream
 )
 
+// writeCacheStatus sets the X-Cache response header and records the matching
+// hit/miss counter, keeping the header and tag_cache_{hits,misses}_total in
+// lockstep. Call it once per response, where the status is committed — never pair
+// it with a separate RecordCacheHit/RecordCacheMiss for the same response.
+//
+// HIT increments hits; MISS increments misses. REVALIDATED, BYPASS, and DISABLED
+// set the header but are neither hits nor misses: REVALIDATED (object changed on
+// upstream) is tracked by the tag_revalidations_* metrics, and a bypassed/disabled
+// request made no cache decision. Range-from-cache hits additionally call
+// RecordRangeFromCacheHit for the specialized counter.
+func writeCacheStatus(w http.ResponseWriter, status string) {
+	w.Header().Set(XCacheHeader, status)
+	switch status {
+	case XCacheHit:
+		metrics.RecordCacheHit()
+	case XCacheMiss:
+		metrics.RecordCacheMiss()
+	}
+}
+
+// cacheMissStatus returns the X-Cache status for a request not served from cache:
+// DISABLED when caching is off, BYPASS when the client opted out (Cache-Control:
+// no-store), otherwise MISS. Only MISS counts as a cache miss.
+func (s *Service) cacheMissStatus(bypassCache bool) string {
+	switch {
+	case !s.cache.IsEnabled():
+		return XCacheDisabled
+	case bypassCache:
+		return XCacheBypass
+	default:
+		return XCacheMiss
+	}
+}
+
 // Service provides the core caching proxy logic.
 type Service struct {
 	forwarder               RequestForwarder
@@ -335,27 +369,25 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 			}
 
 			if !forceRevalidate {
-				metrics.RecordCacheHit()
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD served from cache")
 				meta.WriteHeaders(w)
-				w.Header().Set(XCacheHeader, XCacheHit)
+				writeCacheStatus(w, XCacheHit)
 				w.WriteHeader(meta.StatusCode)
 				metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
 				return nil
 			}
 			// forceRevalidate but no ETag — fall through to upstream
 		}
-		metrics.RecordCacheMiss()
 	}
 
-	// Cache miss - forward to upstream
-	// Set X-Cache header before forwarding (will be included in response)
+	// Cache miss - forward to upstream. Set the X-Cache header (and the matching
+	// hit/miss counter) before forwarding; a disabled/bypassed request is neither.
 	if !s.cache.IsEnabled() {
-		w.Header().Set(XCacheHeader, XCacheDisabled)
+		writeCacheStatus(w, XCacheDisabled)
 	} else if bypassCache {
-		w.Header().Set(XCacheHeader, XCacheBypass)
+		writeCacheStatus(w, XCacheBypass)
 	} else {
-		w.Header().Set(XCacheHeader, XCacheMiss)
+		writeCacheStatus(w, XCacheMiss)
 	}
 	err = s.forwarder.Forward(ctx, w, r)
 


### PR DESCRIPTION
Follow-up to the metrics audit: the `tag_cache_{hits,misses}_total` counters had drifted from the `X-Cache` header, so a hit ratio built from them was skewed.

## Gaps fixed
- **Range-from-cache hits** recorded only `tag_range_from_cache_hits_total`, never `tag_cache_hits_total`.
- **Revalidation-fallback miss** (`forwardAfterCacheMiss`) and the **body-gone range miss** set `X-Cache: MISS` but recorded no miss.
- The **HEAD handler** recorded a miss even when the response was `BYPASS`/`DISABLED`; **range requests** always reported `MISS` (never `BYPASS`/`DISABLED`).

## Fix
Funnel every `X-Cache` write through a single `writeCacheStatus(w, status)` that sets the header **and** records the matching counter (`HIT`→hit, `MISS`→miss; `REVALIDATED`/`BYPASS`/`DISABLED`→neither). All the scattered `RecordCacheHit`/`RecordCacheMiss` calls are removed, so the header and counters can't diverge again. Added `cacheMissStatus()` so the range path reports `DISABLED`/`BYPASS`/`MISS` correctly (threaded into `handleRangeWithBackgroundCache`), and kept `RecordRangeFromCacheHit` as the specialized counter (range hits now increment both).

`REVALIDATED` stays its own category (`tag_revalidations_*`) — documented in `metrics.md`, along with a note that the hit/miss counters cover only HIT/MISS.

## Tests
- `TestWriteCacheStatus_HeaderAndCounterInLockstep` pins the header↔counter mapping for all five statuses.
- Existing integration `X-Cache` assertions still pass.

`make build`, `lint`, `test`, `test-integration` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches observability and every GetObject/HeadObject cache response path; behavior change is intentional (more accurate metrics) with low risk to request handling itself.
> 
> **Overview**
> **Fixes cache hit/miss metrics drifting from the `X-Cache` response header**, which skewed hit-ratio dashboards built from `tag_cache_hits_total` / `tag_cache_misses_total`.
> 
> All response paths now call **`writeCacheStatus`**, which sets `X-Cache` and increments counters only for **`HIT`** and **`MISS`**. **`REVALIDATED`**, **`BYPASS`**, and **`DISABLED`** set the header but do not touch hit/miss counters (revalidation stays on `tag_revalidations_*`). Scattered `RecordCacheHit` / `RecordCacheMiss` calls are removed.
> 
> **`cacheMissStatus`** picks `DISABLED` / `BYPASS` / `MISS` for non-cache serves and is threaded into range miss handling so range requests no longer always report `MISS` and HEAD no longer counts bypass/disabled as misses. **`docs/metrics.md`** clarifies what counts toward hit ratio.
> 
> **`TestWriteCacheStatus_HeaderAndCounterInLockstep`** locks the five-status mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4838c2dedf94db8fe0fa914bf40f74af5b626272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->