### PR TITLE
feat: protect warm-on-write populates from the read-miss warm flood (#100)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"strconv"
@@ -495,8 +496,12 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	// Clamp the reservation fraction to [0, 1] (negative disables the reservation).
 	// Applied after defaults + env so both a stray config value and an env override
-	// land in range.
-	if cfg.Cache.WarmOnWriteReservedFraction < 0 {
+	// land in range. NaN is unordered — it slips past both comparisons — so a
+	// malformed non-finite value (e.g. env/YAML "NaN") falls back to the default
+	// rather than propagating into the integer budget cap as garbage.
+	if math.IsNaN(cfg.Cache.WarmOnWriteReservedFraction) {
+		cfg.Cache.WarmOnWriteReservedFraction = DefaultWarmOnWriteReservedFraction
+	} else if cfg.Cache.WarmOnWriteReservedFraction < 0 {
 		cfg.Cache.WarmOnWriteReservedFraction = 0
 	} else if cfg.Cache.WarmOnWriteReservedFraction > 1 {
 		cfg.Cache.WarmOnWriteReservedFraction = 1

--- a/config/config.go
+++ b/config/config.go
@@ -484,8 +484,11 @@ func applyEnvOverrides(cfg *Config) {
 			}
 		}
 		// Override the warm-on-write populate reservation fraction from environment.
+		// f != 0 mirrors the sibling budget overrides: an env "0" means "use the
+		// default" (per the documented 0-or-unset contract), not "disable" — a
+		// negative value disables.
 		if val := os.Getenv("TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION"); val != "" {
-			if f, err := strconv.ParseFloat(val, 64); err == nil {
+			if f, err := strconv.ParseFloat(val, 64); err == nil && f != 0 {
 				cfg.Cache.WarmOnWriteReservedFraction = f
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,15 @@ const (
 	// fan-out — e.g. 256 large populates × ~80 MB ≈ 20 GB — so this budget, not the
 	// count, is what actually bounds populate memory.
 	DefaultCacheMaxPopulateMemoryBytes = 1 << 30
+
+	// DefaultWarmOnWriteReservedFraction is the default cap on the fraction of the
+	// cache-populate memory budget reserved for warm-on-write populates (when
+	// warm_on_write is enabled). The reservation is demand-driven and elastic:
+	// read-miss warms use the whole budget when no warm-on-write is pending, and
+	// back off only by what pending warm-on-writes actually need, up to this cap.
+	// This protects warm-on-write from being starved by the read-miss full-object
+	// warm flood for read-recently-written workloads (issue #100).
+	DefaultWarmOnWriteReservedFraction = 0.5
 )
 
 // Config holds all configuration for TAG.
@@ -206,6 +215,16 @@ type CacheConfig struct {
 	// best-effort background GET (deduplicated and shed under the populate budget).
 	// It costs one extra upstream GET per write, so it defaults to false.
 	WarmOnWrite bool `yaml:"warm_on_write"`
+	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget
+	// that warm-on-write populates may reserve ahead of read-miss warms, so
+	// warm-on-write is never starved by the read-miss full-object warm flood. The
+	// reservation is demand-driven and elastic: read-miss warms use the whole
+	// budget when no warm-on-write is pending, and back off only by what pending
+	// warm-on-writes need (up to this cap). Only applied when WarmOnWrite is true.
+	// 0 or unset uses DefaultWarmOnWriteReservedFraction; a negative value disables
+	// the reservation (read-miss and warm-on-write compete equally). Clamped to
+	// [0, 1].
+	WarmOnWriteReservedFraction float64 `yaml:"warm_on_write_reserved_fraction"`
 }
 
 // IsEnabled returns whether caching is enabled.
@@ -347,6 +366,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Cache.MaxPopulateMemoryBytes == 0 {
 		cfg.Cache.MaxPopulateMemoryBytes = DefaultCacheMaxPopulateMemoryBytes
 	}
+	if cfg.Cache.WarmOnWriteReservedFraction == 0 {
+		cfg.Cache.WarmOnWriteReservedFraction = DefaultWarmOnWriteReservedFraction
+	}
 
 	// Broadcast defaults
 	if cfg.Broadcast.ChunkSize == 0 {
@@ -461,6 +483,20 @@ func applyEnvOverrides(cfg *Config) {
 				cfg.Cache.WarmOnWrite = b
 			}
 		}
+		// Override the warm-on-write populate reservation fraction from environment.
+		if val := os.Getenv("TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION"); val != "" {
+			if f, err := strconv.ParseFloat(val, 64); err == nil {
+				cfg.Cache.WarmOnWriteReservedFraction = f
+			}
+		}
+	}
+	// Clamp the reservation fraction to [0, 1] (negative disables the reservation).
+	// Applied after defaults + env so both a stray config value and an env override
+	// land in range.
+	if cfg.Cache.WarmOnWriteReservedFraction < 0 {
+		cfg.Cache.WarmOnWriteReservedFraction = 0
+	} else if cfg.Cache.WarmOnWriteReservedFraction > 1 {
+		cfg.Cache.WarmOnWriteReservedFraction = 1
 	}
 
 	// Override log level from environment

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -468,8 +468,9 @@ func TestLoad_WarmOnWriteReservedFractionOverrideAndClamp(t *testing.T) {
 		want float64
 	}{
 		{"0.25", 0.25}, // in-range value honored
-		{"-1", 0},      // negative disables the reservation
-		{"2.5", 1},     // above 1 clamps to 1
+		{"0", DefaultWarmOnWriteReservedFraction}, // 0 means "use default", not disable
+		{"-1", 0},  // negative disables the reservation
+		{"2.5", 1}, // above 1 clamps to 1
 	}
 	for _, tc := range cases {
 		t.Run(tc.env, func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -468,7 +468,8 @@ func TestLoad_WarmOnWriteReservedFractionOverrideAndClamp(t *testing.T) {
 		want float64
 	}{
 		{"0.25", 0.25}, // in-range value honored
-		{"0", DefaultWarmOnWriteReservedFraction}, // 0 means "use default", not disable
+		{"0", DefaultWarmOnWriteReservedFraction},   // 0 means "use default", not disable
+		{"NaN", DefaultWarmOnWriteReservedFraction}, // non-finite is malformed → default
 		{"-1", 0},  // negative disables the reservation
 		{"2.5", 1}, // above 1 clamps to 1
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -447,6 +447,49 @@ func TestLoad_CachePopulateMemoryFromYAML(t *testing.T) {
 	}
 }
 
+func TestLoad_WarmOnWriteReservedFractionDefault(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte("cache:\n  enabled: true\n"), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cache.WarmOnWriteReservedFraction != DefaultWarmOnWriteReservedFraction {
+		t.Errorf("WarmOnWriteReservedFraction = %v, want %v (default)",
+			cfg.Cache.WarmOnWriteReservedFraction, DefaultWarmOnWriteReservedFraction)
+	}
+}
+
+func TestLoad_WarmOnWriteReservedFractionOverrideAndClamp(t *testing.T) {
+	cases := []struct {
+		env  string
+		want float64
+	}{
+		{"0.25", 0.25}, // in-range value honored
+		{"-1", 0},      // negative disables the reservation
+		{"2.5", 1},     // above 1 clamps to 1
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(tmpFile, []byte("cache:\n  enabled: true\n"), 0o644); err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			t.Setenv("TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION", tc.env)
+			cfg, err := Load(tmpFile)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Cache.WarmOnWriteReservedFraction != tc.want {
+				t.Errorf("env=%s: WarmOnWriteReservedFraction = %v, want %v",
+					tc.env, cfg.Cache.WarmOnWriteReservedFraction, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoad_StorageTuningInvalidEnvIgnored(t *testing.T) {
 	content := `
 cache:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
+| `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -144,6 +145,13 @@ cache:
   # returns 200); a private object is never exposed via the cache.
   # Override with TAG_CACHE_WARM_ON_WRITE env var
   warm_on_write: false
+  # Fraction of the populate memory budget reserved for warm-on-write populates so
+  # they aren't starved by the read-miss full-object warm flood. The reservation is
+  # elastic and demand-driven: read-miss warms use the whole budget when no
+  # warm-on-write is pending, and back off only by what pending warm-on-writes need
+  # (up to this fraction). Only applied when warm_on_write is true. 0/unset = default,
+  # negative disables. Override with TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION env var.
+  warm_on_write_reserved_fraction: 0.5
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -319,6 +327,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |
 | `warm_on_write`         | bool     | `false`          | Warm the cache after a successful write via a background fetch (one extra upstream GET per write) |
+| `warm_on_write_reserved_fraction` | float | `0.5`     | Elastic share of the populate budget reserved for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; `0`/unset = default, negative = disabled) |
 | `node_id`               | string   | `""`             | Unique node identifier for cluster mode                                             |
 | `cluster_addr`          | string   | `:7000`          | Address for memberlist gossip                                                       |
 | `grpc_addr`             | string   | `:9000`          | Address for gRPC server                                                             |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -272,6 +272,32 @@ enabled. The warm's own outcome (success / failure / shed) is recorded by the
 `tag_background_fetches_*` and `tag_cache_populate_skipped_total` metrics; this counts
 how often a write initiated one.
 
+#### tag_cache_populate_skipped_total
+
+**Type:** Counter
+
+Cache-populate operations skipped because the concurrent-cache-write limit
+(count or memory budget) was saturated — the object is still served from upstream,
+just not cached.
+
+| Label    | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `source` | `warm_on_write` (a write-triggered warm) or `read_miss` (a read-triggered warm) |
+
+For a read-recently-written workload with `warm_on_write` on, a healthy deployment
+shows `source="warm_on_write"` near zero while `source="read_miss"` absorbs the
+shedding — warm-on-write is protected from the read-miss warm flood by the reserved
+populate budget (`cache.warm_on_write_reserved_fraction`). Sum across sources for the
+total.
+
+```promql
+# Warm-on-write shed rate (should be ~0 when protected)
+rate(tag_cache_populate_skipped_total{source="warm_on_write"}[5m])
+
+# Total populate shed rate
+sum(rate(tag_cache_populate_skipped_total[5m]))
+```
+
 ### Revalidation Metrics
 
 #### tag_revalidations_triggered_total

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -120,12 +120,16 @@ var (
 
 	// CachePopulateSkipped counts cache-populate operations skipped because the
 	// concurrent-cache-write limit was saturated (the object is still served from
-	// upstream, just not cached).
-	CachePopulateSkipped = promauto.NewCounter(
+	// upstream, just not cached). Labeled by source so warm-on-write starvation is
+	// visible separately from the read-miss warm flood (issue #100): a healthy
+	// deployment shows source="warm_on_write" near zero while source="read_miss"
+	// absorbs the shedding. Sum across sources for the total.
+	CachePopulateSkipped = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "tag_cache_populate_skipped_total",
-			Help: "Total cache populates skipped due to the concurrent-cache-write limit",
+			Help: "Total cache populates skipped due to the concurrent-cache-write limit, by source",
 		},
+		[]string{"source"},
 	)
 
 	// BytesTransferred tracks bytes transferred.
@@ -387,6 +391,17 @@ const (
 	LocalityLocal  = "local"
 	LocalityRemote = "remote"
 )
+
+// Cache-populate source label values (for CachePopulateSkipped).
+const (
+	PopulateSourceWarmOnWrite = "warm_on_write"
+	PopulateSourceReadMiss    = "read_miss"
+)
+
+// RecordCachePopulateSkipped records a shed cache-populate, attributed to its source.
+func RecordCachePopulateSkipped(source string) {
+	CachePopulateSkipped.WithLabelValues(source).Inc()
+}
 
 // RecordCacheServeLocality records a cache body read as served locally or
 // pulled from a peer over gRPC.

--- a/proxy/cache_slot_test.go
+++ b/proxy/cache_slot_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/tigrisdata/tag/config"
@@ -12,18 +13,18 @@ import (
 func TestService_CacheSlotCountLimit(t *testing.T) {
 	s := &Service{cacheSemaphore: make(chan struct{}, 2)}
 
-	if !s.acquireCacheSlot(1) {
+	if !s.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
 		t.Fatal("1st acquire should succeed")
 	}
-	if !s.acquireCacheSlot(1) {
+	if !s.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
 		t.Fatal("2nd acquire should succeed")
 	}
-	if s.acquireCacheSlot(1) {
+	if s.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
 		t.Fatal("3rd acquire should fail when the count limit (2) is reached")
 	}
 
 	s.releaseCacheSlot(1)
-	if !s.acquireCacheSlot(1) {
+	if !s.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
 		t.Fatal("acquire after release should succeed")
 	}
 }
@@ -32,7 +33,7 @@ func TestService_CacheSlotCountLimit(t *testing.T) {
 func TestService_CacheSlotUnlimited(t *testing.T) {
 	s := &Service{} // nil cacheSemaphore and nil populateBudget
 	for range 100 {
-		if !s.acquireCacheSlot(1 << 30) {
+		if !s.acquireCacheSlot(context.Background(), 1<<30, priorityReadMiss) {
 			t.Fatal("nil limiters must always admit")
 		}
 	}
@@ -46,21 +47,21 @@ func TestService_CacheSlotByteBudget(t *testing.T) {
 	// Count effectively unlimited (large), budget = 100 bytes.
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 1000),
-		populateBudget: newByteBudget(100),
+		populateBudget: newByteBudget(100, 0),
 	}
 
-	if !s.acquireCacheSlot(60) {
+	if !s.acquireCacheSlot(context.Background(), 60, priorityReadMiss) {
 		t.Fatal("reserve 60/100 should succeed")
 	}
-	if !s.acquireCacheSlot(40) {
+	if !s.acquireCacheSlot(context.Background(), 40, priorityReadMiss) {
 		t.Fatal("reserve 40 more (100/100) should succeed")
 	}
-	if s.acquireCacheSlot(1) {
+	if s.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
 		t.Fatal("reserve beyond the byte budget should fail")
 	}
 	// A rejected acquire must not leak the count slot it briefly took.
 	s.releaseCacheSlot(40) // free 40 bytes
-	if !s.acquireCacheSlot(40) {
+	if !s.acquireCacheSlot(context.Background(), 40, priorityReadMiss) {
 		t.Fatal("acquire after releasing bytes should succeed")
 	}
 }
@@ -70,14 +71,14 @@ func TestService_CacheSlotByteBudget(t *testing.T) {
 func TestService_CacheSlotByteBudgetReleasesCountOnByteReject(t *testing.T) {
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 1),
-		populateBudget: newByteBudget(10),
+		populateBudget: newByteBudget(10, 0),
 	}
 	// Byte budget too small — acquire must fail and free the single count slot.
-	if s.acquireCacheSlot(1000) {
+	if s.acquireCacheSlot(context.Background(), 1000, priorityReadMiss) {
 		t.Fatal("acquire should fail when weight exceeds the byte budget")
 	}
 	// The count slot must be available again.
-	if !s.acquireCacheSlot(5) {
+	if !s.acquireCacheSlot(context.Background(), 5, priorityReadMiss) {
 		t.Fatal("count slot leaked after byte-budget rejection")
 	}
 }
@@ -126,7 +127,7 @@ func TestService_BackgroundReservationClampedToBudget(t *testing.T) {
 	const budget = 8 << 20 // 8MB budget, below the 80MB ceiling
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 256),
-		populateBudget: newByteBudget(budget),
+		populateBudget: newByteBudget(budget, 0),
 		perPopulateCap: 80 << 20,
 		config:         &config.Config{},
 	}
@@ -136,14 +137,14 @@ func TestService_BackgroundReservationClampedToBudget(t *testing.T) {
 	if w != budget {
 		t.Fatalf("populateWeight(-1) = %d, want %d (clamped to budget)", w, budget)
 	}
-	if !s.acquireCacheSlot(w) {
+	if !s.acquireCacheSlot(context.Background(), w, priorityReadMiss) {
 		t.Fatal("background populate should admit one-at-a-time when budget < ceiling")
 	}
-	if s.acquireCacheSlot(s.populateWeight(-1)) {
+	if s.acquireCacheSlot(context.Background(), s.populateWeight(-1), priorityReadMiss) {
 		t.Fatal("second concurrent background populate should be throttled by the full budget")
 	}
 	s.releaseCacheSlot(w)
-	if !s.acquireCacheSlot(s.populateWeight(-1)) {
+	if !s.acquireCacheSlot(context.Background(), s.populateWeight(-1), priorityReadMiss) {
 		t.Fatal("after release the next background populate should admit")
 	}
 }

--- a/proxy/cache_slot_test.go
+++ b/proxy/cache_slot_test.go
@@ -47,7 +47,7 @@ func TestService_CacheSlotByteBudget(t *testing.T) {
 	// Count effectively unlimited (large), budget = 100 bytes.
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 1000),
-		populateBudget: newByteBudget(100, 0),
+		populateBudget: newByteBudget(100, 0, 1),
 	}
 
 	if !s.acquireCacheSlot(context.Background(), 60, priorityReadMiss) {
@@ -71,7 +71,7 @@ func TestService_CacheSlotByteBudget(t *testing.T) {
 func TestService_CacheSlotByteBudgetReleasesCountOnByteReject(t *testing.T) {
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 1),
-		populateBudget: newByteBudget(10, 0),
+		populateBudget: newByteBudget(10, 0, 1),
 	}
 	// Byte budget too small — acquire must fail and free the single count slot.
 	if s.acquireCacheSlot(context.Background(), 1000, priorityReadMiss) {
@@ -127,7 +127,7 @@ func TestService_BackgroundReservationClampedToBudget(t *testing.T) {
 	const budget = 8 << 20 // 8MB budget, below the 80MB ceiling
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 256),
-		populateBudget: newByteBudget(budget, 0),
+		populateBudget: newByteBudget(budget, 0, 1),
 		perPopulateCap: 80 << 20,
 		config:         &config.Config{},
 	}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -145,8 +145,11 @@ func (s *Service) setupCacheListener(
 	// released on the no-listener path below or by the populate goroutine. weight is
 	// the byte reservation (matching what was/should be acquired) to release.
 	if !slotHeld {
-		if !s.acquireCacheSlot(weight) {
-			metrics.CachePopulateSkipped.Inc()
+		// The inline populate serves a cache miss while streaming from upstream, so
+		// it is a read-triggered populate (priorityReadMiss): non-blocking, yields
+		// budget headroom to pending warm-on-write.
+		if !s.acquireCacheSlot(ctx, weight, priorityReadMiss) {
+			metrics.RecordCachePopulateSkipped(metrics.PopulateSourceReadMiss)
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Skipping cache populate - concurrent write limit reached")
 			return nil, nil
 		}
@@ -328,6 +331,7 @@ func (s *Service) fetchFullObjectToCache(
 	bucket, key, accessKey, secretKey string,
 	anonymous bool,
 	broadcaster *broadcast.Broadcaster,
+	prio populatePriority,
 ) error {
 	// This is a background fetch whose only purpose is to populate the cache, so
 	// reserve a cache-populate slot up front. If the concurrent-write limit is
@@ -342,8 +346,17 @@ func (s *Service) fetchFullObjectToCache(
 	// large-object warms to keep buffered memory bounded (small objects, cached
 	// inline, reserve their actual size instead).
 	weight := s.populateWeight(-1)
-	if !s.acquireCacheSlot(weight) {
-		metrics.CachePopulateSkipped.Inc()
+	// Warm-on-write populates wait (bounded) for their reserved budget and take
+	// priority; read-miss populates acquire non-blocking. Bound the warm wait so a
+	// starved warm doesn't hold a count slot for the whole fetch timeout.
+	acqCtx := ctx
+	if prio == priorityWarmWrite {
+		var cancel context.CancelFunc
+		acqCtx, cancel = context.WithTimeout(ctx, warmPopulateAcquireTimeout)
+		defer cancel()
+	}
+	if !s.acquireCacheSlot(acqCtx, weight, prio) {
+		metrics.RecordCachePopulateSkipped(prio.metricSource())
 		return errCachePopulateDeclined
 	}
 	slotOwned := true
@@ -495,7 +508,7 @@ streamLoop:
 // cached as public-read (see fetchFullObjectToCache); accessKey/secretKey are then
 // ignored. Pass anonymous=true exactly when the triggering request was anonymous, so
 // public-read is only ever inferred from a confirmed anonymous read.
-func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool) {
+func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool, prio populatePriority) {
 	bcastKey := "bg:" + bucket + "/" + key
 
 	// Atomic check-and-set: if key exists, a fetch is already in progress
@@ -521,7 +534,7 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 		}
 		broadcaster := broadcast.NewBroadcaster(channelBuf)
 
-		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, anonymous, broadcaster)
+		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, anonymous, broadcaster, prio)
 
 		switch {
 		case errors.Is(err, errCachePopulateDeclined):

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -290,7 +290,7 @@ func (s *Service) fetchAndBroadcast(
 		if upErr := broadcaster.Error(); upErr == nil ||
 			errors.Is(upErr, context.Canceled) || errors.Is(upErr, context.DeadlineExceeded) {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
 			}
 		}
 	}
@@ -732,7 +732,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 	if cacheable {
 		defer func() {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
 			}
 		}()
 	}

--- a/proxy/populate_priority_test.go
+++ b/proxy/populate_priority_test.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// readMiss uses the whole budget when no warm-on-write is pending (elastic — the
+// reservation costs nothing when unused).
+func TestByteBudget_ReadMissUsesFullBudgetWhenNoWarmPending(t *testing.T) {
+	b := newByteBudget(100, 0.5) // reserveCap = 50, but nothing pending
+	if !b.tryAcquireReadMiss(100) {
+		t.Fatal("read-miss should use the full budget when no warm-on-write is pending")
+	}
+	if b.tryAcquireReadMiss(1) {
+		t.Fatal("budget is now exhausted; further read-miss must be declined")
+	}
+}
+
+// readMiss backs off by exactly the pending warm demand (capped at reserveCap),
+// leaving that headroom protected for warm-on-write.
+func TestByteBudget_ReadMissYieldsPendingWarm(t *testing.T) {
+	b := newByteBudget(100, 0.5) // cap 50
+	b.pendingWarm = 30           // a warm-on-write of 30 is waiting
+
+	// read-miss may take up to 100 - min(30,50) = 70.
+	if !b.tryAcquireReadMiss(70) {
+		t.Fatal("read-miss should be admitted up to budget minus pending warm reserve")
+	}
+	if b.tryAcquireReadMiss(1) {
+		t.Fatal("read-miss must not consume the reserve held for pending warm-on-write")
+	}
+}
+
+// The reserve is capped at reserveCap: even huge pending warm demand can't make
+// read-miss yield more than the configured fraction.
+func TestByteBudget_ReserveCapBoundsYield(t *testing.T) {
+	b := newByteBudget(100, 0.5) // cap 50
+	b.pendingWarm = 90           // more than the cap
+
+	if !b.tryAcquireReadMiss(50) {
+		t.Fatal("read-miss should still get (total - cap) even under large warm demand")
+	}
+	if b.tryAcquireReadMiss(1) {
+		t.Fatal("read-miss must not dip below the capped reserve")
+	}
+}
+
+// reserveFraction 0 disables the reservation: read-miss uses the whole budget even
+// with warm-on-write pending (equal competition).
+func TestByteBudget_ReservationDisabled(t *testing.T) {
+	b := newByteBudget(100, 0) // cap 0
+	b.pendingWarm = 40
+	if !b.tryAcquireReadMiss(100) {
+		t.Fatal("with the reservation disabled, read-miss uses the full budget")
+	}
+}
+
+// The regression this feature exists for: a read-miss flood fills the budget, yet a
+// warm-on-write still acquires — read-miss yields freed budget to the pending warm.
+func TestByteBudget_WarmWinsAgainstReadMissFlood(t *testing.T) {
+	b := newByteBudget(100, 0.5) // cap 50
+
+	// Read-miss fills the entire budget.
+	if !b.tryAcquireReadMiss(100) {
+		t.Fatal("setup: read-miss should fill the budget")
+	}
+
+	// A warm-on-write asks for 40 and waits (budget is full).
+	done := make(chan bool, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- b.acquireWarm(ctx, 40)
+	}()
+
+	// Let the warm register its pending demand.
+	time.Sleep(20 * time.Millisecond)
+
+	// Read-miss releases 40, then immediately tries to re-grab it. It must be
+	// declined — the freed budget is reserved for the pending warm.
+	b.release(40)
+	if b.tryAcquireReadMiss(40) {
+		t.Fatal("read-miss must yield freed budget to the pending warm-on-write")
+	}
+
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("warm-on-write should acquire once read-miss frees budget")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("warm-on-write timed out waiting for its reserved budget")
+	}
+}
+
+// warm-on-write gives up (does not block forever) when budget never frees, so it's
+// shed like any other populate rather than pinning a goroutine.
+func TestByteBudget_WarmTimesOutWhenBudgetNeverFrees(t *testing.T) {
+	b := newByteBudget(100, 0.5)
+	if !b.tryAcquireReadMiss(100) {
+		t.Fatal("setup: fill the budget")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if b.acquireWarm(ctx, 40) {
+		t.Fatal("warm-on-write should time out when budget never frees")
+	}
+}
+
+// Priority routes through acquireCacheSlot: with the budget full, a read-miss slot
+// is declined (non-blocking) while a warm-on-write slot is admitted once freed.
+func TestService_AcquireCacheSlot_WarmPriority(t *testing.T) {
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 1000),
+		populateBudget: newByteBudget(100, 0.5),
+	}
+	if !s.acquireCacheSlot(context.Background(), 100, priorityReadMiss) {
+		t.Fatal("setup: fill the budget with a read-miss")
+	}
+	// read-miss is declined immediately when full.
+	if s.acquireCacheSlot(context.Background(), 40, priorityReadMiss) {
+		t.Fatal("read-miss must be declined when the budget is full")
+	}
+	// warm-on-write waits and wins once the read-miss releases.
+	done := make(chan bool, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- s.acquireCacheSlot(ctx, 40, priorityWarmWrite)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	s.releaseCacheSlot(60) // free 60 of the 100
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("warm-on-write should acquire once budget frees")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("warm-on-write timed out")
+	}
+}

--- a/proxy/populate_priority_test.go
+++ b/proxy/populate_priority_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 )
@@ -76,6 +77,78 @@ func TestByteBudget_ReserveCapFlooredAtPerPopulateCap(t *testing.T) {
 	}
 	if b.tryAcquireReadMiss(1) {
 		t.Fatal("read-miss must not consume the floored reserve held for the pending warm")
+	}
+}
+
+// A non-finite fraction (NaN) is unordered and slips past the </> clamps; it must
+// disable the reserve rather than produce a garbage int64 cap from total*NaN.
+func TestByteBudget_NaNFractionDisablesReserve(t *testing.T) {
+	b := newByteBudget(100, math.NaN(), 40)
+	if b.reserveCap != 0 {
+		t.Fatalf("NaN fraction must disable the reserve (cap 0), got %d", b.reserveCap)
+	}
+	// Reserve disabled: read-miss uses the whole budget even under warm demand.
+	b.pendingWarm = 40
+	if !b.tryAcquireReadMiss(100) {
+		t.Fatal("NaN fraction should leave the full budget available to read-miss")
+	}
+}
+
+// The count slot is shared with read-miss, so a warm holding its reserved bytes must
+// still wait (bounded) for a count slot rather than being shed the instant a
+// read-miss flood has filled every slot.
+func TestService_AcquireCacheSlot_WarmWaitsForCountSlot(t *testing.T) {
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 1), // a single slot, held by the read-miss below
+		populateBudget: newByteBudget(1000, 0.5, 1),
+	}
+	if !s.acquireCacheSlot(context.Background(), 10, priorityReadMiss) {
+		t.Fatal("setup: read-miss should take the only count slot")
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- s.acquireCacheSlot(ctx, 10, priorityWarmWrite)
+	}()
+
+	// Warm has budget headroom but no free count slot; it must wait, not shed.
+	select {
+	case <-done:
+		t.Fatal("warm should wait for a count slot, not be shed immediately")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	s.releaseCacheSlot(10) // free the slot; warm should now win it
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("warm should acquire once a count slot frees")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("warm timed out waiting for the count slot")
+	}
+}
+
+// When no count slot frees before the deadline, warm is shed — and it must hand back
+// the reserved budget it was holding while it waited, or that budget leaks.
+func TestService_AcquireCacheSlot_WarmCountTimeoutReleasesBudget(t *testing.T) {
+	s := &Service{
+		cacheSemaphore: make(chan struct{}, 1),
+		populateBudget: newByteBudget(1000, 0.5, 1),
+	}
+	if !s.acquireCacheSlot(context.Background(), 10, priorityReadMiss) {
+		t.Fatal("setup: read-miss should take the only count slot")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if s.acquireCacheSlot(ctx, 10, priorityWarmWrite) {
+		t.Fatal("warm should be shed when no count slot frees before the deadline")
+	}
+	// Read-miss holds 10 of 1000; if warm released the 10 it briefly took, 990 remain.
+	if !s.populateBudget.tryAcquireReadMiss(990) {
+		t.Fatal("warm must release its held budget when it times out on the count slot")
 	}
 }
 

--- a/proxy/populate_priority_test.go
+++ b/proxy/populate_priority_test.go
@@ -9,7 +9,7 @@ import (
 // readMiss uses the whole budget when no warm-on-write is pending (elastic — the
 // reservation costs nothing when unused).
 func TestByteBudget_ReadMissUsesFullBudgetWhenNoWarmPending(t *testing.T) {
-	b := newByteBudget(100, 0.5) // reserveCap = 50, but nothing pending
+	b := newByteBudget(100, 0.5, 1) // reserveCap = 50, but nothing pending
 	if !b.tryAcquireReadMiss(100) {
 		t.Fatal("read-miss should use the full budget when no warm-on-write is pending")
 	}
@@ -21,8 +21,8 @@ func TestByteBudget_ReadMissUsesFullBudgetWhenNoWarmPending(t *testing.T) {
 // readMiss backs off by exactly the pending warm demand (capped at reserveCap),
 // leaving that headroom protected for warm-on-write.
 func TestByteBudget_ReadMissYieldsPendingWarm(t *testing.T) {
-	b := newByteBudget(100, 0.5) // cap 50
-	b.pendingWarm = 30           // a warm-on-write of 30 is waiting
+	b := newByteBudget(100, 0.5, 1) // cap 50
+	b.pendingWarm = 30              // a warm-on-write of 30 is waiting
 
 	// read-miss may take up to 100 - min(30,50) = 70.
 	if !b.tryAcquireReadMiss(70) {
@@ -36,8 +36,8 @@ func TestByteBudget_ReadMissYieldsPendingWarm(t *testing.T) {
 // The reserve is capped at reserveCap: even huge pending warm demand can't make
 // read-miss yield more than the configured fraction.
 func TestByteBudget_ReserveCapBoundsYield(t *testing.T) {
-	b := newByteBudget(100, 0.5) // cap 50
-	b.pendingWarm = 90           // more than the cap
+	b := newByteBudget(100, 0.5, 1) // cap 50
+	b.pendingWarm = 90              // more than the cap
 
 	if !b.tryAcquireReadMiss(50) {
 		t.Fatal("read-miss should still get (total - cap) even under large warm demand")
@@ -50,17 +50,39 @@ func TestByteBudget_ReserveCapBoundsYield(t *testing.T) {
 // reserveFraction 0 disables the reservation: read-miss uses the whole budget even
 // with warm-on-write pending (equal competition).
 func TestByteBudget_ReservationDisabled(t *testing.T) {
-	b := newByteBudget(100, 0) // cap 0
+	b := newByteBudget(100, 0, 1) // cap 0
 	b.pendingWarm = 40
 	if !b.tryAcquireReadMiss(100) {
 		t.Fatal("with the reservation disabled, read-miss uses the full budget")
 	}
 }
 
+// Fix for the small-budget starvation: when the configured fraction of the budget is
+// smaller than a single populate's byte weight, reserveCap is floored at
+// perPopulateCap so one warm-on-write can still fit. Otherwise a read-miss flood
+// would starve every warm on a small budget (fraction*total < one populate).
+func TestByteBudget_ReserveCapFlooredAtPerPopulateCap(t *testing.T) {
+	const perPopulateCap = 40
+	// 0.1 * 100 = 10, well below a single populate (40); the floor lifts it to 40.
+	b := newByteBudget(100, 0.1, perPopulateCap)
+	if b.reserveCap != perPopulateCap {
+		t.Fatalf("reserveCap should be floored at perPopulateCap %d, got %d", perPopulateCap, b.reserveCap)
+	}
+
+	// A warm-on-write of one populate is pending; read-miss must yield the full 40.
+	b.pendingWarm = perPopulateCap
+	if !b.tryAcquireReadMiss(60) {
+		t.Fatal("read-miss should take total minus the floored reserve (100-40=60)")
+	}
+	if b.tryAcquireReadMiss(1) {
+		t.Fatal("read-miss must not consume the floored reserve held for the pending warm")
+	}
+}
+
 // The regression this feature exists for: a read-miss flood fills the budget, yet a
 // warm-on-write still acquires — read-miss yields freed budget to the pending warm.
 func TestByteBudget_WarmWinsAgainstReadMissFlood(t *testing.T) {
-	b := newByteBudget(100, 0.5) // cap 50
+	b := newByteBudget(100, 0.5, 1) // cap 50
 
 	// Read-miss fills the entire budget.
 	if !b.tryAcquireReadMiss(100) {
@@ -98,7 +120,7 @@ func TestByteBudget_WarmWinsAgainstReadMissFlood(t *testing.T) {
 // warm-on-write gives up (does not block forever) when budget never frees, so it's
 // shed like any other populate rather than pinning a goroutine.
 func TestByteBudget_WarmTimesOutWhenBudgetNeverFrees(t *testing.T) {
-	b := newByteBudget(100, 0.5)
+	b := newByteBudget(100, 0.5, 1)
 	if !b.tryAcquireReadMiss(100) {
 		t.Fatal("setup: fill the budget")
 	}
@@ -114,7 +136,7 @@ func TestByteBudget_WarmTimesOutWhenBudgetNeverFrees(t *testing.T) {
 func TestService_AcquireCacheSlot_WarmPriority(t *testing.T) {
 	s := &Service{
 		cacheSemaphore: make(chan struct{}, 1000),
-		populateBudget: newByteBudget(100, 0.5),
+		populateBudget: newByteBudget(100, 0.5, 1),
 	}
 	if !s.acquireCacheSlot(context.Background(), 100, priorityReadMiss) {
 		t.Fatal("setup: fill the budget with a read-miss")

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -368,7 +368,8 @@ func (s *Service) handleRevalidation206Range(
 		totalSize <= s.config.Cache.SizeThreshold &&
 		s.cache.IsEnabled() &&
 		accessKey != "" && secretKey != "" {
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r))
+		// Revalidation re-warm is a read-triggered populate.
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
 	}
 
 	return copyErr

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -213,7 +214,9 @@ type byteBudget struct {
 // a fraction*total smaller than a single populate would let read-miss oscillate just
 // below the warm's required weight and starve it under a small budget.
 func newByteBudget(total int64, reserveFraction float64, perPopulateCap int64) *byteBudget {
-	if reserveFraction < 0 {
+	// NaN is unordered, so it slips past the < / > clamps below; converting
+	// total*NaN to int64 yields a garbage cap. Disable the reservation in that case.
+	if math.IsNaN(reserveFraction) || reserveFraction < 0 {
 		reserveFraction = 0
 	} else if reserveFraction > 1 {
 		reserveFraction = 1
@@ -302,10 +305,14 @@ func (s *Service) acquireCacheSlot(ctx context.Context, weight int64, prio popul
 		if s.populateBudget != nil && !s.populateBudget.acquireWarm(ctx, weight) {
 			return false
 		}
+		// The count slot is shared with read-miss populates, so protecting only the
+		// byte budget still lets a read-miss flood that fills every slot shed a warm
+		// that already holds its reserved bytes. Wait for a slot too, bounded by ctx
+		// (the caller's warm-acquire deadline); free the held budget if it never comes.
 		if s.cacheSemaphore != nil {
 			select {
 			case s.cacheSemaphore <- struct{}{}:
-			default:
+			case <-ctx.Done():
 				if s.populateBudget != nil {
 					s.populateBudget.release(weight) // hand back budget we can't use
 				}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -96,7 +96,13 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 
 	var populateBudget *byteBudget
 	if cfg.Cache.MaxPopulateMemoryBytes > 0 {
-		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes)
+		// Reserve a share of the budget for warm-on-write only when it's enabled;
+		// otherwise there's no warm path to protect.
+		reserveFraction := 0.0
+		if cfg.Cache.WarmOnWrite {
+			reserveFraction = cfg.Cache.WarmOnWriteReservedFraction
+		}
+		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, reserveFraction)
 	}
 
 	log.Info().
@@ -158,25 +164,116 @@ func (s *Service) populateWeight(contentLength int64) int64 {
 	return w
 }
 
-// byteBudget is a non-blocking weighted semaphore bounding the aggregate bytes
-// reserved by concurrent cache-populate operations.
+// populatePriority classifies a cache-populate for admission against the byte
+// budget. warmWrite populates (cache-warm-on-write, which pre-cache data about to
+// be read) get a reserved, prioritized slice of the budget so the read-miss
+// full-object warm flood can't starve them; readMiss populates use the rest.
+type populatePriority int
+
+const (
+	priorityReadMiss populatePriority = iota
+	priorityWarmWrite
+)
+
+func (p populatePriority) metricSource() string {
+	if p == priorityWarmWrite {
+		return metrics.PopulateSourceWarmOnWrite
+	}
+	return metrics.PopulateSourceReadMiss
+}
+
+// warmPopulateAcquireTimeout bounds how long a warm-on-write populate waits for
+// budget before giving up (and being shed like any other populate). With the
+// reservation active this wait is normally sub-second; the cap just prevents a warm
+// goroutine from holding a slot indefinitely if the budget is disabled-reservation
+// and permanently contended.
+const warmPopulateAcquireTimeout = 30 * time.Second
+
+// byteBudget is a priority-aware weighted semaphore bounding the aggregate bytes
+// reserved by concurrent cache-populate operations. Read-miss populates acquire
+// non-blocking and leave headroom for pending warm-on-write demand (elastic: they
+// use the whole budget when no warm-on-write is pending, and back off only by what
+// pending warm-on-writes need, capped at reserveCap). Warm-on-write populates wait
+// (bounded) for budget and, by registering their pending demand, get priority as
+// read-miss populates release — so warm-on-write is never starved by the read-miss
+// flood while no budget is wasted.
 type byteBudget struct {
-	mu        sync.Mutex
-	remaining int64
+	mu          sync.Mutex
+	remaining   int64
+	pendingWarm int64 // sum of weights of warm-on-write acquirers currently waiting
+	reserveCap  int64 // max bytes read-miss will hold back for pending warm-on-write
 }
 
-func newByteBudget(total int64) *byteBudget {
-	return &byteBudget{remaining: total}
+// newByteBudget creates a budget of `total` bytes. reserveFraction (clamped to
+// [0,1]) caps the share read-miss populates will yield to pending warm-on-write; 0
+// disables the reservation (equal competition).
+func newByteBudget(total int64, reserveFraction float64) *byteBudget {
+	if reserveFraction < 0 {
+		reserveFraction = 0
+	} else if reserveFraction > 1 {
+		reserveFraction = 1
+	}
+	cap := int64(float64(total) * reserveFraction)
+	if cap > total {
+		cap = total
+	}
+	return &byteBudget{remaining: total, reserveCap: cap}
 }
 
-func (b *byteBudget) tryAcquire(n int64) bool {
+// tryAcquireReadMiss reserves n bytes for a read-miss populate without blocking. It
+// succeeds only if it leaves room for what pending warm-on-write populates need
+// (min(pendingWarm, reserveCap)), protecting warm-on-write, while using the whole
+// budget when nothing is pending.
+func (b *byteBudget) tryAcquireReadMiss(n int64) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.remaining < n {
+	reserve := b.pendingWarm
+	if reserve > b.reserveCap {
+		reserve = b.reserveCap
+	}
+	if b.remaining-n < reserve {
 		return false
 	}
 	b.remaining -= n
 	return true
+}
+
+// acquireWarm reserves n bytes for a warm-on-write populate, waiting (bounded by
+// ctx) for budget and taking priority over read-miss populates: while it waits it
+// registers pendingWarm so read-miss acquirers yield, then polls until budget frees
+// or ctx is cancelled. Returns false only on cancellation. Warm volume is low, so
+// the bounded poll is cheap relative to the correctness of not missing a wakeup.
+func (b *byteBudget) acquireWarm(ctx context.Context, n int64) bool {
+	b.mu.Lock()
+	b.pendingWarm += n
+	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		b.pendingWarm -= n
+		b.mu.Unlock()
+	}()
+
+	backoff := time.Millisecond
+	for {
+		b.mu.Lock()
+		if b.remaining >= n {
+			b.remaining -= n
+			b.mu.Unlock()
+			return true
+		}
+		b.mu.Unlock()
+
+		t := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return false
+		case <-t.C:
+		}
+		if backoff < 25*time.Millisecond {
+			backoff *= 2
+		}
+	}
 }
 
 func (b *byteBudget) release(n int64) {
@@ -191,7 +288,7 @@ func (b *byteBudget) release(n int64) {
 // and the byte budget are reserved, or when a limiter is disabled (nil). It returns
 // false when either the count limit or the memory budget is saturated, in which
 // case the caller should skip caching rather than block or spawn unbounded work.
-func (s *Service) acquireCacheSlot(weight int64) bool {
+func (s *Service) acquireCacheSlot(ctx context.Context, weight int64, prio populatePriority) bool {
 	if s.cacheSemaphore != nil {
 		select {
 		case s.cacheSemaphore <- struct{}{}:
@@ -199,11 +296,19 @@ func (s *Service) acquireCacheSlot(weight int64) bool {
 			return false
 		}
 	}
-	if s.populateBudget != nil && !s.populateBudget.tryAcquire(weight) {
-		if s.cacheSemaphore != nil {
-			<-s.cacheSemaphore // hand back the count slot we just took
+	if s.populateBudget != nil {
+		var ok bool
+		if prio == priorityWarmWrite {
+			ok = s.populateBudget.acquireWarm(ctx, weight)
+		} else {
+			ok = s.populateBudget.tryAcquireReadMiss(weight)
 		}
-		return false
+		if !ok {
+			if s.cacheSemaphore != nil {
+				<-s.cacheSemaphore // hand back the count slot we just took
+			}
+			return false
+		}
 	}
 	return true
 }
@@ -511,7 +616,7 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 	// probe). See the doc comment: never infer public-read from a public write.
 	if hasNoAuthCredentials(r) {
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*anonymous*/)
+		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*anonymous*/, priorityWarmWrite)
 		return
 	}
 
@@ -520,7 +625,7 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 		return
 	}
 	metrics.WarmOnWriteTriggered.Inc()
-	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/)
+	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -102,7 +102,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		if cfg.Cache.WarmOnWrite {
 			reserveFraction = cfg.Cache.WarmOnWriteReservedFraction
 		}
-		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, reserveFraction)
+		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, reserveFraction, perPopulateCap)
 	}
 
 	log.Info().
@@ -199,6 +199,7 @@ const warmPopulateAcquireTimeout = 30 * time.Second
 // flood while no budget is wasted.
 type byteBudget struct {
 	mu          sync.Mutex
+	cond        *sync.Cond // signaled on release so waiting warm-on-write acquirers wake
 	remaining   int64
 	pendingWarm int64 // sum of weights of warm-on-write acquirers currently waiting
 	reserveCap  int64 // max bytes read-miss will hold back for pending warm-on-write
@@ -206,18 +207,27 @@ type byteBudget struct {
 
 // newByteBudget creates a budget of `total` bytes. reserveFraction (clamped to
 // [0,1]) caps the share read-miss populates will yield to pending warm-on-write; 0
-// disables the reservation (equal competition).
-func newByteBudget(total int64, reserveFraction float64) *byteBudget {
+// disables the reservation (equal competition). When the reservation is enabled,
+// reserveCap is floored at perPopulateCap (the largest weight a single populate
+// reserves) so one warm-on-write populate can always fit in the reserve — otherwise
+// a fraction*total smaller than a single populate would let read-miss oscillate just
+// below the warm's required weight and starve it under a small budget.
+func newByteBudget(total int64, reserveFraction float64, perPopulateCap int64) *byteBudget {
 	if reserveFraction < 0 {
 		reserveFraction = 0
 	} else if reserveFraction > 1 {
 		reserveFraction = 1
 	}
 	cap := int64(float64(total) * reserveFraction)
+	if reserveFraction > 0 && cap < perPopulateCap {
+		cap = perPopulateCap
+	}
 	if cap > total {
 		cap = total
 	}
-	return &byteBudget{remaining: total, reserveCap: cap}
+	b := &byteBudget{remaining: total, reserveCap: cap}
+	b.cond = sync.NewCond(&b.mu)
+	return b
 }
 
 // tryAcquireReadMiss reserves n bytes for a read-miss populate without blocking. It
@@ -240,46 +250,40 @@ func (b *byteBudget) tryAcquireReadMiss(n int64) bool {
 
 // acquireWarm reserves n bytes for a warm-on-write populate, waiting (bounded by
 // ctx) for budget and taking priority over read-miss populates: while it waits it
-// registers pendingWarm so read-miss acquirers yield, then polls until budget frees
-// or ctx is cancelled. Returns false only on cancellation. Warm volume is low, so
-// the bounded poll is cheap relative to the correctness of not missing a wakeup.
+// registers pendingWarm so read-miss acquirers yield, then parks on the condition
+// variable until a release wakes it (or ctx is cancelled). Returns false only on
+// cancellation.
 func (b *byteBudget) acquireWarm(ctx context.Context, n int64) bool {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.pendingWarm += n
-	b.mu.Unlock()
-	defer func() {
-		b.mu.Lock()
-		b.pendingWarm -= n
-		b.mu.Unlock()
-	}()
+	defer func() { b.pendingWarm -= n }()
 
-	backoff := time.Millisecond
-	for {
+	// Wake this waiter if ctx is cancelled while it's parked in cond.Wait() — the
+	// condition variable itself has no timeout. stop() cancels the hook once we're
+	// done (whether we acquired or gave up).
+	stop := context.AfterFunc(ctx, func() {
 		b.mu.Lock()
-		if b.remaining >= n {
-			b.remaining -= n
-			b.mu.Unlock()
-			return true
-		}
+		b.cond.Broadcast()
 		b.mu.Unlock()
+	})
+	defer stop()
 
-		t := time.NewTimer(backoff)
-		select {
-		case <-ctx.Done():
-			t.Stop()
+	for b.remaining < n {
+		if ctx.Err() != nil {
 			return false
-		case <-t.C:
 		}
-		if backoff < 25*time.Millisecond {
-			backoff *= 2
-		}
+		b.cond.Wait()
 	}
+	b.remaining -= n
+	return true
 }
 
 func (b *byteBudget) release(n int64) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	b.remaining += n
+	b.cond.Broadcast() // wake warm-on-write waiters to re-check the freed budget
+	b.mu.Unlock()
 }
 
 // acquireCacheSlot tries to reserve a cache-populate slot without blocking,
@@ -289,6 +293,29 @@ func (b *byteBudget) release(n int64) {
 // false when either the count limit or the memory budget is saturated, in which
 // case the caller should skip caching rather than block or spawn unbounded work.
 func (s *Service) acquireCacheSlot(ctx context.Context, weight int64, prio populatePriority) bool {
+	// Warm-on-write may block waiting for its reserved budget, so it reserves the
+	// byte budget FIRST and takes the count slot only once budget is secured.
+	// Reversing this (count-then-blocking-budget) would let a waiting warm hold a
+	// count slot for the whole wait, shedding read-miss populates that have budget
+	// headroom and exhausting MaxConcurrentWrites under a burst of warms.
+	if prio == priorityWarmWrite {
+		if s.populateBudget != nil && !s.populateBudget.acquireWarm(ctx, weight) {
+			return false
+		}
+		if s.cacheSemaphore != nil {
+			select {
+			case s.cacheSemaphore <- struct{}{}:
+			default:
+				if s.populateBudget != nil {
+					s.populateBudget.release(weight) // hand back budget we can't use
+				}
+				return false
+			}
+		}
+		return true
+	}
+
+	// Read-miss acquires non-blocking: count slot then byte budget.
 	if s.cacheSemaphore != nil {
 		select {
 		case s.cacheSemaphore <- struct{}{}:
@@ -296,19 +323,11 @@ func (s *Service) acquireCacheSlot(ctx context.Context, weight int64, prio popul
 			return false
 		}
 	}
-	if s.populateBudget != nil {
-		var ok bool
-		if prio == priorityWarmWrite {
-			ok = s.populateBudget.acquireWarm(ctx, weight)
-		} else {
-			ok = s.populateBudget.tryAcquireReadMiss(weight)
+	if s.populateBudget != nil && !s.populateBudget.tryAcquireReadMiss(weight) {
+		if s.cacheSemaphore != nil {
+			<-s.cacheSemaphore // hand back the count slot we just took
 		}
-		if !ok {
-			if s.cacheSemaphore != nil {
-				<-s.cacheSemaphore // hand back the count slot we just took
-			}
-			return false
-		}
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
## Summary

Phase 1 of #100: **protect warm-on-write populates from being starved by the read-miss full-object warm flood.**

For a read-recently-written workload (metrics-on-object-store / Parseable), read-miss range warms fetch the *whole* object and flood the shared cache-populate byte budget. That crowds out **warm-on-write** — the mechanism designed to pre-cache exactly the data about to be read. Diagnosed in production (v1.14.1): ~99% of populates shed at the default 1 GiB budget, hit ratio collapsed to ~11%, and ~88% of reads proxied to upstream (the "1 GB/s ceiling"). Raising the budget helped (→ ~80%) but tapped out because the residual skips are *amplification*-limited, not budget-limited — with warm-on-write competing equally.

## Design: elastic, demand-driven reservation with priority

`byteBudget` becomes priority-aware (details in the PR discussion / #100):
- **Read-miss** populates acquire non-blocking and yield headroom to *pending* warm-on-write demand — `min(pendingWarm, reserveCap)`. So they use the **whole budget when no warm is pending** (elastic — no wasted reserve) and back off only by what warms actually need.
- **Warm-on-write** populates wait (bounded, they're already background goroutines) and, by registering their pending demand, take **priority** as read-miss populates release.
- The reserve is a **cap**, not a static carve-out — neither side can starve the other, and read-miss keeps full throughput (including fast cold-start warming) whenever warm-on-write is idle.

## Changes
- `populatePriority` (`warmWrite`/`readMiss`) threaded through `triggerBackgroundCacheFetch → fetchFullObjectToCache → acquireCacheSlot`. Warm-on-write sites set `warmWrite`; range / inline / revalidation read paths set `readMiss`.
- **Config**: `cache.warm_on_write_reserved_fraction` (default **0.5**, env `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION`) caps the reservation; only applied when `warm_on_write` is on; negative disables; clamped to `[0,1]`.
- **Metric**: `tag_cache_populate_skipped_total` gains a **`source`** label (`warm_on_write` vs `read_miss`) — the validation signal (warm shed rate → ~0).
- Docs: `configuration.md` + `metrics.md`.

## Tests
- `byteBudget`: read-miss uses full budget when no warm pending; yields exactly the pending warm demand; reserve cap bounds the yield; reservation-disabled path.
- **Regression**: a read-miss flood fills the budget, yet warm-on-write still acquires (read-miss yields freed budget) — the exact prod failure, reproduced.
- Warm-on-write times out (shed, not pinned) when budget never frees.
- `acquireCacheSlot` priority routing.
- Config default / env-override / clamp.
- All pass under `-race`.

## Notes / known edge
- Behavior is unchanged when `warm_on_write` is off (reserve fraction ignored).
- **Coalescing edge (documented, not addressed):** `triggerBackgroundCacheFetch` dedups per key; a warm-on-write for key K that coalesces into an in-flight read-miss for K inherits its priority. Writes fire the warm before reads arrive, so this is rare — will address only if the `source="warm_on_write"` skip metric shows it in practice.
- **Phase 2 (separate):** reduce the read-miss flood at its source (repeat-access / size gating) per #100's Option 1/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path cache admission and populate budgeting under load; mis-tuning could affect hit ratio or upstream load, but behavior is unchanged when `warm_on_write` is off and the change is covered by extensive tests.
> 
> **Overview**
> Fixes **warm-on-write starvation** when read-miss full-object warms saturate the shared populate memory budget (#100). The populate **byte budget** is now **priority-aware**: read-miss populates acquire **non-blocking** and only leave headroom for **pending** warm-on-write demand (elastic—full budget when no warm is waiting); warm-on-write populates **wait** (bounded) and win budget as read-miss releases.
> 
> **`populatePriority`** (`read_miss` vs `warm_on_write`) is threaded through `triggerBackgroundCacheFetch` → `fetchFullObjectToCache` → `acquireCacheSlot`. Warm paths use `priorityWarmWrite`; range/inline/revalidation reads use `priorityReadMiss`. Warm admission reserves **budget before** the count slot to avoid holding slots while waiting.
> 
> New **`cache.warm_on_write_reserved_fraction`** (default **0.5**, env `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION`) caps the reservation when `warm_on_write` is on; negative disables equal competition. **`tag_cache_populate_skipped_total`** gains a **`source`** label (`warm_on_write` / `read_miss`) for validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0048a9fcccdafeea4d385a366c720e036273659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->