### PR TITLE
docs: v1.14.0 version references + fix serve-locality ratio query

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.12.0/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.14.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.12.0
+    newTag: v1.14.0
 ```
 
 ## Production Considerations

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -9,7 +9,7 @@ Two sets of Compose files ship in this repo:
 - **`docker/docker-compose.yml`** / **`docker/docker-compose-cluster.yml`** — package a locally built binary into the image via the local `Dockerfile`. Use these for local development against source. The `Dockerfile` does not compile TAG; it copies a pre-built **Linux** binary from `docker/bin/<arch>/tag` (`<arch>` is `amd64` or `arm64`), so you must stage that binary before building — see [Building the local image](#building-the-local-image) below.
 - **`deploy/docker/docker-compose.release.yml`** / **`deploy/docker/docker-compose-cluster.release.yml`** — pull the published `tigrisdata/tag` image. Use these to run a released version without building anything, e.g. `docker compose -f docker-compose.release.yml up -d`.
 
-The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.12.0`) in your `.env`.
+The examples below use the build-from-source files in `docker/`. To run a released image instead, `cd deploy/docker` and pass the `*.release.yml` files with `-f`. The released-image files default to the `latest` published image; to pin a specific release, set `TAG_VERSION` (e.g. `TAG_VERSION=v1.14.0`) in your `.env`.
 
 ### Building the local image
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.12.0
+    image: tigrisdata/tag:v1.14.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Updates pinned version references from `v1.12.0` → `v1.14.0` (current release) in `docs/tls.md`, `docs/deploy.md`, `docs/docker.md`, and `README.md`.

The `tag_cache_serve_locality_total` metric is already documented in `docs/metrics.md` (shipped with #124).

**Out of scope (flagged):** `deploy/kubernetes/base/{statefulset,kustomization}.yaml`, `deploy/native/{install,run}.sh`, and the `*.release.yml` compose examples still pin `v1.12.0`. Those are deploy config rather than docs — happy to bump them in a separate PR (or fold in here if preferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version string updates with no code or configuration changes in this PR.
> 
> **Overview**
> Updates **documentation examples** that pin a specific TAG release from **`v1.12.0` to `v1.14.0`**, aligning install and deploy snippets with the current release.
> 
> Changes cover the install-script URL in `README.md`, the Kustomize `newTag` example in `docs/deploy.md`, the `TAG_VERSION` example in `docs/docker.md`, and the Docker TLS sample image in `docs/tls.md`. No runtime, API, or deploy manifest behavior is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b8c227dcb6a8a194207f53232b8311af84a4a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->