### PR TITLE
feat: write-through cache tee for single PutObject (#134)

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -150,6 +150,11 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 // the orphaned body is cleaned up. Checking after body stream (rather than
 // before) closes the TOCTOU window where an invalidation during streaming
 // could be missed, causing resurrected metadata without a body.
+//
+// Returns wrote=true only when the metadata was actually written (the entry is now
+// visible). It is false when the write was skipped without error — the object was not
+// cacheable (no ETag) or a newer tombstone superseded it — so callers can distinguish a
+// no-op from a real write (e.g. for metrics or a fallback).
 func (c *Cache) PutWithMetaStreamTombstoneAware(
 	ctx context.Context,
 	bucket, key string,
@@ -157,9 +162,9 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	body io.Reader,
 	ttl int,
 	writeStartTime int64, // Unix nano timestamp when write started
-) error {
+) (wrote bool, err error) {
 	if !c.IsEnabled() {
-		return nil
+		return false, nil
 	}
 
 	// Objects without an ETag are not cached: they would share a single
@@ -170,7 +175,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	// Drain the body first so the producer side of the pipe never blocks.
 	if meta.ETag == "" {
 		_, _ = io.Copy(io.Discard, body)
-		return nil
+		return false, nil
 	}
 
 	if ttl == 0 {
@@ -184,13 +189,13 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	metaBytes, err := meta.Encode()
 	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta encode error")
-		return err
+		return false, err
 	}
 
 	// Stream body to cache
 	if err := c.client.PutStream(ctx, bodyKey, body, int64(ttl)); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache body put error")
-		return err
+		return false, err
 	}
 
 	// Check tombstone AFTER body stream, right before meta write.
@@ -209,7 +214,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		// a reader streaming this exact body key, and deleting it would truncate
 		// that reader. Without a visible meta entry the orphaned body is unreachable
 		// and harmless until it expires.
-		return nil
+		return false, nil
 	}
 
 	// Write metadata AFTER body (makes entry visible)
@@ -217,7 +222,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
 		// Same rationale as the tombstone branch: leave the versioned body to TTL
 		// rather than risk truncating a concurrent same-version reader.
-		return err
+		return false, err
 	}
 
 	log.Debug().
@@ -226,7 +231,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		Int("ttl", ttl).
 		Int("meta_size", len(metaBytes)).
 		Msg("Cached object with metadata (streamed, tombstone-aware)")
-	return nil
+	return true, nil
 }
 
 // GetMeta retrieves only object metadata from cache (no body).

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -128,7 +128,7 @@ func TestETagVersionedBody_EmptyETagNotCachedViaStream(t *testing.T) {
 
 	body := bytes.NewReader([]byte("body-bytes"))
 	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 10, StatusCode: 200}
-	if err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1); err != nil {
+	if _, err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1); err != nil {
 		t.Fatalf("PutWithMetaStreamTombstoneAware: %v", err)
 	}
 	if _, found, _ := c.GetMeta(ctx, bucket, key); found {

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,11 @@ const (
 	// DefaultCacheSizeThreshold is the max object size to cache (1GB).
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
 
+	// DefaultCacheWriteThroughMaxSize caps the object size eligible for the write-through
+	// tee (16 MiB). It is far smaller than DefaultCacheSizeThreshold because the tee buffers
+	// the whole object in memory while forwarding the PUT, whereas the read/warm paths stream.
+	DefaultCacheWriteThroughMaxSize = 16 * 1024 * 1024
+
 	// DefaultCacheDiskPath is the default disk path for embedded cache storage.
 	DefaultCacheDiskPath = "/var/cache/tag"
 
@@ -216,6 +221,16 @@ type CacheConfig struct {
 	// best-effort background GET (deduplicated and shed under the populate budget).
 	// It costs one extra upstream GET per write, so it defaults to false.
 	WarmOnWrite bool `yaml:"warm_on_write"`
+	// WriteThroughMaxSize caps the object size eligible for the write-through tee — the
+	// optimization that caches an authenticated single PutObject by teeing its body while
+	// forwarding (metadata sourced from a HEAD), avoiding the warm-on-write read-back GET.
+	// The tee BUFFERS the whole object in memory, so this is deliberately much smaller than
+	// SizeThreshold (which only decides whether an object is cacheable at all, on the
+	// streaming read/warm paths). Larger-but-cacheable objects fall back to the streaming
+	// warm-on-write read-back instead of being buffered. Only applied when WarmOnWrite is
+	// true. 0 or unset uses DefaultCacheWriteThroughMaxSize; a negative value disables the
+	// tee (all writes warm). Clamped to SizeThreshold, since a tee'd object must be cacheable.
+	WriteThroughMaxSize int64 `yaml:"write_through_max_size"`
 	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget
 	// that warm-on-write populates may reserve ahead of read-miss warms, so
 	// warm-on-write is never starved by the read-miss full-object warm flood. The
@@ -340,6 +355,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Cache.SizeThreshold == 0 {
 		cfg.Cache.SizeThreshold = DefaultCacheSizeThreshold
+	}
+	if cfg.Cache.WriteThroughMaxSize == 0 {
+		cfg.Cache.WriteThroughMaxSize = DefaultCacheWriteThroughMaxSize
 	}
 	if cfg.Cache.DiskPath == "" {
 		cfg.Cache.DiskPath = DefaultCacheDiskPath
@@ -483,6 +501,18 @@ func applyEnvOverrides(cfg *Config) {
 			if b, err := strconv.ParseBool(val); err == nil {
 				cfg.Cache.WarmOnWrite = b
 			}
+		}
+		// Override the write-through tee size cap from environment (negative disables the tee;
+		// 0/unset keeps the default set in applyDefaults).
+		if val := os.Getenv("TAG_CACHE_WRITE_THROUGH_MAX_SIZE"); val != "" {
+			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n != 0 {
+				cfg.Cache.WriteThroughMaxSize = n
+			}
+		}
+		// A tee'd object must be cacheable, so the tee cap can never exceed SizeThreshold.
+		// (A negative cap — the tee disabled — is left as-is.)
+		if cfg.Cache.WriteThroughMaxSize > cfg.Cache.SizeThreshold {
+			cfg.Cache.WriteThroughMaxSize = cfg.Cache.SizeThreshold
 		}
 		// Override the warm-on-write populate reservation fraction from environment.
 		// f != 0 mirrors the sibling budget overrides: an env "0" means "use the

--- a/config/config.go
+++ b/config/config.go
@@ -39,9 +39,12 @@ const (
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
 
 	// DefaultCacheWriteThroughMaxSize caps the object size eligible for the write-through
-	// tee (16 MiB). It is far smaller than DefaultCacheSizeThreshold because the tee buffers
+	// tee (25 MiB). It is far smaller than DefaultCacheSizeThreshold because the tee buffers
 	// the whole object in memory while forwarding the PUT, whereas the read/warm paths stream.
-	DefaultCacheWriteThroughMaxSize = 16 * 1024 * 1024
+	// 25 MiB matches the common S3 client single-PUT/multipart cutover (e.g. Parseable's
+	// P_MULTIPART_MIN_SIZE), so every single PutObject is tee-eligible and only multipart
+	// uploads (which the tee doesn't handle) fall back to warm-on-write.
+	DefaultCacheWriteThroughMaxSize = 25 * 1024 * 1024
 
 	// DefaultCacheDiskPath is the default disk path for embedded cache storage.
 	DefaultCacheDiskPath = "/var/cache/tag"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -502,7 +502,7 @@ func TestLoad_WriteThroughMaxSizeDefaultOverrideAndClamp(t *testing.T) {
 		{"default", "cache:\n  enabled: true\n", "", DefaultCacheWriteThroughMaxSize},
 		{"env override honored", "cache:\n  enabled: true\n", "8388608", 8388608}, // 8 MiB
 		{"negative disables the tee", "cache:\n  enabled: true\n", "-1", -1},
-		// WT default (16 MiB) exceeds a 1 MiB size_threshold, so it clamps down: a tee'd
+		// WT default (25 MiB) exceeds a 1 MiB size_threshold, so it clamps down: a tee'd
 		// object must be cacheable.
 		{"clamped to size_threshold", "cache:\n  enabled: true\n  size_threshold: 1048576\n", "", 1048576},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -492,6 +492,40 @@ func TestLoad_WarmOnWriteReservedFractionOverrideAndClamp(t *testing.T) {
 	}
 }
 
+func TestLoad_WriteThroughMaxSizeDefaultOverrideAndClamp(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		env  string
+		want int64
+	}{
+		{"default", "cache:\n  enabled: true\n", "", DefaultCacheWriteThroughMaxSize},
+		{"env override honored", "cache:\n  enabled: true\n", "8388608", 8388608}, // 8 MiB
+		{"negative disables the tee", "cache:\n  enabled: true\n", "-1", -1},
+		// WT default (16 MiB) exceeds a 1 MiB size_threshold, so it clamps down: a tee'd
+		// object must be cacheable.
+		{"clamped to size_threshold", "cache:\n  enabled: true\n  size_threshold: 1048576\n", "", 1048576},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(tmpFile, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			if tc.env != "" {
+				t.Setenv("TAG_CACHE_WRITE_THROUGH_MAX_SIZE", tc.env)
+			}
+			cfg, err := Load(tmpFile)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Cache.WriteThroughMaxSize != tc.want {
+				t.Errorf("WriteThroughMaxSize = %d, want %d", cfg.Cache.WriteThroughMaxSize, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoad_StorageTuningInvalidEnvIgnored(t *testing.T) {
 	content := `
 cache:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
+| `TAG_CACHE_WRITE_THROUGH_MAX_SIZE` | Max object size (bytes) cached via the write-through tee, which buffers the body in memory (only when `warm_on_write` is on; larger objects fall back to the streaming warm read-back; negative disables the tee; clamped to `size_threshold`) | `16777216` (16 MiB) |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -152,6 +153,14 @@ cache:
   # (up to this fraction). Only applied when warm_on_write is true. 0/unset = default,
   # negative disables. Override with TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION env var.
   warm_on_write_reserved_fraction: 0.5
+
+  # Max object size cached via the write-through tee. The tee buffers the whole object
+  # in memory while forwarding the PUT, so this is far smaller than size_threshold (which
+  # only decides overall cacheability on the streaming paths). Larger-but-cacheable objects
+  # fall back to the streaming warm-on-write read-back. Only applied when warm_on_write is
+  # true. 0/unset = default, negative disables the tee, clamped to size_threshold. Override
+  # with TAG_CACHE_WRITE_THROUGH_MAX_SIZE env var.
+  write_through_max_size: 16777216
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -323,6 +332,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `enabled`               | bool     | `true`           | Enable caching                                                                      |
 | `ttl`                   | duration | `24h`            | Default TTL for cached objects                                                      |
 | `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
+| `write_through_max_size` | int64   | `16777216`       | Max object size cached via the write-through tee (buffers in memory; negative disables; clamped to `size_threshold`) |
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
-| `TAG_CACHE_WRITE_THROUGH_MAX_SIZE` | Max object size (bytes) cached via the write-through tee, which buffers the body in memory (only when `warm_on_write` is on; larger objects fall back to the streaming warm read-back; negative disables the tee; clamped to `size_threshold`) | `16777216` (16 MiB) |
+| `TAG_CACHE_WRITE_THROUGH_MAX_SIZE` | Max object size (bytes) cached via the write-through tee, which buffers the body in memory (only when `warm_on_write` is on; larger objects fall back to the streaming warm read-back; negative disables the tee; clamped to `size_threshold`) | `26214400` (25 MiB) |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -160,7 +160,7 @@ cache:
   # fall back to the streaming warm-on-write read-back. Only applied when warm_on_write is
   # true. 0/unset = default, negative disables the tee, clamped to size_threshold. Override
   # with TAG_CACHE_WRITE_THROUGH_MAX_SIZE env var.
-  write_through_max_size: 16777216
+  write_through_max_size: 26214400
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -332,7 +332,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `enabled`               | bool     | `true`           | Enable caching                                                                      |
 | `ttl`                   | duration | `24h`            | Default TTL for cached objects                                                      |
 | `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
-| `write_through_max_size` | int64   | `16777216`       | Max object size cached via the write-through tee (buffers in memory; negative disables; clamped to `size_threshold`) |
+| `write_through_max_size` | int64   | `26214400`       | Max object size cached via the write-through tee (buffers in memory; negative disables; clamped to `size_threshold`) |
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -277,10 +277,13 @@ how often a write initiated one.
 **Type:** Counter
 
 Number of objects cached by teeing the `PutObject` body on the write path
-(write-through), avoiding a read-back warm-on-write GET. Applies to authenticated single
-PUTs within `cache.size_threshold` in signing mode. Compare with
-`tag_warm_on_write_triggered_total` (the read-back fallback used for multipart completions,
-`CopyObject`, over-threshold or anonymous writes, and when the populate budget is saturated).
+(write-through): the body is captured as it's forwarded and the object's metadata is sourced
+from a lightweight HEAD (which returns the same headers a GET would, without the body), so
+**no full-object read-back GET** is needed. Applies to authenticated single PUTs within
+`cache.size_threshold` in signing mode. Compare with `tag_warm_on_write_triggered_total`
+(the read-back full GET, used for multipart completions, `CopyObject`, over-threshold or
+anonymous writes, when the populate budget is saturated, and when the tee's HEAD can't
+confirm the just-written version).
 
 ```promql
 # Share of write-triggered cache populates served by the write-through tee (no read-back)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -272,6 +272,22 @@ enabled. The warm's own outcome (success / failure / shed) is recorded by the
 `tag_background_fetches_*` and `tag_cache_populate_skipped_total` metrics; this counts
 how often a write initiated one.
 
+#### tag_cache_write_through_total
+
+**Type:** Counter
+
+Number of objects cached by teeing the `PutObject` body on the write path
+(write-through), avoiding a read-back warm-on-write GET. Applies to authenticated single
+PUTs within `cache.size_threshold` in signing mode. Compare with
+`tag_warm_on_write_triggered_total` (the read-back fallback used for multipart completions,
+`CopyObject`, over-threshold or anonymous writes, and when the populate budget is saturated).
+
+```promql
+# Share of write-triggered cache populates served by the write-through tee (no read-back)
+rate(tag_cache_write_through_total[5m]) /
+(rate(tag_cache_write_through_total[5m]) + rate(tag_warm_on_write_triggered_total[5m]))
+```
+
 #### tag_cache_populate_skipped_total
 
 **Type:** Counter

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -236,6 +236,16 @@ var (
 		},
 	)
 
+	// CacheWriteThrough counts objects populated into the cache by teeing the PUT body
+	// on the write path (write-through), avoiding a read-back warm-on-write GET. Compare
+	// with tag_warm_on_write_triggered_total, which counts the read-back fallback.
+	CacheWriteThrough = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_cache_write_through_total",
+			Help: "Number of objects cached by teeing the PUT body (write-through, no read-back)",
+		},
+	)
+
 	// LocalAuthValidations counts local auth validation attempts and results.
 	LocalAuthValidations = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -212,7 +212,7 @@ func (s *Service) setupCacheListener(
 		// Start cache writer goroutine - will call Read() when ready
 		cacheErrCh := make(chan error, 1)
 		go func() {
-			cacheErr := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime)
+			_, cacheErr := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime)
 			if cacheErr != nil {
 				log.Debug().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write with metadata failed")
 			}

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -476,7 +476,15 @@ func prepareForwardedRequest(fwdReq *http.Request, contentLength int64, chunked 
 // AWS S3 allows combined values like "aws-chunked,gzip". After decoding the chunked
 // layer, we strip only the aws-chunked token and preserve any remaining encodings.
 func stripAWSChunkedEncoding(req *http.Request) {
-	ce := req.Header.Get("Content-Encoding")
+	stripAWSChunkedEncodingHeader(req.Header)
+}
+
+// stripAWSChunkedEncodingHeader removes the "aws-chunked" token from a header set's
+// Content-Encoding, preserving any other encodings (e.g. "aws-chunked,gzip" -> "gzip").
+// Used both on the forwarded upstream request and when synthesizing cache metadata for a
+// write-through tee (which stores the DECODED body, so aws-chunked must not be advertised).
+func stripAWSChunkedEncodingHeader(h http.Header) {
+	ce := h.Get("Content-Encoding")
 	if ce == "" {
 		return
 	}
@@ -489,9 +497,9 @@ func stripAWSChunkedEncoding(req *http.Request) {
 	}
 
 	if len(remaining) == 0 {
-		req.Header.Del("Content-Encoding")
+		h.Del("Content-Encoding")
 	} else {
-		req.Header.Set("Content-Encoding", strings.Join(remaining, ","))
+		h.Set("Content-Encoding", strings.Join(remaining, ","))
 	}
 }
 

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -476,15 +476,7 @@ func prepareForwardedRequest(fwdReq *http.Request, contentLength int64, chunked 
 // AWS S3 allows combined values like "aws-chunked,gzip". After decoding the chunked
 // layer, we strip only the aws-chunked token and preserve any remaining encodings.
 func stripAWSChunkedEncoding(req *http.Request) {
-	stripAWSChunkedEncodingHeader(req.Header)
-}
-
-// stripAWSChunkedEncodingHeader removes the "aws-chunked" token from a header set's
-// Content-Encoding, preserving any other encodings (e.g. "aws-chunked,gzip" -> "gzip").
-// Used both on the forwarded upstream request and when synthesizing cache metadata for a
-// write-through tee (which stores the DECODED body, so aws-chunked must not be advertised).
-func stripAWSChunkedEncodingHeader(h http.Header) {
-	ce := h.Get("Content-Encoding")
+	ce := req.Header.Get("Content-Encoding")
 	if ce == "" {
 		return
 	}
@@ -497,9 +489,9 @@ func stripAWSChunkedEncodingHeader(h http.Header) {
 	}
 
 	if len(remaining) == 0 {
-		h.Del("Content-Encoding")
+		req.Header.Del("Content-Encoding")
 	} else {
-		h.Set("Content-Encoding", strings.Join(remaining, ","))
+		req.Header.Set("Content-Encoding", strings.Join(remaining, ","))
 	}
 }
 

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -190,6 +190,15 @@ func newBaseForwarder(tigrisEndpoint, region string, maxIdleConnsPerHost int) ba
 // originalReq is the original client request, passed to the response interceptor
 // for parsing auth info. It can be nil if no interceptor is set.
 func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64, originalReq *http.Request) error {
+	_, _, err := b.executeAndStreamReturningMeta(w, fwdReq, inContentLength, originalReq)
+	return err
+}
+
+// executeAndStreamReturningMeta is executeAndStream that also returns the upstream
+// status code and a clone of the upstream response headers. Used by the write-through
+// tee path, which needs the response ETag to build cache metadata for the just-written
+// object without a read-back GET. On a transport error it returns (0, nil, err).
+func (b *baseForwarder) executeAndStreamReturningMeta(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64, originalReq *http.Request) (int, http.Header, error) {
 	if inContentLength > 0 {
 		metrics.BytesTransferred.WithLabelValues("in").Add(float64(inContentLength))
 	}
@@ -199,7 +208,7 @@ func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Req
 	metrics.RecordUpstreamRequest(fwdReq.Method, time.Since(upstreamStart).Seconds(), err)
 	if err != nil {
 		log.Error().Err(err).Str("method", fwdReq.Method).Str("path", fwdReq.URL.Path).Msg("Failed to forward request")
-		return err
+		return 0, nil, err
 	}
 	defer resp.Body.Close()
 
@@ -207,6 +216,10 @@ func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Req
 	if b.responseInterceptor != nil {
 		b.responseInterceptor(resp, originalReq)
 	}
+
+	// Clone response headers before streaming so callers can read the upstream ETag
+	// after the body is consumed.
+	respHeaders := resp.Header.Clone()
 
 	// Stream response back to client
 	copyHeaders(w.Header(), resp.Header)
@@ -218,7 +231,7 @@ func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Req
 	metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
 
 	logUpstreamResponse(fwdReq, originalReq, resp.StatusCode, upstreamStart)
-	return nil
+	return resp.StatusCode, respHeaders, nil
 }
 
 // executeAndCapture executes the request, streams to client, and captures the response.

--- a/proxy/forwarder_signing.go
+++ b/proxy/forwarder_signing.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
@@ -54,6 +55,47 @@ func (f *signingForwarder) Forward(ctx context.Context, w http.ResponseWriter, r
 	prepareForwardedRequest(fwdReq, contentLength, chunked)
 
 	return f.executeAndStream(w, fwdReq, contentLength, nil)
+}
+
+// ForwardTeeingBody forwards a single PutObject while teeing the decoded request body
+// into `tee`, so the caller can populate the cache from the bytes TAG already has in hand
+// (a write-through tee) instead of a read-back warm-on-write GET. Returns the upstream
+// status code and a clone of the response headers (for the ETag) so the caller can build
+// cache metadata for the just-written object.
+//
+// Only the signing forwarder implements this: it decodes any AWS chunked encoding, so it
+// sees the assembled object bytes. The transparent forwarder preserves the client's opaque
+// (possibly chunked) body and signature, so it can't tee cleanly and falls back to
+// warm-on-write. The `tee` writer must never return an error — that would truncate the
+// upstream stream via io.TeeReader — so callers pass a capped, non-erroring buffer and
+// check overflow out of band.
+func (f *signingForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
+
+	accessKey, err := f.validator.ValidateRequest(r)
+	if err != nil {
+		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
+		return 0, nil, mapAuthError(err)
+	}
+	secretKey, err := f.credStore.GetSecretKey(accessKey)
+	if err != nil {
+		return 0, nil, mapAuthError(err)
+	}
+
+	path := r.URL.Path
+	if r.URL.RawQuery != "" {
+		path = path + "?" + r.URL.RawQuery
+	}
+
+	// Tee the decoded body into the caller's buffer as it is streamed upstream.
+	teedBody := io.TeeReader(body, tee)
+	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, teedBody, bodyHash, accessKey, secretKey, r.Header)
+	if err != nil {
+		return 0, nil, err
+	}
+	prepareForwardedRequest(fwdReq, contentLength, chunked)
+
+	return f.executeAndStreamReturningMeta(w, fwdReq, contentLength, nil)
 }
 
 // ForwardWithCapture forwards request and captures response for caching.

--- a/proxy/forwarder_signing.go
+++ b/proxy/forwarder_signing.go
@@ -69,17 +69,17 @@ func (f *signingForwarder) Forward(ctx context.Context, w http.ResponseWriter, r
 // warm-on-write. The `tee` writer must never return an error — that would truncate the
 // upstream stream via io.TeeReader — so callers pass a capped, non-erroring buffer and
 // check overflow out of band.
-func (f *signingForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+func (f *signingForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, string, string, error) {
 	body, bodyHash, contentLength, chunked := decodeChunkedIfNeeded(r)
 
 	accessKey, err := f.validator.ValidateRequest(r)
 	if err != nil {
 		log.Warn().Err(err).Str("path", r.URL.Path).Msg("Request signature validation failed")
-		return 0, nil, mapAuthError(err)
+		return 0, nil, "", "", mapAuthError(err)
 	}
 	secretKey, err := f.credStore.GetSecretKey(accessKey)
 	if err != nil {
-		return 0, nil, mapAuthError(err)
+		return 0, nil, "", "", mapAuthError(err)
 	}
 
 	path := r.URL.Path
@@ -91,11 +91,13 @@ func (f *signingForwarder) ForwardTeeingBody(ctx context.Context, w http.Respons
 	teedBody := io.TeeReader(body, tee)
 	fwdReq, err := f.signer.SignRequest(ctx, r.Method, path, teedBody, bodyHash, accessKey, secretKey, r.Header)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, "", "", err
 	}
 	prepareForwardedRequest(fwdReq, contentLength, chunked)
 
-	return f.executeAndStreamReturningMeta(w, fwdReq, contentLength, nil)
+	// Return the validated credentials so the caller can HEAD/warm without re-validating.
+	status, headers, err := f.executeAndStreamReturningMeta(w, fwdReq, contentLength, nil)
+	return status, headers, accessKey, secretKey, err
 }
 
 // ForwardWithCapture forwards request and captures response for caching.

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -211,7 +211,7 @@ func (s *Service) handleRevalidation200(
 	// Background goroutine: write to cache from pipe reader
 	cacheErrCh := make(chan error, 1)
 	go func() {
-		cacheErr := s.cache.PutWithMetaStreamTombstoneAware(
+		_, cacheErr := s.cache.PutWithMetaStreamTombstoneAware(
 			context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime,
 		)
 		if cacheErr != nil {

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -418,7 +418,7 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 		cached := false
 		if teed != nil {
 			// writeThroughCache takes ownership of the reserved populate budget.
-			cached = s.writeThroughCache(bucket, key, r, teed)
+			cached = s.writeThroughCache(bucket, key, teed)
 			teed = nil
 		}
 		if !cached {

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -398,9 +398,11 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
 	s.invalidateObject(context.Background(), bucket, key)
 
-	// Forward to Tigris, recording the upstream status.
+	// Forward to Tigris, recording the upstream status. When eligible, forwardPutMaybeTee
+	// tees the decoded body so we can populate the cache directly (write-through) instead of
+	// a read-back warm-on-write GET; teed is non-nil only when a tee was attempted.
 	rec := &statusRecorder{ResponseWriter: w}
-	err := s.forwarder.Forward(r.Context(), rec, r)
+	teed, err := s.forwardPutMaybeTee(r.Context(), rec, r, bucket, key)
 
 	// Re-invalidate AFTER upstream confirms the write. A GET that raced the
 	// in-flight PUT may have fetched the pre-PUT object and begun re-caching it;
@@ -413,7 +415,20 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
 		s.invalidateObject(context.Background(), bucket, key)
-		s.warmOnWrite(r, bucket, key)
+		cached := false
+		if teed != nil {
+			// writeThroughCache takes ownership of the reserved populate budget.
+			cached = s.writeThroughCache(bucket, key, r, teed)
+			teed = nil
+		}
+		if !cached {
+			s.warmOnWrite(r, bucket, key)
+		}
+	}
+	// Forward errored or upstream rejected the write: nothing cached, so release any budget
+	// reserved for the tee.
+	if teed != nil {
+		s.releaseCacheSlot(teed.weight)
 	}
 
 	status := "success"

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -89,7 +89,10 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 		// not populate the cache at all.
 		s.config.Cache.WarmOnWrite &&
 		s.cache.IsEnabled() &&
-		s.populateBudget != nil &&
+		// Not gated on a configured populate budget: acquireCacheSlot/releaseCacheSlot treat a
+		// nil budget as unlimited (count-semaphore only), exactly as warm-on-write does, so the
+		// tee must stay available when the byte budget is explicitly disabled — otherwise every
+		// eligible PUT silently regresses to the read-back warm.
 		// Anonymous writes fall back to warm-on-write, whose unsigned probe learns whether
 		// the object is public-read before caching it; the tee can't make that inference.
 		!hasNoAuthCredentials(r) &&

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -160,11 +160,13 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 		}
 		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed, size
 		// disagreement, or a competing write superseded it). Fall back to a read-back warm to cache
-		// the current object. Admit it NON-BLOCKING (priorityReadMiss): we still hold the tee's
-		// reservation, so a blocking warm could stall on our own slot, and its streaming buffers
-		// must fit the budget alongside ours — if not, shed and let a read-miss cache it later.
+		// the current object, with the same protected (blocking) admission as the normal
+		// warm-on-write path — so budget pressure doesn't shed it and leave a cold-read window.
+		// Holding the tee reservation across this doesn't stall the warm: triggerBackgroundCacheFetch
+		// only SPAWNS the fetch and returns, so this goroutine returns and its deferred release frees
+		// the slot, which the warm's (separate) blocking acquire then observes.
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityReadMiss)
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
 	}()
 	return true
 }

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -18,7 +18,10 @@ import (
 // AWS chunked encoding and thus sees the assembled object bytes. The transparent forwarder
 // preserves the client's opaque body + signature, so it can't tee cleanly.
 type bodyTeeingForwarder interface {
-	ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error)
+	// ForwardTeeingBody forwards the PUT while teeing the decoded body into tee, and returns
+	// the upstream status + response headers plus the client credentials it already validated
+	// and derived (so the caller can HEAD/warm without re-validating the signature).
+	ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (statusCode int, respHeaders http.Header, accessKey, secretKey string, err error)
 }
 
 // cappedBuffer is an io.Writer that accumulates up to cap bytes, then silently discards the
@@ -55,6 +58,8 @@ type teeState struct {
 	respHeaders http.Header
 	statusCode  int
 	weight      int64
+	accessKey   string // client credentials validated by ForwardTeeingBody, reused for the HEAD/warm
+	secretKey   string
 }
 
 // teeObjectSize returns the decoded object size for a PutObject, preferring the AWS
@@ -106,9 +111,11 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 	// Preallocate to the exact known size to avoid repeated append reallocations on the
 	// write hot path.
 	ts := &teeState{buf: &cappedBuffer{buf: make([]byte, 0, int(size)), cap: int(size)}, weight: size}
-	status, headers, err := tf.ForwardTeeingBody(ctx, w, r, ts.buf)
+	status, headers, accessKey, secretKey, err := tf.ForwardTeeingBody(ctx, w, r, ts.buf)
 	ts.statusCode = status
 	ts.respHeaders = headers
+	ts.accessKey = accessKey
+	ts.secretKey = secretKey
 	return ts, err
 }
 
@@ -122,23 +129,20 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 // synchronously (over-cap body, missing ETag, or no usable credentials) so the caller warms.
 // The reserved populate budget is always released: synchronously on decline, or when the
 // async work completes.
-func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *teeState) bool {
+func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 	putETag := ts.respHeaders.Get("ETag")
-	if ts.buf.overflowed || putETag == "" {
-		// Over-declared body, or no version identity from upstream (bodies are ETag-addressed).
-		s.releaseCacheSlot(ts.weight)
-		return false
-	}
-
-	// Credentials for the authoritative HEAD, read synchronously (r must not be used from the
-	// async goroutine — the server may recycle it after the handler returns).
-	_, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
-	if err != nil || accessKey == "" || secretKey == "" {
+	// Credentials were validated and derived by ForwardTeeingBody (no re-validation here). The
+	// async goroutine uses only these captured values — never r, which the server may recycle
+	// after the handler returns.
+	if ts.buf.overflowed || putETag == "" || ts.accessKey == "" || ts.secretKey == "" {
+		// Over-declared body, no version identity from upstream (bodies are ETag-addressed),
+		// or no usable credentials.
 		s.releaseCacheSlot(ts.weight)
 		return false
 	}
 
 	body := ts.buf.buf
+	accessKey, secretKey := ts.accessKey, ts.secretKey
 	go func() {
 		defer s.releaseCacheSlot(ts.weight)
 		if s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey) {
@@ -146,7 +150,7 @@ func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *tee
 		}
 		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed,
 		// or size disagreement). Fall back to a read-back warm so the object is still cached
-		// correctly. Uses the credentials captured above — not r.
+		// correctly.
 		metrics.WarmOnWriteTriggered.Inc()
 		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
 	}()
@@ -157,11 +161,15 @@ func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *tee
 // is still the exact version we teed (ETag matches) and is cacheable, writes that meta with
 // the teed body. Returns false (so the caller can fall back to warm-on-write) when it can't
 // confirm/cache the object.
-//
-// writeStartTime is stamped just before the write (after the caller's post-forward
-// invalidation) so tombstone ordering matches warm-on-write: the object's own invalidations
-// are older and don't block it, while a later competing DELETE/overwrite does.
 func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte, accessKey, secretKey string) bool {
+	// Stamp the tombstone reference BEFORE the HEAD (mirroring warm-on-write, which stamps
+	// before its fetch), so the whole HEAD-to-write window is guarded: a competing overwrite
+	// whose invalidation lands after this point is newer than writeStartTime and skips our
+	// write, while one that landed earlier is caught by the ETag-consistency check below. It
+	// is still newer than this PUT's own post-forward invalidation (stamped before this
+	// goroutine ran), so our own invalidation doesn't block us.
+	writeStartTime := time.Now().UnixNano()
+
 	headCtx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
 	defer cancel()
 
@@ -193,7 +201,6 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 		return false
 	}
 
-	writeStartTime := time.Now().UnixNano()
 	ttl := int(s.config.Cache.TTL.Seconds())
 	cacheCtx, cacheCancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
 	defer cacheCancel()

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -145,12 +145,13 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 	accessKey, secretKey := ts.accessKey, ts.secretKey
 	weight := ts.weight
 	go func() {
+		// Hold the tee's populate reservation for the whole goroutine: it accounts for the
+		// object-sized teed body, which stays live until this returns. Releasing it early
+		// (before a fallback allocates) would let the body coexist unaccounted with the
+		// fallback's buffers and push live populate memory past the budget.
+		defer s.releaseCacheSlot(weight)
+
 		outcome := s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey)
-		// Release the tee's populate reservation (and the buffer it accounts for, now consumed
-		// by the write) BEFORE any fallback warm acquires its own slot — never hold both, or a
-		// saturated / single-slot budget couldn't admit the warm and the object would be left
-		// uncached.
-		s.releaseCacheSlot(weight)
 		if outcome != teeFallbackWarm {
 			// teeCached: already cached. teeNotCacheable: the authoritative HEAD says the object
 			// isn't cacheable (Cache-Control no-store/private, or over threshold), so a warm would
@@ -158,10 +159,12 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 			return
 		}
 		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed, size
-		// disagreement, or a competing write superseded it). Fall back to a read-back warm to
-		// cache the current object correctly.
+		// disagreement, or a competing write superseded it). Fall back to a read-back warm to cache
+		// the current object. Admit it NON-BLOCKING (priorityReadMiss): we still hold the tee's
+		// reservation, so a blocking warm could stall on our own slot, and its streaming buffers
+		// must fit the budget alongside ours — if not, shed and let a read-miss cache it later.
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityReadMiss)
 	}()
 	return true
 }

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -13,11 +13,6 @@ import (
 	"github.com/tigrisdata/tag/metrics"
 )
 
-// defaultObjectContentType approximates the Content-Type an origin GET returns for an
-// object uploaded without one, so a write-through cache hit doesn't diverge from a miss by
-// omitting the header entirely.
-const defaultObjectContentType = "application/octet-stream"
-
 // bodyTeeingForwarder is implemented by forwarders that can tee the decoded request body
 // while forwarding a single PutObject. Only the signing forwarder implements it: it decodes
 // AWS chunked encoding and thus sees the assembled object bytes. The transparent forwarder
@@ -117,89 +112,95 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 	return ts, err
 }
 
-// writeThroughCache populates the cache from a teed PutObject body, avoiding a read-back
-// GET. It returns true when the object was handed off to an async cache write, false when
-// it declined (over-cap body, missing ETag, or not cacheable) — in which case the caller
-// should fall back to warm-on-write. It always releases the reserved populate budget:
-// immediately on decline, or when the async write completes on success.
+// writeThroughCache populates the cache from a teed PutObject body without a full-object
+// read-back. It fetches AUTHORITATIVE object metadata with a HEAD (which returns exactly the
+// headers a GET would, minus the body), so the cached entry can never diverge from an origin
+// GET, then writes that meta with the bytes already teed.
 //
-// writeStartTime is stamped here (after the caller's post-forward invalidation) so this
-// write's own tombstone ordering matches warm-on-write: the object's own invalidations are
-// older and don't block it, while a later competing DELETE/overwrite does.
+// Returns true when the write was handed off to the async path (which caches the object or,
+// if the HEAD can't confirm it, falls back to a read-back warm), false when it declined
+// synchronously (over-cap body, missing ETag, or no usable credentials) so the caller warms.
+// The reserved populate budget is always released: synchronously on decline, or when the
+// async work completes.
 func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *teeState) bool {
-	if ts.buf.overflowed {
-		// Client sent more than its declared length; caching a truncated body would be wrong.
-		s.releaseCacheSlot(ts.weight)
-		return false
-	}
-	etag := ts.respHeaders.Get("ETag")
-	if etag == "" {
-		// No version identity from upstream — bodies are ETag-addressed, so this isn't
-		// cacheable. Fall back to warm-on-write (which learns the ETag from a GET).
+	putETag := ts.respHeaders.Get("ETag")
+	if ts.buf.overflowed || putETag == "" {
+		// Over-declared body, or no version identity from upstream (bodies are ETag-addressed).
 		s.releaseCacheSlot(ts.weight)
 		return false
 	}
 
-	// Build the headers a GET of this object would return: object metadata (Content-Type,
-	// Content-Encoding, Cache-Control, x-amz-meta-*, ...) from the PUT request; ETag/version
-	// from the PUT response; Content-Length from the bytes actually teed. Several fields must
-	// be corrected so a cache-hit GET matches an origin GET rather than the raw write request.
-	h := r.Header.Clone()
-	h.Set("ETag", etag)
-	h.Set("Content-Length", strconv.FormatInt(int64(len(ts.buf.buf)), 10))
-
-	// version-id comes from the PUT response, not the request.
-	if v := ts.respHeaders.Get("x-amz-version-id"); v != "" {
-		h.Set("x-amz-version-id", v)
-	} else {
-		h.Del("x-amz-version-id")
+	// Credentials for the authoritative HEAD, read synchronously (r must not be used from the
+	// async goroutine — the server may recycle it after the handler returns).
+	_, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil || accessKey == "" || secretKey == "" {
+		s.releaseCacheSlot(ts.weight)
+		return false
 	}
 
-	// The tee stores the DECODED body, so strip the aws-chunked transfer token (as the
-	// forwarded upstream request does); otherwise a cache hit would advertise a bogus
-	// Content-Encoding over un-chunked bytes.
-	stripAWSChunkedEncodingHeader(h)
+	body := ts.buf.buf
+	go func() {
+		defer s.releaseCacheSlot(ts.weight)
+		if s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey) {
+			return
+		}
+		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed,
+		// or size disagreement). Fall back to a read-back warm so the object is still cached
+		// correctly. Uses the credentials captured above — not r.
+		metrics.WarmOnWriteTriggered.Inc()
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
+	}()
+	return true
+}
 
-	// X-Amz-Acl is a write-only directive; an origin GET never echoes it. Drop it so cache
-	// hits don't emit a header the origin omits (and so the entry isn't marked public-read
-	// from a write directive — the tee is authenticated-only regardless).
-	h.Del("X-Amz-Acl")
+// cacheTeedBodyFromHead HEADs the object for authoritative metadata and, only if the object
+// is still the exact version we teed (ETag matches) and is cacheable, writes that meta with
+// the teed body. Returns false (so the caller can fall back to warm-on-write) when it can't
+// confirm/cache the object.
+//
+// writeStartTime is stamped just before the write (after the caller's post-forward
+// invalidation) so tombstone ordering matches warm-on-write: the object's own invalidations
+// are older and don't block it, while a later competing DELETE/overwrite does.
+func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte, accessKey, secretKey string) bool {
+	headCtx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
 
-	// A PUT request carries no Last-Modified. Approximate the object's modification time from
-	// the PUT response (Last-Modified if present, else Date, else now) so conditional GETs
-	// (If-Modified-Since) work and the header isn't absent where an origin GET returns it.
-	if lm := ts.respHeaders.Get("Last-Modified"); lm != "" {
-		h.Set("Last-Modified", lm)
-	} else if d := ts.respHeaders.Get("Date"); d != "" {
-		h.Set("Last-Modified", d)
-	} else {
-		h.Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	// Empty etag/lastModified => a plain (non-conditional) HEAD.
+	resp, err := s.forwarder.DoConditionalHeadRequest(headCtx, bucket, key, accessKey, secretKey, "", 0)
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through tee HEAD failed")
+		return false
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false // object removed or unreadable
+	}
+	// Only cache if the object is still the exact version we teed. A concurrent overwrite
+	// returns a different ETag whose body is NOT what we hold; caching it would pair
+	// mismatched meta and body (the torn-pair hazard ETag-versioned bodies prevent).
+	if resp.Header.Get("ETag") != putETag {
+		return false
 	}
 
-	// When the client omits Content-Type, the origin applies a default on GET; mirror it so a
-	// cache hit doesn't return an empty Content-Type where a miss returns the default.
-	if h.Get("Content-Type") == "" {
-		h.Set("Content-Type", defaultObjectContentType)
-	}
-
-	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, h)
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
 	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
-		s.releaseCacheSlot(ts.weight)
+		return false
+	}
+	if meta.ContentLength != int64(len(body)) {
+		// HEAD's advertised length disagrees with the bytes we teed; don't cache a mismatch.
 		return false
 	}
 
 	writeStartTime := time.Now().UnixNano()
 	ttl := int(s.config.Cache.TTL.Seconds())
-	body := ts.buf.buf
-
-	go func() {
-		defer s.releaseCacheSlot(ts.weight)
-		cacheCtx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
-		defer cancel()
-		if err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime); err != nil {
-			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee failed")
-		}
-	}()
+	cacheCtx, cacheCancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
+	defer cacheCancel()
+	if err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime); err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee write failed")
+		return false
+	}
 	metrics.CacheWriteThrough.Inc()
 	return true
 }

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -1,0 +1,164 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// bodyTeeingForwarder is implemented by forwarders that can tee the decoded request body
+// while forwarding a single PutObject. Only the signing forwarder implements it: it decodes
+// AWS chunked encoding and thus sees the assembled object bytes. The transparent forwarder
+// preserves the client's opaque body + signature, so it can't tee cleanly.
+type bodyTeeingForwarder interface {
+	ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error)
+}
+
+// cappedBuffer is an io.Writer that accumulates up to cap bytes, then silently discards the
+// rest and records that it overflowed. It NEVER returns an error — that is essential, because
+// it is used as an io.TeeReader sink where a write error would truncate the upstream stream.
+// Overflow (a client sending more than its declared Content-Length) is surfaced out of band
+// so the caller can decline to cache a partial body.
+type cappedBuffer struct {
+	buf        []byte
+	cap        int
+	overflowed bool
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if !c.overflowed {
+		room := c.cap - len(c.buf)
+		if len(p) <= room {
+			c.buf = append(c.buf, p...)
+		} else {
+			if room > 0 {
+				c.buf = append(c.buf, p[:room]...)
+			}
+			c.overflowed = true
+		}
+	}
+	return len(p), nil
+}
+
+// teeState carries a write-through tee attempt from the forward call to the post-forward
+// cache write. When non-nil, the caller has reserved `weight` bytes of populate budget that
+// must be released exactly once — writeThroughCache takes ownership of that release.
+type teeState struct {
+	buf         *cappedBuffer
+	respHeaders http.Header
+	statusCode  int
+	weight      int64
+}
+
+// teeObjectSize returns the decoded object size for a PutObject, preferring the AWS
+// decoded-content-length header (chunked uploads) over the raw Content-Length.
+func teeObjectSize(r *http.Request) int64 {
+	if dcl := r.Header.Get("X-Amz-Decoded-Content-Length"); dcl != "" {
+		if n, err := strconv.ParseInt(dcl, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return r.ContentLength
+}
+
+// forwardPutMaybeTee forwards a PutObject. When the object is eligible for a write-through
+// tee — signing-mode forwarder, cache enabled, a single object within the cache size
+// threshold, and the populate budget admits it without blocking — it tees the decoded body
+// so the caller can populate the cache without a read-back warm GET. It returns a non-nil
+// *teeState only when a tee was attempted; the caller must then route it through
+// writeThroughCache (which releases the reserved budget). Otherwise it performs a plain
+// forward and returns nil, and the caller falls back to warm-on-write.
+func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string) (*teeState, error) {
+	tf, ok := s.forwarder.(bodyTeeingForwarder)
+	size := teeObjectSize(r)
+	eligible := ok &&
+		s.cache.IsEnabled() &&
+		s.populateBudget != nil &&
+		// Anonymous writes fall back to warm-on-write, whose unsigned probe learns whether
+		// the object is public-read before caching it; the tee can't make that inference.
+		!hasNoAuthCredentials(r) &&
+		size > 0 &&
+		size <= s.config.Cache.SizeThreshold
+
+	if !eligible {
+		return nil, s.forwarder.Forward(ctx, w, r)
+	}
+
+	// Non-blocking admission: the tee runs on the client PUT path, so it must never block
+	// the write waiting for budget. priorityReadMiss acquires the count slot and byte budget
+	// without blocking; on denial we fall back to a plain forward + (async, blocking)
+	// warm-on-write, so the object still gets cached under budget pressure.
+	if !s.acquireCacheSlot(ctx, size, priorityReadMiss) {
+		return nil, s.forwarder.Forward(ctx, w, r)
+	}
+
+	ts := &teeState{buf: &cappedBuffer{cap: int(size)}, weight: size}
+	status, headers, err := tf.ForwardTeeingBody(ctx, w, r, ts.buf)
+	ts.statusCode = status
+	ts.respHeaders = headers
+	return ts, err
+}
+
+// writeThroughCache populates the cache from a teed PutObject body, avoiding a read-back
+// GET. It returns true when the object was handed off to an async cache write, false when
+// it declined (over-cap body, missing ETag, or not cacheable) — in which case the caller
+// should fall back to warm-on-write. It always releases the reserved populate budget:
+// immediately on decline, or when the async write completes on success.
+//
+// writeStartTime is stamped here (after the caller's post-forward invalidation) so this
+// write's own tombstone ordering matches warm-on-write: the object's own invalidations are
+// older and don't block it, while a later competing DELETE/overwrite does.
+func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *teeState) bool {
+	if ts.buf.overflowed {
+		// Client sent more than its declared length; caching a truncated body would be wrong.
+		s.releaseCacheSlot(ts.weight)
+		return false
+	}
+	etag := ts.respHeaders.Get("ETag")
+	if etag == "" {
+		// No version identity from upstream — bodies are ETag-addressed, so this isn't
+		// cacheable. Fall back to warm-on-write (which learns the ETag from a GET).
+		s.releaseCacheSlot(ts.weight)
+		return false
+	}
+
+	// Build the headers a GET of this object would return: object metadata (Content-Type,
+	// Content-Encoding, x-amz-meta-*, ...) from the PUT request; ETag/version from the PUT
+	// response; Content-Length from the bytes actually teed.
+	h := r.Header.Clone()
+	h.Set("ETag", etag)
+	if v := ts.respHeaders.Get("x-amz-version-id"); v != "" {
+		h.Set("x-amz-version-id", v)
+	} else {
+		h.Del("x-amz-version-id")
+	}
+	h.Set("Content-Length", strconv.FormatInt(int64(len(ts.buf.buf)), 10))
+
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, h)
+	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
+		s.releaseCacheSlot(ts.weight)
+		return false
+	}
+
+	writeStartTime := time.Now().UnixNano()
+	ttl := int(s.config.Cache.TTL.Seconds())
+	body := ts.buf.buf
+
+	go func() {
+		defer s.releaseCacheSlot(ts.weight)
+		cacheCtx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
+		defer cancel()
+		if err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime); err != nil {
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee failed")
+		}
+	}()
+	metrics.CacheWriteThrough.Inc()
+	return true
+}

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -210,8 +210,16 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 	ttl := int(s.config.Cache.TTL.Seconds())
 	cacheCtx, cacheCancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
 	defer cacheCancel()
-	if err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime); err != nil {
+	wrote, err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime)
+	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee write failed")
+		return false
+	}
+	if !wrote {
+		// A newer tombstone (competing DELETE/overwrite) superseded our teed version, so
+		// nothing was cached. Report not-cached so the caller warms: warm's own writeStartTime
+		// is newer than that tombstone, so it will cache the CURRENT version (or no-op on a
+		// delete) rather than our stale body.
 		return false
 	}
 	metrics.CacheWriteThrough.Inc()

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -13,6 +13,11 @@ import (
 	"github.com/tigrisdata/tag/metrics"
 )
 
+// defaultObjectContentType approximates the Content-Type an origin GET returns for an
+// object uploaded without one, so a write-through cache hit doesn't diverge from a miss by
+// omitting the header entirely.
+const defaultObjectContentType = "application/octet-stream"
+
 // bodyTeeingForwarder is implemented by forwarders that can tee the decoded request body
 // while forwarding a single PutObject. Only the signing forwarder implements it: it decodes
 // AWS chunked encoding and thus sees the assembled object bytes. The transparent forwarder
@@ -79,6 +84,10 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 	tf, ok := s.forwarder.(bodyTeeingForwarder)
 	size := teeObjectSize(r)
 	eligible := ok &&
+		// The tee is an optimization of warm-on-write (cache-on-write), so it must respect
+		// the same flag: when warm-on-write is disabled (the default), a successful PUT must
+		// not populate the cache at all.
+		s.config.Cache.WarmOnWrite &&
 		s.cache.IsEnabled() &&
 		s.populateBudget != nil &&
 		// Anonymous writes fall back to warm-on-write, whose unsigned probe learns whether
@@ -99,7 +108,9 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 		return nil, s.forwarder.Forward(ctx, w, r)
 	}
 
-	ts := &teeState{buf: &cappedBuffer{cap: int(size)}, weight: size}
+	// Preallocate to the exact known size to avoid repeated append reallocations on the
+	// write hot path.
+	ts := &teeState{buf: &cappedBuffer{buf: make([]byte, 0, int(size)), cap: int(size)}, weight: size}
 	status, headers, err := tf.ForwardTeeingBody(ctx, w, r, ts.buf)
 	ts.statusCode = status
 	ts.respHeaders = headers
@@ -130,16 +141,46 @@ func (s *Service) writeThroughCache(bucket, key string, r *http.Request, ts *tee
 	}
 
 	// Build the headers a GET of this object would return: object metadata (Content-Type,
-	// Content-Encoding, x-amz-meta-*, ...) from the PUT request; ETag/version from the PUT
-	// response; Content-Length from the bytes actually teed.
+	// Content-Encoding, Cache-Control, x-amz-meta-*, ...) from the PUT request; ETag/version
+	// from the PUT response; Content-Length from the bytes actually teed. Several fields must
+	// be corrected so a cache-hit GET matches an origin GET rather than the raw write request.
 	h := r.Header.Clone()
 	h.Set("ETag", etag)
+	h.Set("Content-Length", strconv.FormatInt(int64(len(ts.buf.buf)), 10))
+
+	// version-id comes from the PUT response, not the request.
 	if v := ts.respHeaders.Get("x-amz-version-id"); v != "" {
 		h.Set("x-amz-version-id", v)
 	} else {
 		h.Del("x-amz-version-id")
 	}
-	h.Set("Content-Length", strconv.FormatInt(int64(len(ts.buf.buf)), 10))
+
+	// The tee stores the DECODED body, so strip the aws-chunked transfer token (as the
+	// forwarded upstream request does); otherwise a cache hit would advertise a bogus
+	// Content-Encoding over un-chunked bytes.
+	stripAWSChunkedEncodingHeader(h)
+
+	// X-Amz-Acl is a write-only directive; an origin GET never echoes it. Drop it so cache
+	// hits don't emit a header the origin omits (and so the entry isn't marked public-read
+	// from a write directive — the tee is authenticated-only regardless).
+	h.Del("X-Amz-Acl")
+
+	// A PUT request carries no Last-Modified. Approximate the object's modification time from
+	// the PUT response (Last-Modified if present, else Date, else now) so conditional GETs
+	// (If-Modified-Since) work and the header isn't absent where an origin GET returns it.
+	if lm := ts.respHeaders.Get("Last-Modified"); lm != "" {
+		h.Set("Last-Modified", lm)
+	} else if d := ts.respHeaders.Get("Date"); d != "" {
+		h.Set("Last-Modified", d)
+	} else {
+		h.Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	}
+
+	// When the client omits Content-Type, the origin applies a default on GET; mirror it so a
+	// cache hit doesn't return an empty Content-Type where a miss returns the default.
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", defaultObjectContentType)
+	}
 
 	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, h)
 	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -94,7 +94,10 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 		// the object is public-read before caching it; the tee can't make that inference.
 		!hasNoAuthCredentials(r) &&
 		size > 0 &&
-		size <= s.config.Cache.SizeThreshold
+		// The tee buffers the whole object in memory, so it uses WriteThroughMaxSize (a small
+		// cap), not SizeThreshold. Larger-but-cacheable objects fall back to streaming
+		// warm-on-write. IsCacheable(SizeThreshold) still applies to the meta after the HEAD.
+		size <= s.config.Cache.WriteThroughMaxSize
 
 	if !eligible {
 		return nil, s.forwarder.Forward(ctx, w, r)
@@ -199,7 +202,7 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 
 	// Empty etag/lastModified => a plain (non-conditional) HEAD.
 	resp, err := s.forwarder.DoConditionalHeadRequest(headCtx, bucket, key, accessKey, secretKey, "", 0)
-	if err != nil {
+	if err != nil || resp == nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through tee HEAD failed")
 		return teeFallbackWarm
 	}

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -145,29 +145,42 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 	accessKey, secretKey := ts.accessKey, ts.secretKey
 	weight := ts.weight
 	go func() {
-		cached := s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey)
+		outcome := s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey)
 		// Release the tee's populate reservation (and the buffer it accounts for, now consumed
 		// by the write) BEFORE any fallback warm acquires its own slot — never hold both, or a
 		// saturated / single-slot budget couldn't admit the warm and the object would be left
 		// uncached.
 		s.releaseCacheSlot(weight)
-		if cached {
+		if outcome != teeFallbackWarm {
+			// teeCached: already cached. teeNotCacheable: the authoritative HEAD says the object
+			// isn't cacheable (Cache-Control no-store/private, or over threshold), so a warm would
+			// only re-download the full body to reject it again — skip it.
 			return
 		}
-		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed,
-		// or size disagreement). Fall back to a read-back warm so the object is still cached
-		// correctly.
+		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed, size
+		// disagreement, or a competing write superseded it). Fall back to a read-back warm to
+		// cache the current object correctly.
 		metrics.WarmOnWriteTriggered.Inc()
 		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
 	}()
 	return true
 }
 
+// teeOutcome is the result of a HEAD-verified write-through cache attempt.
+type teeOutcome int
+
+const (
+	teeCached       teeOutcome = iota // meta+body written; no fallback needed
+	teeNotCacheable                   // HEAD authoritatively says not cacheable; a warm would only re-download and re-reject
+	teeFallbackWarm                   // couldn't confirm/write the version; a read-back warm may still cache the current object
+)
+
 // cacheTeedBodyFromHead HEADs the object for authoritative metadata and, only if the object
 // is still the exact version we teed (ETag matches) and is cacheable, writes that meta with
-// the teed body. Returns false (so the caller can fall back to warm-on-write) when it can't
-// confirm/cache the object.
-func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte, accessKey, secretKey string) bool {
+// the teed body. It returns teeCached on a successful write, teeNotCacheable when the HEAD
+// authoritatively shows the object should not be cached (so warming is pointless), and
+// teeFallbackWarm when it couldn't confirm/write the version (so a read-back warm may help).
+func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte, accessKey, secretKey string) teeOutcome {
 	// Stamp the tombstone reference BEFORE the HEAD (mirroring warm-on-write, which stamps
 	// before its fetch), so the whole HEAD-to-write window is guarded: a competing overwrite
 	// whose invalidation lands after this point is newer than writeStartTime and skips our
@@ -183,28 +196,32 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 	resp, err := s.forwarder.DoConditionalHeadRequest(headCtx, bucket, key, accessKey, secretKey, "", 0)
 	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through tee HEAD failed")
-		return false
+		return teeFallbackWarm
 	}
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if resp.StatusCode != http.StatusOK {
-		return false // object removed or unreadable
+		return teeFallbackWarm // object removed/unreadable now; a warm may still fetch it
 	}
 	// Only cache if the object is still the exact version we teed. A concurrent overwrite
 	// returns a different ETag whose body is NOT what we hold; caching it would pair
 	// mismatched meta and body (the torn-pair hazard ETag-versioned bodies prevent).
 	if resp.Header.Get("ETag") != putETag {
-		return false
+		return teeFallbackWarm // superseded by a concurrent overwrite; warm caches the current version
 	}
 
 	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
 	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
-		return false
+		// The authoritative HEAD says this object must not be cached (Cache-Control no-store/
+		// private, or over threshold). A warm would only re-download the full body to reject it
+		// again, so don't fall back.
+		return teeNotCacheable
 	}
 	if meta.ContentLength != int64(len(body)) {
-		// HEAD's advertised length disagrees with the bytes we teed; don't cache a mismatch.
-		return false
+		// HEAD's advertised length disagrees with the bytes we teed; let a warm fetch the
+		// authoritative body instead of caching a mismatch.
+		return teeFallbackWarm
 	}
 
 	ttl := int(s.config.Cache.TTL.Seconds())
@@ -213,15 +230,14 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 	wrote, err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime)
 	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee write failed")
-		return false
+		return teeFallbackWarm
 	}
 	if !wrote {
 		// A newer tombstone (competing DELETE/overwrite) superseded our teed version, so
-		// nothing was cached. Report not-cached so the caller warms: warm's own writeStartTime
-		// is newer than that tombstone, so it will cache the CURRENT version (or no-op on a
-		// delete) rather than our stale body.
-		return false
+		// nothing was cached. Warm instead: its own writeStartTime is newer than that tombstone,
+		// so it caches the CURRENT version (or no-ops on a delete) rather than our stale body.
+		return teeFallbackWarm
 	}
 	metrics.CacheWriteThrough.Inc()
-	return true
+	return teeCached
 }

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -143,9 +143,15 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 
 	body := ts.buf.buf
 	accessKey, secretKey := ts.accessKey, ts.secretKey
+	weight := ts.weight
 	go func() {
-		defer s.releaseCacheSlot(ts.weight)
-		if s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey) {
+		cached := s.cacheTeedBodyFromHead(bucket, key, putETag, body, accessKey, secretKey)
+		// Release the tee's populate reservation (and the buffer it accounts for, now consumed
+		// by the write) BEFORE any fallback warm acquires its own slot — never hold both, or a
+		// saturated / single-slot budget couldn't admit the warm and the object would be left
+		// uncached.
+		s.releaseCacheSlot(weight)
+		if cached {
 			return
 		}
 		// The HEAD couldn't confirm the version we teed (HEAD failed, object changed/removed,

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -20,23 +20,33 @@ import (
 // authoritative HEAD the tee then issues is served from the embedded mock's conditionalResp.
 type teeMockForwarder struct {
 	*mockForwarder
-	teeFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error)
+	teeFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, string, string, error)
+	// headHook, if set, runs when the tee issues its authoritative HEAD — used to simulate a
+	// competing write landing during the HEAD window.
+	headHook func()
 }
 
-func (m *teeMockForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+func (m *teeMockForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, string, string, error) {
 	return m.teeFunc(ctx, w, r, tee)
 }
 
+func (m *teeMockForwarder) DoConditionalHeadRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, lastModified int64) (*http.Response, error) {
+	if m.headHook != nil {
+		m.headHook()
+	}
+	return m.mockForwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, etag, lastModified)
+}
+
 // teeUpstream returns a teeFunc that tees the whole body, responds 200 with the given
-// ETag, and counts how many PUTs reached "upstream".
-func teeUpstream(puts *atomic.Int32, etag string) func(context.Context, http.ResponseWriter, *http.Request, io.Writer) (int, http.Header, error) {
-	return func(_ context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+// ETag and validated credentials, and counts how many PUTs reached "upstream".
+func teeUpstream(puts *atomic.Int32, etag string) func(context.Context, http.ResponseWriter, *http.Request, io.Writer) (int, http.Header, string, string, error) {
+	return func(_ context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, string, string, error) {
 		_, _ = io.Copy(tee, r.Body) // tee the object bytes into the caller's buffer
 		puts.Add(1)
 		h := http.Header{}
 		h.Set("ETag", etag)
 		w.WriteHeader(http.StatusOK)
-		return http.StatusOK, h, nil
+		return http.StatusOK, h, "access", "secret", nil
 	}
 }
 
@@ -175,6 +185,38 @@ func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T
 	}
 	if got := warmGets.Load(); got != 1 {
 		t.Errorf("warm read-back GETs = %d, want 1 (HEAD failure must fall back to warm)", got)
+	}
+}
+
+// A competing overwrite/DELETE that lands during the HEAD window must not be resurrected:
+// writeStartTime is stamped BEFORE the HEAD, so a tombstone written during the HEAD is newer
+// and the tombstone-aware write skips. (With writeStartTime stamped after the HEAD, the stale
+// teed body would be cached.)
+func TestHandlePutObject_WriteThroughTee_TombstoneDuringHeadBlocksWrite(t *testing.T) {
+	var puts atomic.Int32
+	var svc *Service
+	body := "stale-teed-body"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalResp: headResp(`"tee-etag"`, "text/plain", int64(len(body))),
+			// No doFullObjectFunc: the write is a tombstone-skip (not an error), so no warm fallback.
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+		// Simulate the competing write's invalidation landing in the HEAD window.
+		headHook: func() { svc.invalidateObject(context.Background(), wowBucket, wowKey) },
+	}
+	s, c := newTestService(mock, true)
+	svc = s
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if metaCached(c, wowBucket, wowKey, 500*time.Millisecond) {
+		t.Error("stale teed body was cached despite a tombstone during the HEAD window")
 	}
 }
 

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -80,6 +80,7 @@ func TestHandlePutObject_WriteThroughTee_CachesFromHead(t *testing.T) {
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
@@ -141,6 +142,7 @@ func TestHandlePutObject_WriteThroughTee_ETagMismatchFallsBackToWarm(t *testing.
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
@@ -174,6 +176,7 @@ func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, "body")); err != nil {
@@ -208,6 +211,7 @@ func TestHandlePutObject_WriteThroughTee_NotCacheableSkipsWarm(t *testing.T) {
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
@@ -247,6 +251,7 @@ func TestHandlePutObject_WriteThroughTee_TombstoneDuringHeadFallsBackToWarm(t *t
 	svc = s
 	svc.config.Cache.WarmOnWrite = true
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
@@ -280,6 +285,7 @@ func TestHandlePutObject_WriteThroughTee_DisabledWhenWarmOnWriteOff(t *testing.T
 	}
 	svc, c := newTestService(mock, true) // WarmOnWrite defaults to false
 	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, "body")); err != nil {
@@ -293,11 +299,11 @@ func TestHandlePutObject_WriteThroughTee_DisabledWhenWarmOnWriteOff(t *testing.T
 	}
 }
 
-// An object larger than the cache size threshold is not eligible for the tee; it falls
-// back to warm-on-write (the read-back path).
-func TestHandlePutObject_WriteThroughTee_FallsBackAboveSizeThreshold(t *testing.T) {
+// An object larger than WriteThroughMaxSize is not eligible for the tee (it would have to
+// be buffered); it falls back to the streaming warm-on-write read-back instead.
+func TestHandlePutObject_WriteThroughTee_FallsBackAboveWriteThroughMaxSize(t *testing.T) {
 	var puts, warmGets atomic.Int32
-	body := "this-body-exceeds-the-tiny-threshold"
+	body := "this-body-exceeds-the-tiny-write-through-cap"
 
 	mock := &teeMockForwarder{
 		mockForwarder: &mockForwarder{
@@ -311,9 +317,10 @@ func TestHandlePutObject_WriteThroughTee_FallsBackAboveSizeThreshold(t *testing.
 	}
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
-	// Threshold sits between the PUT body (36 bytes) and the warm object (9 bytes): the tee
-	// is skipped (body too big) but the read-back warm still caches the smaller fetched object.
-	svc.config.Cache.SizeThreshold = 20
+	// WriteThroughMaxSize sits below the PUT body: the tee is skipped (too big to buffer),
+	// but the object is still cacheable (SizeThreshold large) so the warm read-back caches it.
+	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 8
 
 	w := httptest.NewRecorder()
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
@@ -321,12 +328,12 @@ func TestHandlePutObject_WriteThroughTee_FallsBackAboveSizeThreshold(t *testing.
 	}
 
 	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
-		t.Fatal("object was not warmed after an above-threshold PUT")
+		t.Fatal("object was not warmed after an above-cap PUT")
 	}
 	if got := warmGets.Load(); got != 1 {
-		t.Errorf("read-back warm GETs = %d, want 1 (above threshold must fall back to warm)", got)
+		t.Errorf("read-back warm GETs = %d, want 1 (above write-through cap must fall back to warm)", got)
 	}
 	if got := puts.Load(); got != 0 {
-		t.Errorf("tee upstream PUTs = %d, want 0 (tee must not run above threshold)", got)
+		t.Errorf("tee upstream PUTs = %d, want 0 (tee must not run above the write-through cap)", got)
 	}
 }

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -125,6 +125,45 @@ func TestHandlePutObject_WriteThroughTee_CachesFromHead(t *testing.T) {
 	}
 }
 
+// A negative max_populate_memory_bytes disables the byte budget (svc.populateBudget == nil).
+// The tee must still run in that supported config — acquireCacheSlot treats a nil budget as
+// unlimited (count-semaphore only), just like warm-on-write — instead of silently regressing
+// every eligible PUT to a read-back warm.
+func TestHandlePutObject_WriteThroughTee_CachesWithNilPopulateBudget(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	body := "tee-body-without-populate-budget"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalResp:  headResp(`"tee-etag"`, "text/plain", int64(len(body))),
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"), // fires only on fallback
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.WriteThroughMaxSize = 1 << 20
+	svc.populateBudget = nil // byte budget explicitly disabled (max_populate_memory_bytes < 0)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("client status = %d, want 200", w.Code)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object was not cached via write-through tee with a nil populate budget")
+	}
+	if got := warmGets.Load(); got != 0 {
+		t.Errorf("read-back warm GETs = %d, want 0 (tee must run without a byte budget)", got)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Errorf("upstream PUTs = %d, want 1", got)
+	}
+}
+
 // If the HEAD reports a different ETag than the PUT (a concurrent overwrite landed between
 // our PUT and HEAD), the teed body is stale and must NOT be cached against that version; the
 // tee falls back to a read-back warm.

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -91,6 +91,77 @@ func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
 	}
 }
 
+// With warm-on-write disabled (the default), an eligible PUT must NOT be cached by the
+// tee — the tee is an optimization of warm-on-write and must respect the flag.
+func TestHandlePutObject_WriteThroughTee_DisabledWhenWarmOnWriteOff(t *testing.T) {
+	var puts atomic.Int32
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			forwardFunc: func(_ context.Context, w http.ResponseWriter, _ *http.Request) error {
+				w.WriteHeader(http.StatusOK)
+				return nil
+			},
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true) // WarmOnWrite defaults to false
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, "body")); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if metaCached(c, wowBucket, wowKey, 300*time.Millisecond) {
+		t.Error("object was cached by the tee despite warm_on_write=false")
+	}
+	if got := puts.Load(); got != 0 {
+		t.Errorf("tee upstream PUTs = %d, want 0 (tee must not run when warm_on_write is off)", got)
+	}
+}
+
+// The tee synthesizes cache metadata that matches an origin GET rather than the raw PUT
+// request: aws-chunked is stripped from Content-Encoding (the decoded body is cached),
+// X-Amz-Acl is not cached/echoed, a missing Content-Type defaults, and Last-Modified is set.
+func TestHandlePutObject_WriteThroughTee_MetaMatchesOriginGet(t *testing.T) {
+	var puts atomic.Int32
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{},
+		teeFunc:       teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	r := authedPut(wowBucket, wowKey, "chunked-decoded-body")
+	r.Header.Set("Content-Encoding", "aws-chunked,gzip") // combined transfer token + real encoding
+	r.Header.Set("X-Amz-Acl", "public-read")             // write-only directive, not a GET header
+	// No Content-Type set → should default.
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, r); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object not cached via tee")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if meta.ContentEncoding != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q (aws-chunked stripped)", meta.ContentEncoding, "gzip")
+	}
+	if meta.ACL != "" {
+		t.Errorf("ACL = %q, want empty (X-Amz-Acl must not be cached)", meta.ACL)
+	}
+	if meta.ContentType != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want application/octet-stream (default)", meta.ContentType)
+	}
+	if meta.LastModified == 0 {
+		t.Error("LastModified = 0, want a populated timestamp")
+	}
+	if meta.IsPublicRead() {
+		t.Error("object marked public-read from a write directive")
+	}
+}
+
 // An object larger than the cache size threshold is not eligible for the tee; it falls
 // back to warm-on-write (the read-back path).
 func TestHandlePutObject_WriteThroughTee_FallsBackAboveSizeThreshold(t *testing.T) {

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -3,9 +3,11 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,7 +16,8 @@ import (
 // teeMockForwarder is a mockForwarder that also implements bodyTeeingForwarder, so
 // HandlePutObject takes the write-through tee path. teeFunc simulates the signing
 // forwarder: it reads the request body into the tee (as decodeChunkedIfNeeded + TeeReader
-// would) and returns the upstream PUT status + response headers (with the ETag).
+// would) and returns the upstream PUT status + response headers (with the ETag). The
+// authoritative HEAD the tee then issues is served from the embedded mock's conditionalResp.
 type teeMockForwarder struct {
 	*mockForwarder
 	teeFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error)
@@ -37,16 +40,30 @@ func teeUpstream(puts *atomic.Int32, etag string) func(context.Context, http.Res
 	}
 }
 
-// A single authenticated PutObject within the size threshold is cached by teeing the body
-// on the write path — no read-back warm GET — and the cached body/ETag match the write.
-func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
+// headResp builds the HEAD response the tee uses to source authoritative cache metadata.
+func headResp(etag, contentType string, contentLength int64) *http.Response {
+	h := http.Header{}
+	h.Set("ETag", etag)
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	h.Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	h.Set("Last-Modified", "Wed, 21 Oct 2026 07:28:00 GMT")
+	return &http.Response{StatusCode: http.StatusOK, Header: h, Body: http.NoBody, ContentLength: contentLength}
+}
+
+// A single authenticated PutObject within the size threshold is cached by teeing the body,
+// with metadata sourced from an authoritative HEAD (not the read-back full-object GET). The
+// cached ETag/Content-Type/Content-Length/Last-Modified come from the HEAD, and the body
+// matches the write.
+func TestHandlePutObject_WriteThroughTee_CachesFromHead(t *testing.T) {
 	var puts, warmGets atomic.Int32
 	body := "write-through-tee-body-contents"
 
 	mock := &teeMockForwarder{
 		mockForwarder: &mockForwarder{
-			// If this fires, the tee fell back to a read-back warm — which we assert against.
-			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+			conditionalResp:  headResp(`"tee-etag"`, "text/plain", int64(len(body))),
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"), // fires only on fallback
 		},
 		teeFunc: teeUpstream(&puts, `"tee-etag"`),
 	}
@@ -66,7 +83,7 @@ func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
 		t.Fatal("object was not cached via write-through tee")
 	}
 	if got := warmGets.Load(); got != 0 {
-		t.Errorf("read-back warm GETs = %d, want 0 (tee must avoid the read-back)", got)
+		t.Errorf("read-back warm GETs = %d, want 0 (tee sources meta from HEAD, no full read-back)", got)
 	}
 	if got := puts.Load(); got != 1 {
 		t.Errorf("upstream PUTs = %d, want 1", got)
@@ -79,8 +96,14 @@ func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
 	if meta.ETag != `"tee-etag"` {
 		t.Errorf("cached ETag = %q, want %q", meta.ETag, `"tee-etag"`)
 	}
+	if meta.ContentType != "text/plain" {
+		t.Errorf("cached Content-Type = %q, want text/plain (from HEAD)", meta.ContentType)
+	}
 	if meta.ContentLength != int64(len(body)) {
 		t.Errorf("cached ContentLength = %d, want %d", meta.ContentLength, len(body))
+	}
+	if meta.LastModified == 0 {
+		t.Error("cached LastModified = 0, want the HEAD's value")
 	}
 	var buf bytes.Buffer
 	if err := c.GetBodyStream(context.Background(), wowBucket, wowKey, meta.ETag, &buf); err != nil {
@@ -88,6 +111,70 @@ func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
 	}
 	if buf.String() != body {
 		t.Errorf("cached body = %q, want %q", buf.String(), body)
+	}
+}
+
+// If the HEAD reports a different ETag than the PUT (a concurrent overwrite landed between
+// our PUT and HEAD), the teed body is stale and must NOT be cached against that version; the
+// tee falls back to a read-back warm.
+func TestHandlePutObject_WriteThroughTee_ETagMismatchFallsBackToWarm(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	body := "teed-body"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalResp:  headResp(`"newer-etag"`, "text/plain", int64(len(body))), // != tee ETag
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object was not cached (expected the warm fallback to cache it)")
+	}
+	if got := warmGets.Load(); got != 1 {
+		t.Errorf("warm read-back GETs = %d, want 1 (ETag mismatch must fall back to warm)", got)
+	}
+	// Cached via the warm fallback (its ETag), not the stale teed version.
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if meta.ETag != `"warm-etag"` {
+		t.Errorf("cached ETag = %q, want %q (warm fallback, not the teed body)", meta.ETag, `"warm-etag"`)
+	}
+}
+
+// If the HEAD itself fails, the tee can't source authoritative metadata, so it falls back to
+// a read-back warm rather than caching with guessed headers.
+func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalErr:   errors.New("head failed"),
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, "body")); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object was not cached (expected the warm fallback after HEAD failure)")
+	}
+	if got := warmGets.Load(); got != 1 {
+		t.Errorf("warm read-back GETs = %d, want 1 (HEAD failure must fall back to warm)", got)
 	}
 }
 
@@ -116,49 +203,6 @@ func TestHandlePutObject_WriteThroughTee_DisabledWhenWarmOnWriteOff(t *testing.T
 	}
 	if got := puts.Load(); got != 0 {
 		t.Errorf("tee upstream PUTs = %d, want 0 (tee must not run when warm_on_write is off)", got)
-	}
-}
-
-// The tee synthesizes cache metadata that matches an origin GET rather than the raw PUT
-// request: aws-chunked is stripped from Content-Encoding (the decoded body is cached),
-// X-Amz-Acl is not cached/echoed, a missing Content-Type defaults, and Last-Modified is set.
-func TestHandlePutObject_WriteThroughTee_MetaMatchesOriginGet(t *testing.T) {
-	var puts atomic.Int32
-	mock := &teeMockForwarder{
-		mockForwarder: &mockForwarder{},
-		teeFunc:       teeUpstream(&puts, `"tee-etag"`),
-	}
-	svc, c := newTestService(mock, true)
-	svc.config.Cache.WarmOnWrite = true
-	svc.config.Cache.SizeThreshold = 1 << 20
-
-	r := authedPut(wowBucket, wowKey, "chunked-decoded-body")
-	r.Header.Set("Content-Encoding", "aws-chunked,gzip") // combined transfer token + real encoding
-	r.Header.Set("X-Amz-Acl", "public-read")             // write-only directive, not a GET header
-	// No Content-Type set → should default.
-
-	w := httptest.NewRecorder()
-	if err := svc.HandlePutObject(w, r); err != nil {
-		t.Fatalf("HandlePutObject: %v", err)
-	}
-	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
-		t.Fatal("object not cached via tee")
-	}
-	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
-	if meta.ContentEncoding != "gzip" {
-		t.Errorf("Content-Encoding = %q, want %q (aws-chunked stripped)", meta.ContentEncoding, "gzip")
-	}
-	if meta.ACL != "" {
-		t.Errorf("ACL = %q, want empty (X-Amz-Acl must not be cached)", meta.ACL)
-	}
-	if meta.ContentType != "application/octet-stream" {
-		t.Errorf("Content-Type = %q, want application/octet-stream (default)", meta.ContentType)
-	}
-	if meta.LastModified == 0 {
-		t.Error("LastModified = 0, want a populated timestamp")
-	}
-	if meta.IsPublicRead() {
-		t.Error("object marked public-read from a write directive")
 	}
 }
 

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -188,6 +188,42 @@ func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T
 	}
 }
 
+// When the authoritative HEAD shows the object is not cacheable (Cache-Control: no-store),
+// the tee must NOT fall back to a read-back warm — a warm would only re-download the full
+// body to reject it again, defeating the bandwidth win.
+func TestHandlePutObject_WriteThroughTee_NotCacheableSkipsWarm(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	body := "no-store-body"
+
+	head := headResp(`"tee-etag"`, "text/plain", int64(len(body)))
+	head.Header.Set("Cache-Control", "no-store")
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalResp:  head,
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"), // must NOT fire
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if metaCached(c, wowBucket, wowKey, 300*time.Millisecond) {
+		t.Error("no-store object was cached")
+	}
+	if got := warmGets.Load(); got != 0 {
+		t.Errorf("read-back warm GETs = %d, want 0 (HEAD said not cacheable — warm would only re-download and re-reject)", got)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Errorf("tee upstream PUTs = %d, want 1", got)
+	}
+}
+
 // A competing overwrite/DELETE that lands during the HEAD window must not be resurrected:
 // writeStartTime is stamped BEFORE the HEAD, so a tombstone written during the HEAD is newer
 // and the tombstone-aware write skips the stale teed body. Because it was skipped (not an

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// teeMockForwarder is a mockForwarder that also implements bodyTeeingForwarder, so
+// HandlePutObject takes the write-through tee path. teeFunc simulates the signing
+// forwarder: it reads the request body into the tee (as decodeChunkedIfNeeded + TeeReader
+// would) and returns the upstream PUT status + response headers (with the ETag).
+type teeMockForwarder struct {
+	*mockForwarder
+	teeFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error)
+}
+
+func (m *teeMockForwarder) ForwardTeeingBody(ctx context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+	return m.teeFunc(ctx, w, r, tee)
+}
+
+// teeUpstream returns a teeFunc that tees the whole body, responds 200 with the given
+// ETag, and counts how many PUTs reached "upstream".
+func teeUpstream(puts *atomic.Int32, etag string) func(context.Context, http.ResponseWriter, *http.Request, io.Writer) (int, http.Header, error) {
+	return func(_ context.Context, w http.ResponseWriter, r *http.Request, tee io.Writer) (int, http.Header, error) {
+		_, _ = io.Copy(tee, r.Body) // tee the object bytes into the caller's buffer
+		puts.Add(1)
+		h := http.Header{}
+		h.Set("ETag", etag)
+		w.WriteHeader(http.StatusOK)
+		return http.StatusOK, h, nil
+	}
+}
+
+// A single authenticated PutObject within the size threshold is cached by teeing the body
+// on the write path — no read-back warm GET — and the cached body/ETag match the write.
+func TestHandlePutObject_WriteThroughTee_CachesWithoutReadBack(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	body := "write-through-tee-body-contents"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			// If this fires, the tee fell back to a read-back warm — which we assert against.
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("client status = %d, want 200", w.Code)
+	}
+
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object was not cached via write-through tee")
+	}
+	if got := warmGets.Load(); got != 0 {
+		t.Errorf("read-back warm GETs = %d, want 0 (tee must avoid the read-back)", got)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Errorf("upstream PUTs = %d, want 1", got)
+	}
+
+	meta, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if !found {
+		t.Fatal("no cached meta")
+	}
+	if meta.ETag != `"tee-etag"` {
+		t.Errorf("cached ETag = %q, want %q", meta.ETag, `"tee-etag"`)
+	}
+	if meta.ContentLength != int64(len(body)) {
+		t.Errorf("cached ContentLength = %d, want %d", meta.ContentLength, len(body))
+	}
+	var buf bytes.Buffer
+	if err := c.GetBodyStream(context.Background(), wowBucket, wowKey, meta.ETag, &buf); err != nil {
+		t.Fatalf("GetBodyStream: %v", err)
+	}
+	if buf.String() != body {
+		t.Errorf("cached body = %q, want %q", buf.String(), body)
+	}
+}
+
+// An object larger than the cache size threshold is not eligible for the tee; it falls
+// back to warm-on-write (the read-back path).
+func TestHandlePutObject_WriteThroughTee_FallsBackAboveSizeThreshold(t *testing.T) {
+	var puts, warmGets atomic.Int32
+	body := "this-body-exceeds-the-tiny-threshold"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			forwardFunc: func(_ context.Context, w http.ResponseWriter, _ *http.Request) error {
+				w.WriteHeader(http.StatusOK)
+				return nil
+			},
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+		},
+		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	// Threshold sits between the PUT body (36 bytes) and the warm object (9 bytes): the tee
+	// is skipped (body too big) but the read-back warm still caches the smaller fetched object.
+	svc.config.Cache.SizeThreshold = 20
+
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("object was not warmed after an above-threshold PUT")
+	}
+	if got := warmGets.Load(); got != 1 {
+		t.Errorf("read-back warm GETs = %d, want 1 (above threshold must fall back to warm)", got)
+	}
+	if got := puts.Load(); got != 0 {
+		t.Errorf("tee upstream PUTs = %d, want 0 (tee must not run above threshold)", got)
+	}
+}

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -190,17 +190,18 @@ func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T
 
 // A competing overwrite/DELETE that lands during the HEAD window must not be resurrected:
 // writeStartTime is stamped BEFORE the HEAD, so a tombstone written during the HEAD is newer
-// and the tombstone-aware write skips. (With writeStartTime stamped after the HEAD, the stale
-// teed body would be cached.)
-func TestHandlePutObject_WriteThroughTee_TombstoneDuringHeadBlocksWrite(t *testing.T) {
-	var puts atomic.Int32
+// and the tombstone-aware write skips the stale teed body. Because it was skipped (not an
+// error and not a real write), the tee falls back to a warm that caches the CURRENT version.
+func TestHandlePutObject_WriteThroughTee_TombstoneDuringHeadFallsBackToWarm(t *testing.T) {
+	var puts, warmGets atomic.Int32
 	var svc *Service
 	body := "stale-teed-body"
 
 	mock := &teeMockForwarder{
 		mockForwarder: &mockForwarder{
 			conditionalResp: headResp(`"tee-etag"`, "text/plain", int64(len(body))),
-			// No doFullObjectFunc: the write is a tombstone-skip (not an error), so no warm fallback.
+			// The fallback warm fetches the current version (ETag "warm-etag").
+			doFullObjectFunc: warmObjectResponder(&warmGets, "current-body"),
 		},
 		teeFunc: teeUpstream(&puts, `"tee-etag"`),
 		// Simulate the competing write's invalidation landing in the HEAD window.
@@ -215,8 +216,16 @@ func TestHandlePutObject_WriteThroughTee_TombstoneDuringHeadBlocksWrite(t *testi
 	if err := svc.HandlePutObject(w, authedPut(wowBucket, wowKey, body)); err != nil {
 		t.Fatalf("HandlePutObject: %v", err)
 	}
-	if metaCached(c, wowBucket, wowKey, 500*time.Millisecond) {
-		t.Error("stale teed body was cached despite a tombstone during the HEAD window")
+	// The stale teed body is tombstone-skipped; the fallback warm caches the current version.
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("expected the warm fallback to cache the current version after the tombstone skip")
+	}
+	if got := warmGets.Load(); got != 1 {
+		t.Errorf("warm fallback GETs = %d, want 1 (a tombstone-skip must fall back to warm, not count as a write-through)", got)
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if meta.ETag != `"warm-etag"` {
+		t.Errorf("cached ETag = %q, want the warm/current version, not the stale teed body %q", meta.ETag, `"tee-etag"`)
 	}
 }
 

--- a/tests/s3compat/python/run-tests.sh
+++ b/tests/s3compat/python/run-tests.sh
@@ -97,44 +97,36 @@ EOF
 # single op. TAG signs and forwards tigris-* headers upstream, so the header reaches Tigris.
 # This mirrors the Go SDK suite (tests/s3compat/sdk/testutil.go).
 #
-# The header is applied ONLY during fixture setup/teardown (bucket cleanup), never during a
+# The header is scoped to ceph's nuke_bucket cleanup function (see conftest below), never a
 # test body: tests like test_bucket_delete_nonempty assert that deleting a non-empty bucket
 # is rejected, which must keep its natural (non-force) semantics. Written unconditionally so
 # it is present even when the cloned s3-tests/ dir is cached from a previous run.
 cat <<'EOF' >conftest.py
-import boto3
-import pytest
-
-# Toggled True only while a test's setup/teardown fixtures run (where nuke_prefixed_buckets
-# lives), False during the test body — so in-test DeleteBucket calls keep normal semantics.
-_force = {"on": False}
-
-
-def _maybe_force_delete(request, **kwargs):
+def _add_force_delete_header(request, **kwargs):
     # before-sign fires before SigV4, so the header is part of the client-signed request.
-    if _force["on"]:
-        request.headers["Tigris-Force-Delete"] = "true"
+    request.headers["Tigris-Force-Delete"] = "true"
 
 
-# ceph's get_client() builds clients from the default session; register there so every
-# client the tests create inherits the hook. The hook reads _force at request time, so
-# toggling the flag works regardless of when each client was constructed.
-boto3.setup_default_session()
-boto3.DEFAULT_SESSION.events.register("before-sign.s3.DeleteBucket", _maybe_force_delete)
+def pytest_configure(config):
+    # Scope Tigris-Force-Delete to ceph's bucket-cleanup path only. nuke_bucket is the sole
+    # function that deletes a bucket during setup/teardown, and nuke_prefixed_buckets calls it
+    # as a same-module global, so patching the attribute is picked up. Test bodies call
+    # client.delete_bucket directly (never nuke_bucket), so a test like test_bucket_delete_
+    # nonempty — which asserts a non-empty-bucket delete is rejected — keeps natural semantics.
+    # The header is registered on the cleanup client only for the duration of each nuke_bucket
+    # call, then unregistered, so it can never leak into a test body.
+    import s3tests.functional as sf
 
+    orig_nuke_bucket = sf.nuke_bucket
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_setup(item):
-    _force["on"] = True  # ceph clears pre-existing buckets during setup
-    yield
-    _force["on"] = False
+    def _nuke_bucket_force(client, bucket):
+        client.meta.events.register("before-sign.s3.DeleteBucket", _add_force_delete_header)
+        try:
+            return orig_nuke_bucket(client, bucket)
+        finally:
+            client.meta.events.unregister("before-sign.s3.DeleteBucket", _add_force_delete_header)
 
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_teardown(item, nextitem):
-    _force["on"] = True  # nuke_prefixed_buckets runs here
-    yield
-    _force["on"] = False
+    sf.nuke_bucket = _nuke_bucket_force
 EOF
 
 # If specific test path is provided as argument, run that

--- a/tests/s3compat/python/run-tests.sh
+++ b/tests/s3compat/python/run-tests.sh
@@ -90,6 +90,28 @@ commands = pytest {posargs}
 addopts = -W ignore::DeprecationWarning
 EOF
 
+# Drop a conftest.py so the ceph teardown (nuke_prefixed_buckets) force-deletes buckets.
+# The stock teardown does list-objects -> delete-each -> delete-bucket, which trips
+# BucketNotEmpty on any transient object-delete/list hiccup or list lag. Tigris supports
+# deleting a non-empty bucket via the Tigris-Force-Delete header, collapsing teardown to a
+# single op. TAG signs and forwards tigris-* headers upstream, so the header reaches Tigris.
+# This mirrors the Go SDK suite (tests/s3compat/sdk/testutil.go). Written unconditionally so
+# it is present even when the cloned s3-tests/ dir is cached from a previous run.
+cat <<'EOF' >conftest.py
+import boto3
+
+
+def _tigris_force_delete(request, **kwargs):
+    # before-sign fires before SigV4, so the header is part of the client-signed request.
+    request.headers["Tigris-Force-Delete"] = "true"
+
+
+# ceph's get_client() builds clients from the default session; register there so every
+# client the tests create inherits the hook.
+boto3.setup_default_session()
+boto3.DEFAULT_SESSION.events.register("before-sign.s3.DeleteBucket", _tigris_force_delete)
+EOF
+
 # If specific test path is provided as argument, run that
 if [ $# -ge 1 ]; then
     tox -- "s3tests/functional/$1"

--- a/tests/s3compat/python/run-tests.sh
+++ b/tests/s3compat/python/run-tests.sh
@@ -95,21 +95,46 @@ EOF
 # BucketNotEmpty on any transient object-delete/list hiccup or list lag. Tigris supports
 # deleting a non-empty bucket via the Tigris-Force-Delete header, collapsing teardown to a
 # single op. TAG signs and forwards tigris-* headers upstream, so the header reaches Tigris.
-# This mirrors the Go SDK suite (tests/s3compat/sdk/testutil.go). Written unconditionally so
+# This mirrors the Go SDK suite (tests/s3compat/sdk/testutil.go).
+#
+# The header is applied ONLY during fixture setup/teardown (bucket cleanup), never during a
+# test body: tests like test_bucket_delete_nonempty assert that deleting a non-empty bucket
+# is rejected, which must keep its natural (non-force) semantics. Written unconditionally so
 # it is present even when the cloned s3-tests/ dir is cached from a previous run.
 cat <<'EOF' >conftest.py
 import boto3
+import pytest
+
+# Toggled True only while a test's setup/teardown fixtures run (where nuke_prefixed_buckets
+# lives), False during the test body — so in-test DeleteBucket calls keep normal semantics.
+_force = {"on": False}
 
 
-def _tigris_force_delete(request, **kwargs):
+def _maybe_force_delete(request, **kwargs):
     # before-sign fires before SigV4, so the header is part of the client-signed request.
-    request.headers["Tigris-Force-Delete"] = "true"
+    if _force["on"]:
+        request.headers["Tigris-Force-Delete"] = "true"
 
 
 # ceph's get_client() builds clients from the default session; register there so every
-# client the tests create inherits the hook.
+# client the tests create inherits the hook. The hook reads _force at request time, so
+# toggling the flag works regardless of when each client was constructed.
 boto3.setup_default_session()
-boto3.DEFAULT_SESSION.events.register("before-sign.s3.DeleteBucket", _tigris_force_delete)
+boto3.DEFAULT_SESSION.events.register("before-sign.s3.DeleteBucket", _maybe_force_delete)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    _force["on"] = True  # ceph clears pre-existing buckets during setup
+    yield
+    _force["on"] = False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item, nextitem):
+    _force["on"] = True  # nuke_prefixed_buckets runs here
+    yield
+    _force["on"] = False
 EOF
 
 # If specific test path is provided as argument, run that


### PR DESCRIPTION
Closes #134.

## Summary

On an authenticated single `PutObject` within `cache.size_threshold`, populate the cache by **teeing the request body as it's forwarded upstream** instead of the read-back warm-on-write GET. In signing mode TAG already has the assembled body (after chunked decode), so the read-back is pure waste — this eliminates one full-object upstream fetch per written object and makes the object hot without a cold-read window.

Object **metadata** is sourced from a **HEAD** (which returns exactly the headers a GET would, minus the body), so the cached entry is authoritative and can't diverge from an origin GET. Net cost vs warm-on-write: a bodyless HEAD instead of a full-body GET — the bandwidth win is preserved.

## Design

- **Tee** the decoded body into a capped buffer while forwarding (`signingForwarder.ForwardTeeingBody`, exposed as an optional `bodyTeeingForwarder` capability). The capped buffer never errors, so it's a safe `io.TeeReader` sink.
- **HEAD for authoritative metadata** in the async populate path (reuses `DoConditionalHeadRequest` with empty conditions), build meta via `MetaFromHTTPHeaders`, write it with the teed body — no full-object read-back.
- **ETag-consistency guard**: cache only if the HEAD's ETag matches the PUT-response ETag. A concurrent overwrite returns a different ETag whose body isn't what we hold; caching it would pair mismatched meta/body (the torn-pair hazard ETag-versioned bodies prevent).
- **Tombstone/read-after-write**: `writeStartTime` is stamped **before** the HEAD (mirroring warm-on-write) so the whole HEAD→write window is guarded — the ETag guard catches pre-HEAD overwrites, the tombstone catches later ones, and our own post-forward invalidation doesn't block us.
- **Memory accounting**: reuses the existing cache-populate byte budget via a non-blocking `acquireCacheSlot` (weight = object size) — never blocks the client PUT, no new memory pool; on budget saturation it falls back to warm-on-write. Slot released when the async work completes.
- **Credentials** validated once by `ForwardTeeingBody` and threaded through; the async path never touches `r`.

## Scope / fallbacks

The tee applies to **authenticated single PUTs ≤ `size_threshold` in signing mode, when `warm_on_write` is enabled**. Everything else falls back to warm-on-write (unchanged): multipart completion and `CopyObject` (TAG can't see the assembled body), over-threshold, anonymous writes (keep warm's public-read probe), budget-saturated, and any case where the HEAD can't confirm the just-written version (HEAD failure / ETag mismatch / size disagreement).

## Metric

`tag_cache_write_through_total` — objects cached via the tee (no read-back). Compare with `tag_warm_on_write_triggered_total` (the read-back fallback).

## Tests

`proxy/write_through_test.go`: cache-from-HEAD (meta comes from the HEAD), ETag-mismatch and HEAD-failure both fall back to warm, a tombstone-during-HEAD blocks the stale write, warm-on-write-off disables the tee, and above-threshold falls back to warm. Full `proxy`/`metrics` suite passes with `-race`.

## Follow-up (not in this PR)

**v2**: stream the body into ocache under a token with `meta.BodyRef` (backward-compatible `BodyRef`-else-`ETag` read) to drop the buffer and its size cap for large objects. Tracked in #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PutObject cache population, concurrency, and memory accounting on the write hot path; mistakes could serve stale or mismatched cached data, though guards and extensive tests mitigate this.
> 
> **Overview**
> When **`warm_on_write`** is on, eligible **authenticated single `PutObject`** requests in **signing mode** can populate the cache by **teeing the decoded body** while forwarding upstream, using a **HEAD** for authoritative metadata instead of a full read-back GET.
> 
> **`write_through_max_size`** (default 25 MiB, env `TAG_CACHE_WRITE_THROUGH_MAX_SIZE`) caps in-memory buffering; larger objects still use streaming warm-on-write. **`PutWithMetaStreamTombstoneAware`** now returns **`(wrote bool, err error)`** so callers can tell a skipped write (tombstone, no ETag) from a real cache entry and fall back to warm. **`tag_cache_write_through_total`** tracks successful tee populates.
> 
> Safety checks include ETag match with the PUT response, tombstone-aware writes, populate budget via non-blocking slot acquire, and fallbacks to warm-on-write on HEAD failure, mismatch, `no-store`, or budget pressure. Transparent proxy, anonymous writes, multipart, and over-cap objects are unchanged.
> 
> Docs and **`proxy/write_through_test.go`** cover the behavior; Python s3-tests teardown gets **`Tigris-Force-Delete`** for bucket cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40e12a4136332061e18c037b53b9b076b7ea6ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->