### PR TITLE
docs: fix serve-locality remote-ratio query (was remote/remote)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -153,9 +153,12 @@ everything is `local`.
 **Example queries:**
 
 ```promql
-# Remote serve ratio (fraction of cache reads pulled cross-node; lower is better)
-rate(tag_cache_serve_locality_total{locality="remote"}[5m]) /
-rate(tag_cache_serve_locality_total[5m])
+# Remote serve ratio (fraction of cache reads pulled cross-node; lower is better).
+# Aggregate with sum() so the denominator is local+remote; dividing the raw
+# vectors would match locality="remote" against itself and always report 1.
+sum(rate(tag_cache_serve_locality_total{locality="remote"}[5m]))
+/
+sum(rate(tag_cache_serve_locality_total[5m]))
 
 # Cross-node read rate per node
 sum by (pod) (rate(tag_cache_serve_locality_total{locality="remote"}[5m]))


### PR DESCRIPTION
The `tag_cache_serve_locality_total` remote-ratio example in `docs/metrics.md` divided the raw vectors, so Prometheus matched `locality="remote"` against itself (the `local` denominator series has no match and is dropped) and always reported 1 instead of remote÷total. Wrap both sides in `sum()` so the denominator aggregates local+remote.

Same fix applied to the external tigris-os-docs (tigrisdata/tigris-os-docs#513), where Greptile caught it. Follow-up to #124/#126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example PromQL query; no runtime or metric behavior is modified.
> 
> **Overview**
> Corrects the **`tag_cache_serve_locality_total` remote-ratio** example in `docs/metrics.md`. The query now uses **`sum()` on both numerator and denominator** so the ratio is remote reads over total (local + remote).
> 
> Adds a short note that dividing the raw labeled vectors causes Prometheus to align only **`locality="remote"`** series, drop the unmatched **`local`** denominator, and **always yield 1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4639bff6cfda6232afd39ea4433f9d529ac44eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->