### PR TITLE
chore: bump deploy version pins to v1.14.0

### DIFF
--- a/deploy/docker/docker-compose-cluster.release.yml
+++ b/deploy/docker/docker-compose-cluster.release.yml
@@ -12,7 +12,7 @@
 #   docker compose -f docker-compose-cluster.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.14.0) in your .env.
 # All nodes share this variable, so the cluster stays on a single version.
 
 x-tag-common: &tag-common

--- a/deploy/docker/docker-compose.release.yml
+++ b/deploy/docker/docker-compose.release.yml
@@ -11,7 +11,7 @@
 #   docker compose -f docker-compose.release.yml up -d
 #
 # Defaults to the latest published image. For reproducible deployments, pin a
-# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.12.0) in your .env.
+# specific release by setting TAG_VERSION (e.g. TAG_VERSION=v1.14.0) in your .env.
 
 services:
   tag:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.12.0
+    newTag: v1.14.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.12.0
+          image: tigrisdata/tag:v1.14.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TAG_VERSION="${TAG_VERSION:-v1.12.0}"
+TAG_VERSION="${TAG_VERSION:-v1.14.0}"
 TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
-TAG_VERSION="${TAG_VERSION:-v1.12.0}"
+TAG_VERSION="${TAG_VERSION:-v1.14.0}"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Bumps pinned version references `v1.12.0` → `v1.14.0` in the deploy config (the piece left out of the docs PR #126):

- `deploy/kubernetes/base/statefulset.yaml` (image) + `kustomization.yaml` (newTag)
- `deploy/native/install.sh` + `run.sh` (`TAG_VERSION` default)
- `deploy/docker/*.release.yml` (example `TAG_VERSION` in comments)

Version-string only; no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only version pin updates with no application or runtime logic changes.
> 
> **Overview**
> Updates deployment defaults and examples from **v1.12.0** to **v1.14.0** so Docker, Kubernetes, and native installs point at the same release.
> 
> Kubernetes **StatefulSet** image and **kustomize** `newTag` are both set to `v1.14.0`. Native **`install.sh`** and **`run.sh`** use `v1.14.0` as the default `TAG_VERSION`. Docker release compose files only change the documented `TAG_VERSION` example in comments; images still resolve via `${TAG_VERSION:-latest}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be708475d1ac355cac3cbed9910eb90302df7459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->