### PR TITLE
perf: cut per-block costs on block-cache serves

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,6 +14,18 @@ on:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default). e.g. 65536 to match the 64 KiB GET RANGE size."
         type: string
         default: ""
+      duration:
+        description: "Per-operation duration (empty = 30s default), e.g. 60s."
+        type: string
+        default: ""
+      range_objects:
+        description: "Distinct objects for GET RANGE (empty = 8). Shrinking the working set (e.g. 1) makes the run warm-hit-dominated instead of cold-miss-dominated."
+        type: string
+        default: ""
+      range_obj_size:
+        description: "Object size for GET RANGE (empty = 256MiB), e.g. 64MiB to shrink the block working set."
+        type: string
+        default: ""
   workflow_call:
     inputs:
       cache_mode:
@@ -22,6 +34,18 @@ on:
         default: default
       block_size:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default)"
+        type: string
+        default: ""
+      duration:
+        description: "Per-operation duration (empty = 30s default)"
+        type: string
+        default: ""
+      range_objects:
+        description: "Distinct objects for GET RANGE (empty = 8)"
+        type: string
+        default: ""
+      range_obj_size:
+        description: "Object size for GET RANGE (empty = 256MiB)"
         type: string
         default: ""
   schedule:
@@ -69,10 +93,18 @@ jobs:
           TAG_CACHE_BLOCK_SIZE: ${{ inputs.block_size }}
         run: make s3-test-local
 
+      # Warp knobs pass through as env; empty values fall back to run-warp.sh's defaults
+      # (the script expands with ':-', which treats empty the same as unset). A
+      # warm-hit-dominated GET RANGE run: range_objects=1 range_obj_size=64MiB shrinks the
+      # block working set to ~1k blocks, so a standard-duration run's ~25k random reads hit
+      # warm blocks almost entirely — measuring the serve path instead of upstream fetches.
       - name: Run warp benchmarks
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          WARP_DURATION: ${{ inputs.duration }}
+          WARP_RANGE_OBJECTS: ${{ inputs.range_objects }}
+          WARP_RANGE_OBJ_SIZE: ${{ inputs.range_obj_size }}
         run: make bench-warp
 
       - name: Upload benchmark results

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,6 +22,10 @@ on:
         description: "Per-operation duration (empty = 30s default), e.g. 60s."
         type: string
         default: ""
+      obj_size:
+        description: "Object size for GET/PUT (empty = 4MiB). e.g. 64MiB to make full GETs span many blocks in blocks mode."
+        type: string
+        default: ""
       range_objects:
         description: "Distinct objects for GET RANGE (empty = 8). Shrinking the working set (e.g. 1) makes the run warm-hit-dominated instead of cold-miss-dominated."
         type: string
@@ -46,6 +50,10 @@ on:
         default: ""
       duration:
         description: "Per-operation duration (empty = 30s default)"
+        type: string
+        default: ""
+      obj_size:
+        description: "Object size for GET/PUT (empty = 4MiB)"
         type: string
         default: ""
       range_objects:
@@ -120,6 +128,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WARP_BUCKET: tag-warp-ci-${{ github.run_id }}
           WARP_DURATION: ${{ inputs.duration }}
+          WARP_OBJ_SIZE: ${{ inputs.obj_size }}
           WARP_RANGE_OBJECTS: ${{ inputs.range_objects }}
           WARP_RANGE_OBJ_SIZE: ${{ inputs.range_obj_size }}
         run: make bench-warp

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -60,13 +60,12 @@ on:
     # Nightly at 07:00 UTC (runs the default-mode benchmark)
     - cron: "0 7 * * *"
 
-# All benchmark runs share one Tigris bucket (tag-warp-benchmark), and warp clears that bucket
-# before and after every op — two runs executing concurrently delete each other's objects
+# Each run benchmarks against its own bucket (tag-warp-ci-<run id>): warp clears its bucket
+# before and after every op, so two runs sharing a bucket would delete each other's objects
 # mid-measurement (observed as sustained NoSuchKey download errors and garbage numbers).
-# Serialize the whole workflow: queued runs wait for the active one instead of racing it.
-concurrency:
-  group: warp-benchmark-bucket
-  cancel-in-progress: false
+# Per-run buckets make concurrent runs data-safe; they still share the Tigris account's
+# bandwidth, so avoid overlapping heavy runs unless a simultaneous A/B pair is the point.
+# The delete-bucket step below removes the run's bucket and sweeps any leaked ones.
 
 env:
   GO_VERSION: "1.24.2"
@@ -119,6 +118,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          WARP_BUCKET: tag-warp-ci-${{ github.run_id }}
           WARP_DURATION: ${{ inputs.duration }}
           WARP_RANGE_OBJECTS: ${{ inputs.range_objects }}
           WARP_RANGE_OBJ_SIZE: ${{ inputs.range_obj_size }}
@@ -131,6 +131,35 @@ jobs:
           name: benchmark-results
           path: tests/benchmark/results/
           if-no-files-found: warn
+
+      # Best-effort, never fails the job. warp's after-op clear leaves the bucket empty on a
+      # clean run; the recursive rm covers ops that died mid-run. The sweep catches buckets
+      # leaked by hard-killed jobs (cancelled/timed out before this step) — only per-run
+      # (tag-warp-ci-*) buckets older than a day, so an in-flight run's bucket is never touched.
+      - name: Delete benchmark bucket
+        if: always()
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          AWS_EC2_METADATA_DISABLED: "true"
+          ENDPOINT: https://t3.storage.dev
+          BUCKET: tag-warp-ci-${{ github.run_id }}
+        run: |
+          set -u
+          aws --endpoint-url "$ENDPOINT" s3 rm "s3://$BUCKET" --recursive --only-show-errors || true
+          aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$BUCKET" || true
+          cutoff=$(date -u -d '1 day ago' +%s)
+          aws --endpoint-url "$ENDPOINT" s3api list-buckets \
+            --query 'Buckets[?starts_with(Name, `tag-warp-ci-`)].[Name,CreationDate]' --output text |
+          while read -r name created; do
+            [ -n "$name" ] || continue
+            [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ] || continue
+            echo "Sweeping leaked benchmark bucket: $name (created $created)"
+            aws --endpoint-url "$ENDPOINT" s3 rm "s3://$name" --recursive --only-show-errors || true
+            aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$name" || true
+          done || true
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -26,6 +26,10 @@ on:
         description: "Object size for GET/PUT (empty = 4MiB). e.g. 64MiB to make full GETs span many blocks in blocks mode."
         type: string
         default: ""
+      max_populate_memory:
+        description: "Populate memory budget in bytes (empty = 1GiB default). Diagnostic knob for budget-contention hypotheses."
+        type: string
+        default: ""
       range_objects:
         description: "Distinct objects for GET RANGE (empty = 8). Shrinking the working set (e.g. 1) makes the run warm-hit-dominated instead of cold-miss-dominated."
         type: string
@@ -54,6 +58,10 @@ on:
         default: ""
       obj_size:
         description: "Object size for GET/PUT (empty = 4MiB)"
+        type: string
+        default: ""
+      max_populate_memory:
+        description: "Populate memory budget in bytes (empty = 1GiB default)"
         type: string
         default: ""
       range_objects:
@@ -115,6 +123,7 @@ jobs:
           TAG_CACHE_BLOCK_CACHING_ENABLED: ${{ inputs.cache_mode == 'blocks' && 'true' || 'false' }}
           TAG_CACHE_BLOCK_SIZE: ${{ inputs.block_size }}
           TAG_CACHE_BLOCK_MIN_OBJECT_SIZE: ${{ inputs.block_min_object_size }}
+          TAG_CACHE_MAX_POPULATE_MEMORY: ${{ inputs.max_populate_memory }}
         run: make s3-test-local
 
       # Warp knobs pass through as env; empty values fall back to run-warp.sh's defaults

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,10 +14,6 @@ on:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default). e.g. 65536 to match the 64 KiB GET RANGE size."
         type: string
         default: ""
-      block_min_object_size:
-        description: "Whole-vs-block boundary in bytes for blocks mode (empty = block_size). Objects below it are whole-cached."
-        type: string
-        default: ""
       duration:
         description: "Per-operation duration (empty = 30s default), e.g. 60s."
         type: string
@@ -46,10 +42,6 @@ on:
         default: default
       block_size:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default)"
-        type: string
-        default: ""
-      block_min_object_size:
-        description: "Whole-vs-block boundary in bytes for blocks mode (empty = block_size)"
         type: string
         default: ""
       duration:
@@ -122,7 +114,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TAG_CACHE_BLOCK_CACHING_ENABLED: ${{ inputs.cache_mode == 'blocks' && 'true' || 'false' }}
           TAG_CACHE_BLOCK_SIZE: ${{ inputs.block_size }}
-          TAG_CACHE_BLOCK_MIN_OBJECT_SIZE: ${{ inputs.block_min_object_size }}
           TAG_CACHE_MAX_POPULATE_MEMORY: ${{ inputs.max_populate_memory }}
         run: make s3-test-local
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -60,6 +60,14 @@ on:
     # Nightly at 07:00 UTC (runs the default-mode benchmark)
     - cron: "0 7 * * *"
 
+# All benchmark runs share one Tigris bucket (tag-warp-benchmark), and warp clears that bucket
+# before and after every op — two runs executing concurrently delete each other's objects
+# mid-measurement (observed as sustained NoSuchKey download errors and garbage numbers).
+# Serialize the whole workflow: queued runs wait for the active one instead of racing it.
+concurrency:
+  group: warp-benchmark-bucket
+  cancel-in-progress: false
+
 env:
   GO_VERSION: "1.24.2"
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,6 +14,10 @@ on:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default). e.g. 65536 to match the 64 KiB GET RANGE size."
         type: string
         default: ""
+      block_min_object_size:
+        description: "Whole-vs-block boundary in bytes for blocks mode (empty = block_size). Objects below it are whole-cached."
+        type: string
+        default: ""
       duration:
         description: "Per-operation duration (empty = 30s default), e.g. 60s."
         type: string
@@ -34,6 +38,10 @@ on:
         default: default
       block_size:
         description: "Block size in bytes for blocks mode (empty = 4 MiB default)"
+        type: string
+        default: ""
+      block_min_object_size:
+        description: "Whole-vs-block boundary in bytes for blocks mode (empty = block_size)"
         type: string
         default: ""
       duration:
@@ -91,6 +99,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TAG_CACHE_BLOCK_CACHING_ENABLED: ${{ inputs.cache_mode == 'blocks' && 'true' || 'false' }}
           TAG_CACHE_BLOCK_SIZE: ${{ inputs.block_size }}
+          TAG_CACHE_BLOCK_MIN_OBJECT_SIZE: ${{ inputs.block_min_object_size }}
         run: make s3-test-local
 
       # Warp knobs pass through as env; empty values fall back to run-warp.sh's defaults

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -155,20 +155,7 @@ jobs:
           AWS_EC2_METADATA_DISABLED: "true"
           ENDPOINT: https://t3.storage.dev
           BUCKET: tag-warp-ci-${{ github.run_id }}
-        run: |
-          set -u
-          aws --endpoint-url "$ENDPOINT" s3 rm "s3://$BUCKET" --recursive --only-show-errors || true
-          aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$BUCKET" || true
-          cutoff=$(date -u -d '1 day ago' +%s)
-          aws --endpoint-url "$ENDPOINT" s3api list-buckets \
-            --query 'Buckets[?starts_with(Name, `tag-warp-ci-`)].[Name,CreationDate]' --output text |
-          while read -r name created; do
-            [ -n "$name" ] || continue
-            [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ] || continue
-            echo "Sweeping leaked benchmark bucket: $name (created $created)"
-            aws --endpoint-url "$ENDPOINT" s3 rm "s3://$name" --recursive --only-show-errors || true
-            aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$name" || true
-          done || true
+        run: make bench-clean-buckets
 
       - name: Cleanup
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ help:
 	@echo "Benchmark test targets (warp):"
 	@echo "  bench-warp             - Benchmark core S3 ops with warp (requires running TAG + AWS creds)"
 	@echo "  bench-warp-clean       - Remove cached warp binary and benchmark results"
+	@echo "  bench-clean-buckets    - Delete a per-run warp bucket (BUCKET=...) and sweep leaked tag-warp-ci-* buckets (requires AWS creds)"
 	@echo ""
 	@echo "  Benchmark usage:"
 	@echo "    export AWS_ACCESS_KEY_ID=<your-key>"
@@ -658,5 +659,13 @@ bench-warp:
 bench-warp-clean:
 	@echo "Cleaning up warp benchmark artifacts..."
 	rm -rf tests/benchmark/.bin tests/benchmark/results
+
+.PHONY: bench-clean-buckets
+bench-clean-buckets:
+	@if [ -z "$$AWS_ACCESS_KEY_ID" ] || [ -z "$$AWS_SECRET_ACCESS_KEY" ]; then \
+		echo "Error: AWS credentials not set."; \
+		exit 1; \
+	fi
+	bash tests/benchmark/clean-buckets.sh
 
 .DEFAULT_GOAL := help

--- a/cache/object.go
+++ b/cache/object.go
@@ -48,6 +48,13 @@ type CachedObjectMeta struct {
 	// as fixed-size blocks (MakeBlockKey) of this size. Captured at populate time so an
 	// entry keeps its block layout even if the block_size config later changes.
 	BlockSize int64 `json:"block_size,omitempty"`
+	// BlocksComplete records that every block of a block-mode entry was present when this
+	// meta was written (a full-stream split, or a promotion after a successful full
+	// assembly). Full-object serves use it to skip the per-block existence probe pass and
+	// stream optimistically — a block evicted since is recovered by an inline fetch. It is a
+	// hint, not an invariant: false (including on entries written before the field existed)
+	// only means the probe-first path is used.
+	BlocksComplete bool `json:"blocks_complete,omitempty"`
 }
 
 // MetaFromHTTPHeaders builds CachedObjectMeta from S3 response headers.

--- a/cache/object.go
+++ b/cache/object.go
@@ -55,6 +55,13 @@ type CachedObjectMeta struct {
 	// hint, not an invariant: false (including on entries written before the field existed)
 	// only means the probe-first path is used.
 	BlocksComplete bool `json:"blocks_complete,omitempty"`
+	// CachedAt is the Unix time (seconds) this meta was built from a live upstream response.
+	// Rewrites of an existing meta that do NOT consult upstream (the blocks-complete
+	// promotion) use it to compute the entry's remaining TTL so they never extend its
+	// lifetime — re-stamping a full TTL would reset the staleness clock and let the meta
+	// outlive its blocks. 0 (entries written before the field existed) means the age is
+	// unknown and no lifetime-sensitive rewrite is allowed.
+	CachedAt int64 `json:"cached_at,omitempty"`
 }
 
 // MetaFromHTTPHeaders builds CachedObjectMeta from S3 response headers.
@@ -63,6 +70,7 @@ func MetaFromHTTPHeaders(bucket, key string, statusCode int, headers http.Header
 		Key:                  key,
 		Bucket:               bucket,
 		StatusCode:           statusCode,
+		CachedAt:             time.Now().Unix(),
 		ETag:                 headers.Get("ETag"),
 		ContentType:          headers.Get("Content-Type"),
 		CacheControl:         headers.Get("Cache-Control"),

--- a/config/config.go
+++ b/config/config.go
@@ -235,6 +235,16 @@ type CacheConfig struct {
 	// shared segments. 0 or unset uses DefaultCacheBlockSize (4 MiB). Only meaningful when
 	// BlockCachingEnabled is true.
 	BlockSize int64 `yaml:"block_size"`
+	// BlockMinObjectSize raises the whole-vs-block boundary above BlockSize: objects smaller
+	// than this are whole-cached even when block caching is enabled, so they never pay the
+	// per-block serve overhead (a whole-cached warm GET is 2 cache ops; a block-mode one is
+	// linear in block count). Block caching's win — range reads fetching only their covering
+	// blocks — only matters for objects large enough that whole-caching them is wasteful, so
+	// deployments serving full-object GETs of small/medium objects should set this well above
+	// BlockSize (e.g. 8-16x). 0 or unset keeps the boundary at BlockSize (RFC 0001 behavior);
+	// values at or below BlockSize are equivalent to unset. Only meaningful when
+	// BlockCachingEnabled is true.
+	BlockMinObjectSize int64 `yaml:"block_min_object_size"`
 	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget
 	// that warm-on-write populates may reserve ahead of read-miss warms, so
 	// warm-on-write is never starved by the read-miss full-object warm flood. The
@@ -365,6 +375,11 @@ func applyDefaults(cfg *Config) {
 	// falls back to the default.
 	if cfg.Cache.BlockSize <= 0 {
 		cfg.Cache.BlockSize = DefaultCacheBlockSize
+	}
+	// A negative min-object-size (programmatic or YAML) means unset — the boundary stays at
+	// BlockSize.
+	if cfg.Cache.BlockMinObjectSize < 0 {
+		cfg.Cache.BlockMinObjectSize = 0
 	}
 	if cfg.Cache.DiskPath == "" {
 		cfg.Cache.DiskPath = DefaultCacheDiskPath
@@ -519,6 +534,12 @@ func applyEnvOverrides(cfg *Config) {
 		if val := os.Getenv("TAG_CACHE_BLOCK_SIZE"); val != "" {
 			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n > 0 {
 				cfg.Cache.BlockSize = n
+			}
+		}
+		// Override the whole-vs-block boundary from environment (0/unset keeps it at BlockSize).
+		if val := os.Getenv("TAG_CACHE_BLOCK_MIN_OBJECT_SIZE"); val != "" {
+			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n > 0 {
+				cfg.Cache.BlockMinObjectSize = n
 			}
 		}
 		// Override the warm-on-write populate reservation fraction from environment.

--- a/config/config.go
+++ b/config/config.go
@@ -215,6 +215,13 @@ type CacheConfig struct {
 	// Applied independently of MaxConcurrentWrites (both limits apply). 0 or unset
 	// uses DefaultCacheMaxPopulateMemoryBytes; a negative value disables the memory
 	// cap (count-only, prior behavior).
+	//
+	// This value ALSO sizes a second, independent budget for block-serve staging
+	// buffers (see proxy.NewService): warm block serves hold staging bytes for a whole
+	// response and must not crowd populates out of a shared pool, so the aggregate
+	// budget-bounded buffering is up to 2x this value under combined populate +
+	// warm-serve load. Size container memory headroom accordingly. A negative value
+	// disables both budgets.
 	MaxPopulateMemoryBytes int64 `yaml:"max_populate_memory_bytes"`
 	// WarmOnWrite, when true, repopulates the cache after a successful write
 	// (PutObject / CompleteMultipartUpload / CopyObject) by triggering a background

--- a/config/config.go
+++ b/config/config.go
@@ -235,16 +235,6 @@ type CacheConfig struct {
 	// shared segments. 0 or unset uses DefaultCacheBlockSize (4 MiB). Only meaningful when
 	// BlockCachingEnabled is true.
 	BlockSize int64 `yaml:"block_size"`
-	// BlockMinObjectSize raises the whole-vs-block boundary above BlockSize: objects smaller
-	// than this are whole-cached even when block caching is enabled, so they never pay the
-	// per-block serve overhead (a whole-cached warm GET is 2 cache ops; a block-mode one is
-	// linear in block count). Block caching's win — range reads fetching only their covering
-	// blocks — only matters for objects large enough that whole-caching them is wasteful, so
-	// deployments serving full-object GETs of small/medium objects should set this well above
-	// BlockSize (e.g. 8-16x). 0 or unset keeps the boundary at BlockSize (RFC 0001 behavior);
-	// values at or below BlockSize are equivalent to unset. Only meaningful when
-	// BlockCachingEnabled is true.
-	BlockMinObjectSize int64 `yaml:"block_min_object_size"`
 	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget
 	// that warm-on-write populates may reserve ahead of read-miss warms, so
 	// warm-on-write is never starved by the read-miss full-object warm flood. The
@@ -375,11 +365,6 @@ func applyDefaults(cfg *Config) {
 	// falls back to the default.
 	if cfg.Cache.BlockSize <= 0 {
 		cfg.Cache.BlockSize = DefaultCacheBlockSize
-	}
-	// A negative min-object-size (programmatic or YAML) means unset — the boundary stays at
-	// BlockSize.
-	if cfg.Cache.BlockMinObjectSize < 0 {
-		cfg.Cache.BlockMinObjectSize = 0
 	}
 	if cfg.Cache.DiskPath == "" {
 		cfg.Cache.DiskPath = DefaultCacheDiskPath
@@ -534,12 +519,6 @@ func applyEnvOverrides(cfg *Config) {
 		if val := os.Getenv("TAG_CACHE_BLOCK_SIZE"); val != "" {
 			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n > 0 {
 				cfg.Cache.BlockSize = n
-			}
-		}
-		// Override the whole-vs-block boundary from environment (0/unset keeps it at BlockSize).
-		if val := os.Getenv("TAG_CACHE_BLOCK_MIN_OBJECT_SIZE"); val != "" {
-			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n > 0 {
-				cfg.Cache.BlockMinObjectSize = n
 			}
 		}
 		// Override the warm-on-write populate reservation fraction from environment.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1155,3 +1155,39 @@ func TestTLS_DisabledByDefault(t *testing.T) {
 		t.Error("TLSEnabled() = true, want false (disabled by default)")
 	}
 }
+
+func TestLoad_BlockMinObjectSizeOverrideByEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		env  string
+		want int64
+	}{
+		{"default unset", "cache:\n  enabled: true\n", "", 0},
+		{"yaml value", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "", 67108864},
+		{"env overrides yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "134217728", 134217728},
+		// Zero/negative env values are ignored (0 means "boundary stays at BlockSize").
+		{"zero env keeps yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "0", 67108864},
+		{"invalid env keeps yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "notanumber", 67108864},
+		// A negative yaml value normalizes to unset.
+		{"negative yaml normalizes", "cache:\n  enabled: true\n  block_min_object_size: -5\n", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(tmpFile, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			if tc.env != "" {
+				t.Setenv("TAG_CACHE_BLOCK_MIN_OBJECT_SIZE", tc.env)
+			}
+			cfg, err := Load(tmpFile)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Cache.BlockMinObjectSize != tc.want {
+				t.Errorf("BlockMinObjectSize = %d, want %d", cfg.Cache.BlockMinObjectSize, tc.want)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1155,39 +1155,3 @@ func TestTLS_DisabledByDefault(t *testing.T) {
 		t.Error("TLSEnabled() = true, want false (disabled by default)")
 	}
 }
-
-func TestLoad_BlockMinObjectSizeOverrideByEnv(t *testing.T) {
-	cases := []struct {
-		name string
-		yaml string
-		env  string
-		want int64
-	}{
-		{"default unset", "cache:\n  enabled: true\n", "", 0},
-		{"yaml value", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "", 67108864},
-		{"env overrides yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "134217728", 134217728},
-		// Zero/negative env values are ignored (0 means "boundary stays at BlockSize").
-		{"zero env keeps yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "0", 67108864},
-		{"invalid env keeps yaml", "cache:\n  enabled: true\n  block_min_object_size: 67108864\n", "notanumber", 67108864},
-		// A negative yaml value normalizes to unset.
-		{"negative yaml normalizes", "cache:\n  enabled: true\n  block_min_object_size: -5\n", "", 0},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-			if err := os.WriteFile(tmpFile, []byte(tc.yaml), 0o644); err != nil {
-				t.Fatalf("Failed to create temp file: %v", err)
-			}
-			if tc.env != "" {
-				t.Setenv("TAG_CACHE_BLOCK_MIN_OBJECT_SIZE", tc.env)
-			}
-			cfg, err := Load(tmpFile)
-			if err != nil {
-				t.Fatalf("Load() error = %v", err)
-			}
-			if cfg.Cache.BlockMinObjectSize != tc.want {
-				t.Errorf("BlockMinObjectSize = %d, want %d", cfg.Cache.BlockMinObjectSize, tc.want)
-			}
-		})
-	}
-}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,7 +352,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `delete_batch_size`     | int      | `1000`           | File deletions processed per deletion-queue batch                                   |
 | `recovery_workers`      | int      | `16`             | Parallel workers for startup file recovery                                          |
 | `max_concurrent_writes` | int      | `256`            | Max concurrent cache-populate operations (`0`/unset = default, negative = disabled) |
-| `max_populate_memory_bytes` | int  | `1073741824`     | Aggregate memory budget for concurrent cache-populate buffering; each populate reserves its size (capped at the buffer ceiling), applied independently of `max_concurrent_writes` (`0`/unset = default 1 GiB, negative = memory cap disabled) |
+| `max_populate_memory_bytes` | int  | `1073741824`     | Aggregate memory budget for concurrent cache-populate buffering; each populate reserves its size (capped at the buffer ceiling), applied independently of `max_concurrent_writes` (`0`/unset = default 1 GiB, negative = disables both budgets). Also sizes a second, independent budget of the same value for block-serve staging buffers, so total budget-bounded buffering is up to **2×** this value — size container headroom accordingly |
 
 **TTL Format:**
 

--- a/docs/rfcs/0001-block-aligned-caching.md
+++ b/docs/rfcs/0001-block-aligned-caching.md
@@ -1,8 +1,8 @@
 # RFC 0001: Block-aligned caching for large objects
 
-- **Status:** Draft
+- **Status:** Implemented (core phases 1–4; serve-path performance and robustness in [#141](https://github.com/tigrisdata/tag/pull/141))
 - **Tracking issue:** [#137](https://github.com/tigrisdata/tag/issues/137)
-- **Related:** [#136](https://github.com/tigrisdata/tag/issues/136) (closed — multipart write-through, superseded), [#135](https://github.com/tigrisdata/tag/pull/135) (write-through tee, merged)
+- **Related:** [#136](https://github.com/tigrisdata/tag/issues/136) (closed — multipart write-through, superseded), [#135](https://github.com/tigrisdata/tag/pull/135) (write-through tee, merged), [#141](https://github.com/tigrisdata/tag/pull/141) (per-block serve cost cuts: probe-free serves, pipelined streaming, bounded degraded serves)
 
 ## Summary
 
@@ -70,31 +70,32 @@ A large object's body is stored as N = `ceil(ContentLength / BlockSize)` blocks.
 ### Keys and metadata
 
 - New key builder `MakeBlockKey(bucket,key,etag,blockSize,blockIdx)` → `blk|bucket|key|<etag>|<blockSize>|<blockIdx>`. Distinct prefix from `body|`; ETag-scoped exactly like body keys, so an overwrite (new ETag) writes new block keys and stale blocks age out by TTL — same torn-pair invariant. The **block size is part of the key** so blocks written under one `block_size` can never be resolved by a meta captured under a different `block_size` (e.g. after the config changes and the entry is re-established for an unchanged ETag), which would read a block at the wrong offsets.
-- `cache.CachedObjectMeta` gains one field: `BlockSize int64` (`json:"block_size,omitempty"`). `0` = whole-body (legacy/small — existing path); `>0` = block-mode with that block size. **The block size is captured at populate time**, so existing entries are immune to a later `block_size` config change: readers compute boundaries from `meta.BlockSize`, not current config.
+- `cache.CachedObjectMeta` gains three fields:
+  - `BlockSize int64` (`json:"block_size,omitempty"`). `0` = whole-body (legacy/small — existing path); `>0` = block-mode with that block size. **The block size is captured at populate time**, so existing entries are immune to a later `block_size` config change: readers compute boundaries from `meta.BlockSize`, not current config.
+  - `BlocksComplete bool` (`json:"blocks_complete,omitempty"`). Stamped when a populate wrote every block (the full-stream split) or a full assembly verified them (the promotion, below). A **hint, not an invariant** — blocks and meta evict/expire independently — that lets full-object serves skip the per-block probe pass; `false` (including entries written before the field existed) only means the probe-first path is used.
+  - `CachedAt int64` (`json:"cached_at,omitempty"`). Unix time the meta was built from a live upstream response. Lifetime-sensitive rewrites that do not consult upstream (the promotion) use it to carry only the entry's **remaining** TTL, never a fresh one; `0` (pre-existing entries) means age unknown and no such rewrite happens.
 - Meta remains a single object under `MakeMetaKey` (unchanged), written once per (object, ETag) with total `ContentLength`, `ETag`, headers, and `BlockSize`. Blocks accrete independently afterward.
 
 Readers dispatch on `meta.BlockSize`: `0` → existing `serveRangeFromCache`/`serveFromCache`; `>0` → block path. Both representations coexist during and after rollout.
 
 ### Read path (partial-hit aware)
 
-New `serveRangeFromBlockCache`, taken when `meta.BlockSize > 0` (replacing the `serveRangeFromCache` branch in `HandleGetObject`):
+`serveRangeFromBlockCache`, taken when `meta.BlockSize > 0` (replacing the `serveRangeFromCache` branch in `HandleGetObject`):
 
 1. Parse the range (`parseRangeHeader`). Preserve the existing `serveRangeFromCache` error semantics *before* computing any block indices: a malformed/unsatisfiable range (parse error) or an empty range list → `416` with `Content-Range: bytes */<len>`; a **multi-range** request (`len(ranges) > 1`) → `416` (multi-range from cache is unsupported today and stays so). Only a single, valid range proceeds; compute its covering block indices `b0 = start/BlockSize … bK = end/BlockSize`.
-2. Probe each covering block (a `GetRangeStream` on the block key; not-found = missing).
-3. If any are missing → fetch just those blocks (below), populate them, then serve.
-4. Stream the range in block order: for each covering block, read its local sub-range `[max(start,bStart)−bStart … min(end,bEnd)−bStart]` from that block's blob and copy to the client. Footer read = 1 block; a few row groups = a few blocks.
-
-The pre-206 first-byte probe from `serveRangeFromCache` (commit headers only after the body resolves; fall through on genuine body-miss) carries over on the first covering block.
+2. **Assembled fast path** (`serveAssembledRange`, for a range no longer than one block — the footer/row-group pattern, at most two covering blocks): the requested bytes are assembled into a pooled buffer **before anything is committed**. Each present block is read exactly once — the read itself is the existence probe, halving warm-serve cache ops versus probe-then-stream — and blocks the read reports absent are fetched (coalesced, bounded) and re-read, all pre-commit, so every failure falls through to upstream with the response untouched. The buffer reserves its actual size against the serve-staging budget (see Memory bounds); on decline the probe-first path serves instead.
+3. **Probe-first path** (larger ranges, or a staging-budget decline): probe each covering block with `BlockExistsErr` — a transient probe failure aborts rather than counting as missing, so a network blip can't masquerade as eviction — then fetch the missing ones and stream. At most `maxRangeBlockFanout` (32) absent blocks are fetched per request; a pathologically large client range with more absent blocks than that is served from a single upstream range GET instead of a fetch storm.
+4. **Pipelined streaming**: multi-block spans stream through a double-buffered pipeline — a reader goroutine prefetches block *i+1* into a pooled buffer while block *i*'s bytes write to the client, so cache-read and client-write latency overlap instead of adding up (the structural stall that made warm multi-block serves trail whole-object serves). Degrades to a direct sequential stream on staging-budget decline or single-block spans, where there is nothing to overlap.
 
 ### Block fetch and populate
 
-New `fetchBlocksToCache(ctx, bucket, key, etag, meta, blockIdxs)`:
+`fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, blockIdxs)`:
 
-- For each missing block, issue an **aligned range GET** to upstream (`bytes=bStart-bEnd`, last block clamped to `ContentLength-1`), streaming into the block blob via a tombstone-aware `PutStream`.
-- **Populate weight = block size, not object size** (`populateWeight(blockSize)`) — the core win. An 88 MiB object's footer reserves ~one block, not the per-populate ceiling.
-- **Coalesce** concurrent fetches of the same `(etag, blockIdx)` — extend the broadcast manager keyed on the block key (or a per-block analog of `activeBackgroundFetches`) so N queries hitting the same footer block issue one upstream GET.
-- Fetch multiple missing blocks **concurrently** (bounded).
-- **ETag guard:** the range response carries an ETag; if it ≠ `meta.ETag`, the object was overwritten mid-flight — invalidate meta and re-fetch rather than cache a torn block (same guard the write-through tee uses).
+- For each missing block, issue an **aligned range GET** to upstream (`bytes=bStart-bEnd`, last block clamped to `ContentLength-1`). The response must be a `206` carrying an ETag equal to `meta.ETag`, a `Content-Length` equal to the exact block length, and `Content-Range` bounds matching the block — anything else is rejected (a `200` whole-object response, a length/offset mismatch, or a missing ETag would corrupt block offsets or mix versions). The body is read fully into a pooled buffer before the store, so a truncated upstream body can never persist as a short block that `BlockExists` cannot distinguish from a complete one.
+- **Populate weight = block size, not object size** (`populateWeight(blockLen)`) — the core win. An 88 MiB object's footer reserves ~one block, not the per-populate ceiling. On decline the block is simply not cached this time (`errCachePopulateDeclined`).
+- **Coalesce** concurrent fetches of the same block via `singleflight` on the block key: N requests hitting the same footer block issue one upstream GET. The shared fetch (the singleflight leader) runs under a detached, timeout-bounded context so one caller's cancellation can't fail the block for every waiter; each waiter still stops waiting on its own ctx.
+- Fetch multiple missing blocks **concurrently** (bounded by `maxConcurrentBlockFetches`). Sibling fetches are not canceled on one block's error, so a fast transient failure can't mask a slower **stale signal** from another block — stale signals are reported in preference to transient ones.
+- **Stale signals invalidate centrally**: an ETag mismatch (concurrent overwrite) or upstream `404` (deleted out of band) invalidates the entry *inside* `fetchBlocksToCache` — every block fetch flows through this point, so no caller can forget it. A `403` is deliberately **not** a stale signal: it is principal-level (these credentials), not proof the object is gone, and must not invalidate an entry shared across principals. Invalidation itself is ETag-guarded (`invalidateStaleBlockMeta` deletes only if the stored meta still carries the observed stale ETag), so a concurrently re-established newer entry is never wiped.
 
 On a cold range miss (no meta), write meta from the range response's `Content-Range` total size + headers (ETag etc.) — no extra HEAD — then populate the touched block(s). This replaces the whole-object `triggerBackgroundCacheFetch` in `handleRangeWithBackgroundCache` for block-mode-eligible objects.
 
@@ -110,15 +111,17 @@ Because every full-object fetch of a block-eligible object lands as blocks, ther
 
 ### Full-object GET on a block-mode object
 
-Rare for a range-read-dominated workload but must be correct:
+Rare for a range-read-dominated workload but must be correct — and fast, since it is the case where per-block serve cost is linear in block count:
 
-- **Cold miss:** the object is streamed once from upstream and split into blocks by the shared writer — one upstream fetch, all blocks populated.
-- **Hit, mostly cached:** assemble blocks `0…N-1` in order, fetching any few missing via `fetchBlocksToCache`, streaming as we go.
-- **Hit, mostly missing** (e.g. only a footer block was ever cached): assembling every missing block as a separate aligned range GET would be a large request amplification, so instead fall through to the miss path — a single streaming upstream GET that re-splits into blocks. The threshold (more than half the covering blocks missing) bounds per-block fan-out to the already-mostly-cached case.
+- **Cold miss:** the object is streamed once from upstream and split into blocks by the shared writer (`putBlocksFromStream`) — one upstream fetch, all blocks populated, and the meta is stamped `blocks_complete` (every block was just written). Each block is read to its exact expected length before its store; a body shorter or longer than `Content-Length` leaves the meta unwritten.
+- **Hit on a complete entry (probe-free):** `blocks_complete` lets the serve skip the probe pass entirely — `2N+1 → N+1` cache ops. The first block is read into a pooled, staging-budget-gated buffer **pre-commit** (a gone or unrecoverable first block still falls through to the miss path with the response untouched), then the rest stream pipelined.
+- **Hit on a partial entry (probe-first):** probe all blocks. **Mostly missing** (more than half — e.g. only a footer block was ever cached) bails to the miss path's single streaming re-split instead of a per-block fetch storm, and invalidates the mostly-missing entry (the bail skips the per-block staleness check, so leaving it could serve stale bytes on later range reads). **Mostly cached** assembles the few missing blocks, then **promotes** the entry to `blocks_complete` — async and tombstone-aware (the write-start timestamp is stamped before assembly, so a racing invalidation blocks the write), carrying only the entry's **remaining TTL** computed from `cached_at`. Promotion never extends the entry's lifetime: it does not consult upstream, so a fresh TTL would reset the staleness clock (up to doubling the configured bound after an out-of-band overwrite) and guarantee a window where the meta outlives every block. Each entry pays the probe pass at most once.
 
 So a block-eligible object is **always** block-mode; a full read never produces a competing whole-body entry.
 
-An entry is invalidated when a block fetch returns a definitive stale signal — an ETag mismatch (concurrent overwrite) or 404/403 (deleted / access revoked) — so a stale entry isn't retried on every read until TTL. A client-forced revalidation (`Cache-Control: no-cache`) of a block-mode entry likewise invalidates it and lets the miss path re-establish the current version.
+**Bounded degraded serves.** Because `blocks_complete` is a hint and blocks evict independently of the meta, a committed serve (headers already sent) recovers at most `maxInlineFetchesPerServe` (2) absent blocks via individual aligned upstream fetches. Past that cap, on a populate-budget decline, or on a transient cache-read failure, the committed response is completed **byte-exact from a single uncached upstream remainder stream** — validated against the entry's ETag and the exact remaining byte range — instead of truncating, and a cap-tripped (mass-evicted) entry is invalidated so the next GET re-establishes it with one streaming re-split. Only three things still truncate a committed body: a stale signal (a different object version must never be mixed into a committed response), a client write failure (the client is broken, not the cache — tracked explicitly so it is never "salvaged" with a wasted upstream round trip), and a failed remainder stream.
+
+A client-forced revalidation (`Cache-Control: no-cache`) of a block-mode entry likewise invalidates it and lets the miss path re-establish the current version.
 
 ### Configuration
 
@@ -130,14 +133,25 @@ A single size knob, `block_size`, is the whole↔block boundary; the earlier `wr
 | `cache.block_size` | 4 MiB (must be < 64 MB) | Block granularity **and** the whole↔block boundary: below one block → whole-cached (blocking a sub-block object just stores one blob), at/above → block-cached. The write-through tee (in-memory) also gates on this, keeping its buffer sub-block. |
 | `cache.size_threshold` | 1 GB | Overall cacheability ceiling. Block mode lets TAG cache *parts* of objects up to this ceiling without downloading the whole thing. |
 
-Why one knob: block-caching a sub-block object is identical to whole-caching it, so `block_size` is the natural boundary. It governs every populate path uniformly — read misses, full-GET misses, and warm-on-write all split block-eligible objects into blocks and whole-cache the rest — so representation is a function of size alone, with no separate warm cap and no per-access-pattern collision to guard.
+Why one knob: block-caching a sub-block object is identical to whole-caching it, so `block_size` is the natural boundary. It governs every populate path uniformly — read misses, full-GET misses, and warm-on-write all split block-eligible objects into blocks and whole-cache the rest — so representation is a function of size alone, with no separate warm cap and no per-access-pattern collision to guard. (A `block_min_object_size` knob raising the boundary was trialed and removed: with pipelined serving, block mode sits within ~7% of the whole-object ceiling even at 4 blocks/object, so the extra config surface wasn't warranted.)
+
+The existing `cache.max_populate_memory_bytes` additionally sizes the serve-staging budget — see Memory bounds; no new memory knob is introduced.
 
 ### Invalidation and consistency
 
 - Blocks are ETag-scoped: an overwrite writes new keys under the new ETag; stale blocks age out by TTL (no explicit block deletion — same as bodies today).
-- DELETE tombstone + `PutWithMetaStreamTombstoneAware` semantics apply per block; `writeStartTime` is stamped before each block fetch.
+- The **meta is the visibility gate**: blocks are written first with plain block puts, and the block-mode meta is written last via `PutMetaTombstoneAware` with a `writeStartTime` stamped *before* the fetch/assembly began — a DELETE tombstone that lands mid-populate is then provably newer and blocks the meta write, so background work can't resurrect a deleted object.
 - Meta `Delete` orphans blocks (age out); the next read re-populates meta + touched blocks.
 - The ETag guard on each block fetch prevents mixing versions under one ETag's keys.
+
+### Memory bounds
+
+Two independent byte budgets, both sized by `cache.max_populate_memory_bytes` (so the aggregate budget-bounded buffering is up to **2×** that value; negative disables both):
+
+- **Populate budget** (pre-existing): every block fetch reserves the block's actual size (read-miss priority, non-blocking). A declined fetch means the bytes are served from upstream uncached this time — never a failed request.
+- **Serve-staging budget** (new, independent): the assembled-range buffer, the complete-serve first-block buffer, and the pipeline's two staging buffers reserve their **actual sizes** here, never against the populate budget — a warm serve holds staging bytes for its whole (possibly multi-second) response, and sharing one pool let high-concurrency serving starve cold-miss populates, keeping the working set cold. Staging declines degrade the serve (probe-first path, sequential stream); they never fail it.
+
+Block staging buffers are pooled (`sync.Pool`); the pool's retention cap tracks the configured `block_size` so pooling isn't silently disabled for larger-block deployments.
 
 ## Distributed caching
 
@@ -149,19 +163,22 @@ Co-locating an object's blocks on a single owner (hashing on object identity `bu
 
 Back-compat: legacy whole-body entries (`BlockSize=0`) are served by the existing path; new large-object misses populate block-mode. Both coexist; readers dispatch on `meta.BlockSize`. Gated behind `block_caching_enabled` (default off).
 
-1. `meta.BlockSize` + `MakeBlockKey` + config + reader dispatch (block vs whole).
-2. Block-aware range serve: per-block probe + partial-hit fetch (coalesced, concurrent).
-3. Single shared cache writer splits block-eligible objects into blocks on every full-object populate path (read miss, full-GET miss, warm-on-write read-back); the tee stays sub-block; the whole↔block boundary is `block_size`; remove `block_cache_min_size` and `write_through_max_size`.
-4. Full-GET block assembly (mostly-cached) + single-stream re-split fallback (mostly-missing) + metrics.
-5. *(optional, not required)* ocache block-locality routing for clusters — only if a future workload ever wants an object's blocks co-located.
+1. **Done** — `meta.BlockSize` + `MakeBlockKey` + config + reader dispatch (block vs whole).
+2. **Done** — block-aware range serve: probe-free assembled fast path for sub-block ranges, probe-first path with bounded fan-out for larger ones, partial-hit fetch (coalesced, concurrent).
+3. **Done** — single shared cache writer splits block-eligible objects into blocks on every full-object populate path (read miss, full-GET miss, warm-on-write read-back); the tee stays sub-block; the whole↔block boundary is `block_size`; `block_cache_min_size` and `write_through_max_size` removed. (A `block_min_object_size` knob raising the boundary was added and then removed once pipelining closed the mid-size gap to ~7% — see [#141](https://github.com/tigrisdata/tag/pull/141).)
+4. **Done** — full-GET block assembly (mostly-cached, with `blocks_complete` promotion) + single-stream re-split fallback (mostly-missing) + metrics.
+5. **Done** ([#141](https://github.com/tigrisdata/tag/pull/141)) — per-block serve cost cuts: probe-free serves (`2N+1 → N+1` ops), pipelined block streaming, the serve-staging budget, and bounded degraded serves with the uncached upstream remainder salvage. Measured: warm block-mode full GETs reach put-normalized throughput parity with whole-object caching with median TTFB up to ~22× better on large objects; +89% raw (+~54% bandwidth-normalized) vs `main` at identical 64 KiB-block config.
+6. *(optional, not required)* ocache block-locality routing for clusters — only if a future workload ever wants an object's blocks co-located.
 
-Deferred: block-size-vs-footer-fit (single block size for now).
+Deferred: block-size-vs-footer-fit (single block size for now); density-triggered promotion from per-block demand fetches to one streaming whole-population for range workloads that end up reading most of an object.
 
 ## Metrics
 
-- Block hit/miss and partial-hit rate.
-- Blocks fetched per request; block-fetch coalesce rate.
-- Bytes populated vs bytes served (amplification ratio) — the headline KPI for this work.
+Implemented:
+
+- `tag_cache_block_hits_total` / `tag_cache_block_misses_total` — covering blocks already cached vs fetched at serve time. Recorded **only on committed block-cache serves** (a bail or failed fetch that falls through to upstream records none, avoiding hit-ratio skew), and counting only blocks actually read — inline fetches, remainder-streamed bytes, and blocks never reached on an aborted serve all count against the entry, never as hits.
+- `tag_cache_block_range_served_total{full_hit|partial_hit}` — block-mode serves by whether every covering block was already cached. Partial-hit rate = `partial_hit / (full_hit + partial_hit)`.
+- `tag_cache_block_populated_total` / `tag_cache_block_bytes_populated_total` — blocks and bytes fetched from upstream into cache. Compare bytes populated with `tag_bytes_transferred_total{direction="out"}` for the amplification ratio — the headline KPI for this work.
 - Watch existing `ocache_segment_size_bytes` for recompaction impact of the tier shift.
 
 ## Alternatives considered

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -133,12 +133,23 @@ func (s *Service) serveRangeFromBlockCache(
 	if rangeLen := rng.end - rng.start + 1; rangeLen <= meta.BlockSize {
 		weight := s.populateWeight(rangeLen)
 		if s.populateBudget == nil || s.populateBudget.tryAcquireReadMiss(weight) {
+			assembled, aerr := s.serveAssembledRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng, startTime)
 			if s.populateBudget != nil {
-				defer s.populateBudget.release(weight)
+				s.populateBudget.release(weight)
 			}
-			return s.serveAssembledRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng, startTime)
+			// A budget-declined block fetch during assembly may have been starved by our own
+			// buffer reservation (assembly holds `weight` while the fetch reserves the block
+			// size on top). Nothing is committed on that path, and the reservation is released
+			// above — so retry via the probe path below, whose fetch can use the freed budget,
+			// instead of falling through to upstream a serve the probe path could still cache.
+			if !assembled && errors.Is(aerr, errCachePopulateDeclined) {
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly block fetch budget-declined - retrying via probe path")
+			} else {
+				return assembled, aerr
+			}
+		} else {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly buffer budget declined - serving range via probe path")
 		}
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly buffer budget declined - serving range via probe path")
 	}
 
 	b0, bK := coveringBlocks(rng.start, rng.end, meta.BlockSize)

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -135,21 +135,21 @@ func (s *Service) serveRangeFromBlockCache(
 	// warm-serve cache ops versus the probe-then-stream path below); a missing block is
 	// discovered by that same read and fetched pre-commit, so every failure still leaves the
 	// response unwritten for a clean upstream fall-through — identical semantics, fewer ops.
-	// The buffer (<= one block) is reserved against the populate byte budget — but NOT a
-	// cacheSemaphore count slot, which bounds concurrent cache WRITES and must not be held
-	// across a (possibly slow) client write. On budget decline, serve via the probe path.
+	// The buffer (<= one block) is reserved against the serve-staging byte budget (NOT the
+	// populate budget — long-held serve buffers must not crowd out cold-miss populates — and
+	// NOT a cacheSemaphore count slot, which bounds concurrent cache WRITES and must not be
+	// held across a (possibly slow) client write). On budget decline, serve via the probe path.
 	if rangeLen := rng.end - rng.start + 1; rangeLen <= meta.BlockSize {
 		weight := s.populateWeight(rangeLen)
-		if s.populateBudget == nil || s.populateBudget.tryAcquireReadMiss(weight) {
+		if s.serveStagingBudget == nil || s.serveStagingBudget.tryAcquireReadMiss(weight) {
 			assembled, aerr := s.serveAssembledRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng, startTime)
-			if s.populateBudget != nil {
-				s.populateBudget.release(weight)
+			if s.serveStagingBudget != nil {
+				s.serveStagingBudget.release(weight)
 			}
-			// A budget-declined block fetch during assembly may have been starved by our own
-			// buffer reservation (assembly holds `weight` while the fetch reserves the block
-			// size on top). Nothing is committed on that path, and the reservation is released
-			// above — so retry via the probe path below, whose fetch can use the freed budget,
-			// instead of falling through to upstream a serve the probe path could still cache.
+			// A budget-declined block fetch during assembly means the populate budget is
+			// saturated. Nothing is committed on that path, so retry via the probe path below
+			// — populate budget may have freed by then, and a still-declined fetch there falls
+			// through to upstream exactly as this path would have.
 			if !assembled && errors.Is(aerr, errCachePopulateDeclined) {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly block fetch budget-declined - retrying via probe path")
 			} else {
@@ -355,8 +355,9 @@ func (s *Service) serveAssembledRange(
 // the client write latency overlap instead of adding up — the structural stall that made warm
 // multi-block GETs trail whole-object serves (whose single contiguous body never waits
 // per-block). The pipeline holds at most two block buffers (one draining to the client, one
-// filling), reserved against the populate byte budget; on decline — and for single-block
-// serves, where there is nothing to overlap — it degrades to the direct sequential path.
+// filling), reserved against the serve-staging byte budget (never the populate budget — see
+// NewService); on decline — and for single-block serves, where there is nothing to overlap —
+// it degrades to the direct sequential path.
 func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
 	cw := &countingWriter{w: w}
 	defer func() {
@@ -372,12 +373,12 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 		return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 	}
 	weight := s.populateWeight(2 * meta.BlockSize)
-	if s.populateBudget != nil {
-		if !s.populateBudget.tryAcquireReadMiss(weight) {
+	if s.serveStagingBudget != nil {
+		if !s.serveStagingBudget.tryAcquireReadMiss(weight) {
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Pipeline buffer budget declined - streaming blocks sequentially")
 			return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 		}
-		defer s.populateBudget.release(weight)
+		defer s.serveStagingBudget.release(weight)
 	}
 	return s.streamBlockRangePipelined(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 }
@@ -510,19 +511,19 @@ func (s *Service) serveFullObjectFromBlockCache(
 	lastBlock := (meta.ContentLength - 1) / meta.BlockSize
 
 	// Probe-free fast path for complete entries. The first-block buffer (<= one block) is
-	// reserved against the populate byte budget like the assembled-range path; on decline the
-	// probe-first path below still serves.
+	// reserved against the serve-staging byte budget like the assembled-range path; on
+	// decline the probe-first path below still serves.
 	if meta.BlocksComplete {
 		firstLen := min(meta.BlockSize, meta.ContentLength)
 		weight := s.populateWeight(firstLen)
-		if s.populateBudget == nil || s.populateBudget.tryAcquireReadMiss(weight) {
+		if s.serveStagingBudget == nil || s.serveStagingBudget.tryAcquireReadMiss(weight) {
 			served, err = s.serveCompleteFromBlocks(ctx, w, bucket, key, accessKey, secretKey, meta, startTime)
-			if s.populateBudget != nil {
-				s.populateBudget.release(weight)
+			if s.serveStagingBudget != nil {
+				s.serveStagingBudget.release(weight)
 			}
-			// A budget-declined first-block fetch may have been starved by our own buffer
-			// reservation (released above); the probe path below can still assemble and serve
-			// from cache, so retry there instead of surrendering to a full upstream GET.
+			// A budget-declined first-block fetch means the populate budget is saturated; the
+			// probe path below can still assemble and serve from cache if budget frees, so
+			// retry there instead of surrendering directly to a full upstream GET.
 			if !served && errors.Is(err, errCachePopulateDeclined) {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve block fetch budget-declined - retrying via probe path")
 			} else {

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -392,7 +392,7 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 	if err == nil {
 		return out, nil
 	}
-	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil {
+	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil && start+cw.written <= end {
 		// The committed response can still be completed byte-exact from upstream: cw.written
 		// counts exactly the bytes delivered so far (buffered blocks are written whole; a
 		// direct-streamed partial block advances it precisely), so the remainder picks up at
@@ -527,6 +527,25 @@ func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, se
 	}
 }
 
+// clientWriteTracker distinguishes write-side failures from cache-read failures on the
+// sequential path, where cache bytes stream STRAIGHT into the client connection: an error
+// surfaced by GetBlockRangeStream could have originated on either side, and only cache-side
+// failures are salvageable by an upstream remainder stream — retrying a broken client write
+// from upstream would waste a round trip on a dead connection (and a bytes-plus-error final
+// write could even mask a fully delivered body).
+type clientWriteTracker struct {
+	w        io.Writer
+	writeErr error
+}
+
+func (t *clientWriteTracker) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if err != nil && t.writeErr == nil {
+		t.writeErr = err
+	}
+	return n, err
+}
+
 // streamBlockRangeSequential is streamBlockRange's unbuffered fallback (single-block serves,
 // or the pipeline's buffer budget declined): each block streams from cache directly into the
 // client writer with no staging buffer. Because the read target IS the response body here, an
@@ -536,11 +555,12 @@ func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, se
 func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (out streamOutcome, err error) {
 	b0, bK := coveringBlocks(start, end, meta.BlockSize)
 	fetchesLeft := int64(maxInlineFetchesPerServe)
+	tw := &clientWriteTracker{w: cw}
 	for i := b0; i <= bK; i++ {
 		localStart, localEnd := blockLocalRange(i, start, end, meta.BlockSize, meta.ContentLength)
 		before := cw.written
 		wasFetched := false
-		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, tw)
 		if errors.Is(berr, cache.ErrNotFound) && cw.written == before {
 			if fetchesLeft <= 0 {
 				return out, errBlocksMostlyAbsent
@@ -554,9 +574,14 @@ func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWr
 			}
 			out.fetched++
 			wasFetched = true
-			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, tw)
 		}
 		if berr != nil {
+			// A write-side failure is the client's, not the cache's: return it raw so the
+			// caller truncates instead of attempting an upstream remainder salvage.
+			if tw.writeErr != nil {
+				return out, berr
+			}
 			return out, fmt.Errorf("block %d stream failed (%w): %w", i, berr, errBlockStreamDegraded)
 		}
 		if !wasFetched {

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -392,15 +392,17 @@ func (s *Service) serveFullObjectFromBlockCache(
 			if s.populateBudget != nil {
 				s.populateBudget.release(weight)
 			}
-			if served || err != nil {
+			// A budget-declined first-block fetch may have been starved by our own buffer
+			// reservation (released above); the probe path below can still assemble and serve
+			// from cache, so retry there instead of surrendering to a full upstream GET.
+			if !served && errors.Is(err, errCachePopulateDeclined) {
+				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve block fetch budget-declined - retrying via probe path")
+			} else {
 				return served, err
 			}
-			// (false, nil): first block unrecoverable pre-commit — fall through to the miss
-			// path via the caller (a probe pass over an entry we already failed to read
-			// would just repeat the failure).
-			return false, nil
+		} else {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
 		}
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
 	}
 
 	// Stamp the promotion's write-start BEFORE the assembly work below: any invalidation that
@@ -519,6 +521,14 @@ func (s *Service) serveCompleteFromBlocks(
 		var streamed int64
 		streamed, berr = s.streamBlockRangeInlineFetch(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
 		fetched += streamed
+		// A definitive stale signal from a mid-serve inline fetch must still invalidate,
+		// even though headers are committed (this response truncates either way): leaving
+		// the stale BlocksComplete entry in place would have every later full GET commit
+		// and truncate the same way until the meta TTL expires.
+		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
+			log.Debug().Err(berr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
+			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		}
 	}
 	total := lastBlock + 1
 	metrics.CacheBlockHits.Add(float64(total - fetched))

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -184,7 +184,12 @@ func (s *Service) serveRangeFromBlockCache(
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
 
-	if _, berr := s.streamBlockRange(ctx, w, bucket, key, meta, rng.start, rng.end); berr != nil {
+	if _, berr := s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng.start, rng.end); berr != nil {
+		// A definitive stale signal from a mid-serve inline fetch invalidates the entry even
+		// though this response truncates: leaving it would repeat the truncation until TTL.
+		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
+			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		}
 		return true, berr
 	}
 	metrics.RecordRangeFromCacheHit()
@@ -339,29 +344,150 @@ func (s *Service) serveAssembledRange(
 }
 
 // streamBlockRange streams object bytes [start,end] (inclusive) from a block-mode entry's
-// cached blocks, in order, into w. The caller must have committed the status line + headers and
-// ensured the covering blocks are present. On a block evicted mid-serve it returns a non-nil
-// error; headers are already sent so the caller cannot fall through (the client sees a truncated
-// body). Shared by the range and full-object serve paths.
-func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, bucket, key string, meta *cache.CachedObjectMeta, start, end int64) (written int64, err error) {
-	b0, bK := coveringBlocks(start, end, meta.BlockSize)
+// cached blocks, in order, into w. The caller must have committed the status line + headers.
+// A block the cache reports absent (evicted since the caller last saw it) is fetched from
+// upstream (coalesced, budget-gated) and re-read instead of failing the serve; only a fetch or
+// re-read failure returns a non-nil error, which truncates the client body since headers are
+// already sent. Returns how many blocks were inline-fetched.
+//
+// Multi-block serves are PIPELINED: a reader goroutine prefetches block i+1 into a pooled
+// buffer while block i's bytes are being written to the client, so the cache read latency and
+// the client write latency overlap instead of adding up — the structural stall that made warm
+// multi-block GETs trail whole-object serves (whose single contiguous body never waits
+// per-block). The pipeline holds at most two block buffers (one draining to the client, one
+// filling), reserved against the populate byte budget; on decline — and for single-block
+// serves, where there is nothing to overlap — it degrades to the direct sequential path.
+func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
 	cw := &countingWriter{w: w}
+	defer func() {
+		if cw.written > 0 {
+			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+		}
+		if err != nil {
+			log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block stream failed mid-serve")
+		}
+	}()
+	b0, bK := coveringBlocks(start, end, meta.BlockSize)
+	if b0 == bK {
+		return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+	}
+	weight := s.populateWeight(2 * meta.BlockSize)
+	if s.populateBudget != nil {
+		if !s.populateBudget.tryAcquireReadMiss(weight) {
+			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Pipeline buffer budget declined - streaming blocks sequentially")
+			return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+		}
+		defer s.populateBudget.release(weight)
+	}
+	return s.streamBlockRangePipelined(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+}
+
+// streamBlockRangePipelined is streamBlockRange's overlapped core: an unbuffered channel
+// hands each prefetched block from the reader goroutine to the write loop, so exactly one
+// block is filling while one is draining (double buffering — two pooled buffers alive at
+// peak, which is what streamBlockRange reserved). Absent blocks are recovered by the reader
+// via readBlockSlice before the handoff; the first reader error ends the stream in order,
+// exactly where the sequential path would have failed. The stop channel unwinds the reader
+// (and returns its in-flight buffer) when the write loop exits early on a client write error.
+func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+	b0, bK := coveringBlocks(start, end, meta.BlockSize)
+	type blockRead struct {
+		bufp      *[]byte
+		n         int64
+		fetchedIt bool
+		err       error
+	}
+	results := make(chan blockRead)
+	stop := make(chan struct{})
+	go func() {
+		defer close(results)
+		for i := b0; i <= bK; i++ {
+			bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
+			localStart := max(start, bStart) - bStart
+			localEnd := min(end, bEnd) - bStart
+			br := blockRead{n: localEnd - localStart + 1}
+			br.bufp = getBlockBuf(br.n)
+			br.fetchedIt, br.err = s.readBlockSlice(ctx, bucket, key, accessKey, secretKey, meta, i, localStart, localEnd, (*br.bufp)[:br.n])
+			select {
+			case results <- br:
+			case <-stop:
+				putBlockBuf(br.bufp)
+				return
+			}
+			if br.err != nil {
+				return
+			}
+		}
+	}()
+	defer close(stop)
+	for br := range results {
+		if br.err != nil {
+			putBlockBuf(br.bufp)
+			return fetched, br.err
+		}
+		if br.fetchedIt {
+			fetched++
+		}
+		_, werr := cw.Write((*br.bufp)[:br.n])
+		putBlockBuf(br.bufp)
+		if werr != nil {
+			return fetched, werr
+		}
+	}
+	return fetched, nil
+}
+
+// readBlockSlice reads block idx's local byte range [localStart,localEnd] into dst
+// (len(dst) == the range length). A block the cache reports absent is fetched from upstream
+// (coalesced, budget-gated) and re-read — dst is scratch, never client-visible, so the retry
+// can't duplicate bytes in the response the way a direct-to-client re-read could. A nil-error
+// short read is reported as an error: a present block never legitimately under-delivers an
+// in-bounds range.
+func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, idx, localStart, localEnd int64, dst []byte) (fetched bool, err error) {
+	read := func() error {
+		sw := &sliceWriter{dst: dst}
+		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, idx, localStart, localEnd, sw)
+		if rerr == nil && sw.off != int64(len(dst)) {
+			return fmt.Errorf("block %d stream: short read %d of %d bytes", idx, sw.off, len(dst))
+		}
+		return rerr
+	}
+	rerr := read()
+	if errors.Is(rerr, cache.ErrNotFound) {
+		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{idx}); ferr != nil {
+			return false, ferr
+		}
+		fetched = true
+		rerr = read()
+	}
+	return fetched, rerr
+}
+
+// streamBlockRangeSequential is streamBlockRange's unbuffered fallback (single-block serves,
+// or the pipeline's buffer budget declined): each block streams from cache directly into the
+// client writer with no staging buffer. Because the read target IS the response body here, an
+// absent block is refetched and re-read only when its failed read delivered nothing — a
+// partial write followed by a re-read would duplicate bytes in the response.
+func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+	b0, bK := coveringBlocks(start, end, meta.BlockSize)
 	for i := b0; i <= bK; i++ {
 		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
 		localStart := max(start, bStart) - bStart
 		localEnd := min(end, bEnd) - bStart
-		if berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw); berr != nil {
-			if cw.written > 0 {
-				metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+		before := cw.written
+		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+		if errors.Is(berr, cache.ErrNotFound) && cw.written == before {
+			if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{i}); ferr != nil {
+				return fetched, ferr
 			}
-			log.Warn().Err(berr).Str("bucket", bucket).Str("key", key).Int64("block", i).Msg("Block vanished mid-serve")
-			return cw.written, berr
+			fetched++
+			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+		}
+		if berr != nil {
+			return fetched, berr
 		}
 	}
-	if cw.written > 0 {
-		metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
-	}
-	return cw.written, nil
+	return fetched, nil
 }
 
 // serveFullObjectFromBlockCache serves a full-object GET from a block-mode entry. A complete
@@ -452,7 +578,12 @@ func (s *Service) serveFullObjectFromBlockCache(
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(meta.StatusCode)
 
-	if _, berr := s.streamBlockRange(ctx, w, bucket, key, meta, 0, meta.ContentLength-1); berr != nil {
+	if _, berr := s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, 0, meta.ContentLength-1); berr != nil {
+		// Same rationale as the range path above: a stale signal surfaced by a mid-serve
+		// inline fetch must invalidate even though the response truncates.
+		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
+			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		}
 		return true, berr
 	}
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
@@ -521,7 +652,7 @@ func (s *Service) serveCompleteFromBlocks(
 		berr = werr
 	} else if lastBlock > 0 {
 		var streamed int64
-		streamed, berr = s.streamBlockRangeInlineFetch(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
+		streamed, berr = s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
 		fetched += streamed
 		// A definitive stale signal from a mid-serve inline fetch must still invalidate,
 		// even though headers are committed (this response truncates either way): leaving
@@ -545,44 +676,6 @@ func (s *Service) serveCompleteFromBlocks(
 	}
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
 	return true, nil
-}
-
-// streamBlockRangeInlineFetch streams object bytes [start,end] from a block-mode entry's
-// blocks like streamBlockRange, but a block the read reports absent is fetched from upstream
-// (coalesced, budget-gated) and re-read instead of failing the serve — recovering blocks
-// evicted after a BlocksComplete meta was written. Headers are already committed, so a fetch
-// or re-read failure still returns a non-nil error (truncated body). Returns how many blocks
-// were inline-fetched.
-func (s *Service) streamBlockRangeInlineFetch(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
-	b0, bK := coveringBlocks(start, end, meta.BlockSize)
-	cw := &countingWriter{w: w}
-	defer func() {
-		if cw.written > 0 {
-			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
-		}
-	}()
-	for i := b0; i <= bK; i++ {
-		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
-		localStart := max(start, bStart) - bStart
-		localEnd := min(end, bEnd) - bStart
-		before := cw.written
-		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
-		// Retry only a block whose read delivered NOTHING (an absent key never writes): a
-		// partial write followed by a re-read would duplicate bytes in the response.
-		if errors.Is(berr, cache.ErrNotFound) && cw.written == before {
-			if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{i}); ferr != nil {
-				log.Warn().Err(ferr).Str("bucket", bucket).Str("key", key).Int64("block", i).Msg("Block vanished mid-serve and inline fetch failed")
-				return fetched, ferr
-			}
-			fetched++
-			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
-		}
-		if berr != nil {
-			log.Warn().Err(berr).Str("bucket", bucket).Str("key", key).Int64("block", i).Msg("Block unreadable mid-serve")
-			return fetched, berr
-		}
-	}
-	return fetched, nil
 }
 
 // fetchBlocksToCache fetches the given missing blocks from upstream and writes them to cache,

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -208,30 +208,32 @@ func (sw *sliceWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// maxPooledAssemblyBufBytes caps the capacity of assembly buffers the pool retains, so an
-// entry written under an unusually large historical block_size can't pin oversized buffers
-// in the pool forever.
-const maxPooledAssemblyBufBytes = 4 << 20
+// maxPooledBlockBufBytes caps the capacity of block buffers the pool retains, so an entry
+// written under an unusually large historical block_size can't pin oversized buffers in the
+// pool forever.
+const maxPooledBlockBufBytes = 4 << 20
 
-// assemblyBufPool recycles pre-commit range-assembly buffers. Buffers are handed out by
-// capacity; a request larger than a pooled buffer's capacity allocates fresh.
-var assemblyBufPool sync.Pool
+// blockBufPool recycles block-sized scratch buffers: pre-commit range/first-block assembly on
+// the serve paths, and the block staging buffers on the populate paths (fetchOneBlock,
+// putBlocksFromStream). Buffers are handed out by capacity; a request larger than a pooled
+// buffer's capacity allocates fresh.
+var blockBufPool sync.Pool
 
-func getAssemblyBuf(n int64) *[]byte {
-	if v := assemblyBufPool.Get(); v != nil {
+func getBlockBuf(n int64) *[]byte {
+	if v := blockBufPool.Get(); v != nil {
 		bp := v.(*[]byte)
 		if int64(cap(*bp)) >= n {
 			return bp
 		}
-		assemblyBufPool.Put(bp) // too small for this request; keep it for a smaller one
+		blockBufPool.Put(bp) // too small for this request; keep it for a smaller one
 	}
 	b := make([]byte, n)
 	return &b
 }
 
-func putAssemblyBuf(bp *[]byte) {
-	if int64(cap(*bp)) <= maxPooledAssemblyBufBytes {
-		assemblyBufPool.Put(bp)
+func putBlockBuf(bp *[]byte) {
+	if int64(cap(*bp)) <= maxPooledBlockBufBytes {
+		blockBufPool.Put(bp)
 	}
 }
 
@@ -255,8 +257,8 @@ func (s *Service) serveAssembledRange(
 ) (served bool, err error) {
 	b0, bK := coveringBlocks(rng.start, rng.end, meta.BlockSize)
 	rangeLen := rng.end - rng.start + 1
-	bufp := getAssemblyBuf(rangeLen)
-	defer putAssemblyBuf(bufp)
+	bufp := getBlockBuf(rangeLen)
+	defer putBlockBuf(bufp)
 	buf := (*bufp)[:rangeLen]
 
 	// Pass 1: read every covering block's slice of the range into place. ErrNotFound marks
@@ -477,8 +479,8 @@ func (s *Service) serveCompleteFromBlocks(
 	_, firstEnd := blockBounds(0, meta.BlockSize, meta.ContentLength)
 	firstLen := firstEnd + 1
 
-	bufp := getAssemblyBuf(firstLen)
-	defer putAssemblyBuf(bufp)
+	bufp := getBlockBuf(firstLen)
+	defer putBlockBuf(bufp)
 	buf := (*bufp)[:firstLen]
 
 	fetched := int64(0)
@@ -717,8 +719,12 @@ func (s *Service) fetchOneBlock(ctx context.Context, bucket, key, accessKey, sec
 		// (truncated response) streamed straight into PutBlockStream could persist a short block,
 		// which BlockExists can't distinguish from a complete one — so it would later serve
 		// truncated bytes. io.ReadFull errors on a short body, so a partial block is never stored.
-		// blockLen <= block_size, bounded by maxConcurrentBlockFetches concurrent fetches.
-		blockBuf := make([]byte, blockLen)
+		// blockLen <= block_size, bounded by maxConcurrentBlockFetches concurrent fetches. The
+		// buffer is pooled and safely returned on exit: PutBlockStream consumes the reader
+		// fully before returning, so nothing references it afterwards.
+		bufp := getBlockBuf(blockLen)
+		defer putBlockBuf(bufp)
+		blockBuf := (*bufp)[:blockLen]
 		if _, rerr := io.ReadFull(resp.Body, blockBuf); rerr != nil {
 			return nil, fmt.Errorf("block %d fetch: short body (%w), want %d bytes", blockIdx, rerr, blockLen)
 		}
@@ -852,7 +858,11 @@ func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, m
 			_, _ = io.Copy(io.Discard, r)
 		}
 	}()
-	buf := make([]byte, meta.BlockSize)
+	// Pooled and safely returned on exit: each PutBlockStream consumes its reader fully
+	// before returning, so no block write outlives the loop iteration that staged it.
+	bufp := getBlockBuf(meta.BlockSize)
+	defer putBlockBuf(bufp)
+	buf := (*bufp)[:meta.BlockSize]
 	lastBlock := (meta.ContentLength - 1) / meta.BlockSize
 	for idx := int64(0); idx <= lastBlock; idx++ {
 		bStart, bEnd := blockBounds(idx, meta.BlockSize, meta.ContentLength)

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -48,14 +48,22 @@ var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 // isBlockEligibleSize reports whether an object of the given content length is block-cached on
 // the read-miss path (RFC 0001): block caching is enabled and the object is at least one block
 // (BlockSize is the whole-vs-block boundary — a sub-block object is whole-cached, since blocking
-// it would just store a single blob). A negative/unknown length is not eligible. Requiring
-// BlockSize > 0 keeps a config that enables block caching but leaves BlockSize at 0 (e.g. a
-// Config built directly, bypassing Load's normalization) from dividing by zero in block
-// arithmetic. A read miss for a block-eligible object populates blocks, not a whole blob.
+// it would just store a single blob). BlockMinObjectSize raises that boundary when set: objects
+// below it are whole-cached even though they span multiple blocks, because a whole-cached warm
+// GET costs 2 cache ops while a block-mode one is linear in block count — block caching only
+// pays off once an object is large enough that whole-caching it is wasteful. A negative/unknown
+// length is not eligible. Requiring BlockSize > 0 keeps a config that enables block caching but
+// leaves BlockSize at 0 (e.g. a Config built directly, bypassing Load's normalization) from
+// dividing by zero in block arithmetic. A read miss for a block-eligible object populates
+// blocks, not a whole blob.
 func (s *Service) isBlockEligibleSize(contentLength int64) bool {
+	boundary := s.config.Cache.BlockSize
+	if s.config.Cache.BlockMinObjectSize > boundary {
+		boundary = s.config.Cache.BlockMinObjectSize
+	}
 	return s.config.Cache.BlockCachingEnabled &&
 		s.config.Cache.BlockSize > 0 &&
-		contentLength >= s.config.Cache.BlockSize
+		contentLength >= boundary
 }
 
 // blockBounds returns the inclusive object-byte bounds [start,end] of block i for an object

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -45,6 +46,27 @@ var errBlockUpstreamGone = errors.New("block upstream gone")
 // as "fall through to the miss path", not a real error.
 var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 
+// maxInlineFetchesPerServe bounds how many absent blocks one COMMITTED block serve recovers via
+// individual aligned upstream fetches. BlocksComplete is a hint: blocks and meta evict/expire
+// independently, so a surviving meta over mass-evicted blocks would otherwise turn one full GET
+// into N serial upstream range GETs — the exact amplification bailIfMostlyMissing prevents on
+// the pre-commit probe path. Past this cap the serve switches to a single uncached upstream
+// remainder stream and the degenerate entry is invalidated.
+const maxInlineFetchesPerServe = 2
+
+// errBlockStreamDegraded marks a committed block serve that hit a block the cache can no longer
+// produce and an inline fetch could not (or should not) recover — but whose remaining bytes
+// upstream can still supply. streamBlockRange salvages the response with one uncached upstream
+// range GET for the remainder instead of truncating the committed body. Stale signals
+// (errBlockETagMismatch / errBlockUpstreamGone) are deliberately NEVER wrapped in it: a
+// different object version must not be mixed into an already-committed response.
+var errBlockStreamDegraded = errors.New("block stream degraded")
+
+// errBlocksMostlyAbsent wraps errBlockStreamDegraded when the inline-fetch cap was exhausted:
+// the entry has lost too many blocks to be worth keeping, so after the remainder salvage the
+// serve invalidates it and the next GET re-establishes it via a single streaming re-split.
+var errBlocksMostlyAbsent = fmt.Errorf("too many absent blocks: %w", errBlockStreamDegraded)
+
 // isBlockEligibleSize reports whether an object of the given content length is block-cached on
 // the read-miss path (RFC 0001): block caching is enabled and the object is at least one block
 // (BlockSize is the whole-vs-block boundary — a sub-block object is whole-cached, since blocking
@@ -74,6 +96,13 @@ func blockBounds(i, blockSize, contentLength int64) (start, end int64) {
 // object byte range [s,e].
 func coveringBlocks(s, e, blockSize int64) (b0, bK int64) {
 	return s / blockSize, e / blockSize
+}
+
+// blockLocalRange returns the block-local byte bounds [localStart,localEnd] of the portion of
+// the object byte range [start,end] that falls inside block i (clamped to the object end).
+func blockLocalRange(i, start, end, blockSize, contentLength int64) (localStart, localEnd int64) {
+	bStart, bEnd := blockBounds(i, blockSize, contentLength)
+	return max(start, bStart) - bStart, min(end, bEnd) - bStart
 }
 
 // touchedBlocks returns the block indices a single-range request covers, or nil for a
@@ -131,25 +160,19 @@ func (s *Service) serveRangeFromBlockCache(
 	// populate budget — long-held serve buffers must not crowd out cold-miss populates — and
 	// NOT a cacheSemaphore count slot, which bounds concurrent cache WRITES and must not be
 	// held across a (possibly slow) client write). On budget decline, serve via the probe path.
+	// A fetch failure inside assembly (including a populate-budget decline) returns with the
+	// response untouched and the caller forwards upstream — the probe path's own fetch draws
+	// on the same populate budget, so retrying there could only repeat the outcome.
 	if rangeLen := rng.end - rng.start + 1; rangeLen <= meta.BlockSize {
-		weight := s.populateWeight(rangeLen)
+		weight := s.stagingWeight(rangeLen)
 		if s.serveStagingBudget == nil || s.serveStagingBudget.tryAcquireReadMiss(weight) {
 			assembled, aerr := s.serveAssembledRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng, startTime)
 			if s.serveStagingBudget != nil {
 				s.serveStagingBudget.release(weight)
 			}
-			// A budget-declined block fetch during assembly means the populate budget is
-			// saturated. Nothing is committed on that path, so retry via the probe path below
-			// — populate budget may have freed by then, and a still-declined fetch there falls
-			// through to upstream exactly as this path would have.
-			if !assembled && errors.Is(aerr, errCachePopulateDeclined) {
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly block fetch budget-declined - retrying via probe path")
-			} else {
-				return assembled, aerr
-			}
-		} else {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly buffer budget declined - serving range via probe path")
+			return assembled, aerr
 		}
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly buffer budget declined - serving range via probe path")
 	}
 
 	b0, bK := coveringBlocks(rng.start, rng.end, meta.BlockSize)
@@ -177,11 +200,6 @@ func (s *Service) serveRangeFromBlockCache(
 	w.WriteHeader(http.StatusPartialContent)
 
 	if _, berr := s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng.start, rng.end); berr != nil {
-		// A definitive stale signal from a mid-serve inline fetch invalidates the entry even
-		// though this response truncates: leaving it would repeat the truncation until TTL.
-		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
-			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-		}
 		return true, berr
 	}
 	metrics.RecordRangeFromCacheHit()
@@ -207,8 +225,12 @@ func (sw *sliceWriter) Write(p []byte) (int, error) {
 
 // maxPooledBlockBufBytes caps the capacity of block buffers the pool retains, so an entry
 // written under an unusually large historical block_size can't pin oversized buffers in the
-// pool forever.
-const maxPooledBlockBufBytes = 4 << 20
+// pool forever. It starts at the 4 MiB default block size and is raised (monotonically —
+// services in one process share the pool) to the configured block_size at service
+// construction, so pooling isn't silently disabled for deployments with larger blocks.
+var maxPooledBlockBufBytes atomic.Int64
+
+func init() { maxPooledBlockBufBytes.Store(4 << 20) }
 
 // blockBufPool recycles block-sized scratch buffers: pre-commit range/first-block assembly on
 // the serve paths, and the block staging buffers on the populate paths (fetchOneBlock,
@@ -229,7 +251,7 @@ func getBlockBuf(n int64) *[]byte {
 }
 
 func putBlockBuf(bp *[]byte) {
-	if int64(cap(*bp)) <= maxPooledBlockBufBytes {
+	if int64(cap(*bp)) <= maxPooledBlockBufBytes.Load() {
 		blockBufPool.Put(bp)
 	}
 }
@@ -263,19 +285,16 @@ func (s *Service) serveAssembledRange(
 	// abort with nothing committed. A nil-error short read means the cache delivered fewer
 	// bytes than the in-bounds request, which a present block never legitimately does — also
 	// treated as transient rather than as a missing block.
-	type gap struct{ idx, off, localStart, localEnd int64 }
-	var missing []gap
+	var missing []int64
 	off := int64(0)
 	for i := b0; i <= bK; i++ {
-		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
-		localStart := max(rng.start, bStart) - bStart
-		localEnd := min(rng.end, bEnd) - bStart
+		localStart, localEnd := blockLocalRange(i, rng.start, rng.end, meta.BlockSize, meta.ContentLength)
 		n := localEnd - localStart + 1
 		sw := &sliceWriter{dst: buf[off : off+n]}
 		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, sw)
 		switch {
 		case errors.Is(rerr, cache.ErrNotFound):
-			missing = append(missing, gap{idx: i, off: off, localStart: localStart, localEnd: localEnd})
+			missing = append(missing, i)
 		case rerr != nil:
 			return false, rerr
 		case sw.off != n:
@@ -285,41 +304,29 @@ func (s *Service) serveAssembledRange(
 	}
 
 	// Fetch whatever pass 1 found missing (coalesced across requests, bounded fan-out, stale
-	// signals prioritized over transient ones), then fill the gaps. Still pre-commit: a fetch
-	// or re-read failure falls through with the response untouched, and a definitive stale
-	// signal invalidates the entry so the fall-through re-establishes the current version.
+	// signals prioritized over transient ones — a stale signal also invalidates the entry
+	// inside fetchBlocksToCache), then fill the gaps. Still pre-commit: a fetch or re-read
+	// failure falls through with the response untouched.
 	if len(missing) > 0 {
-		idxs := make([]int64, len(missing))
-		for j, g := range missing {
-			idxs[j] = g.idx
-		}
-		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, idxs); ferr != nil {
-			if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
-				log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
-				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-			}
+		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, missing); ferr != nil {
 			return false, ferr
 		}
-		for _, g := range missing {
-			n := g.localEnd - g.localStart + 1
-			sw := &sliceWriter{dst: buf[g.off : g.off+n]}
-			rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, g.idx, g.localStart, g.localEnd, sw)
+		for _, i := range missing {
+			localStart, localEnd := blockLocalRange(i, rng.start, rng.end, meta.BlockSize, meta.ContentLength)
+			bStart, _ := blockBounds(i, meta.BlockSize, meta.ContentLength)
+			goff := bStart + localStart - rng.start
+			n := localEnd - localStart + 1
+			sw := &sliceWriter{dst: buf[goff : goff+n]}
+			rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, sw)
 			if rerr != nil || sw.off != n {
-				return false, fmt.Errorf("block %d assembly: fetched block unreadable (err=%v, %d of %d bytes)", g.idx, rerr, sw.off, n)
+				return false, fmt.Errorf("block %d assembly: fetched block unreadable (err=%v, %d of %d bytes)", i, rerr, sw.off, n)
 			}
 		}
 	}
 
 	// Committed serve: record hit/miss + serve metrics (only here, never on a fall-through),
 	// then write the response.
-	total := bK - b0 + 1
-	metrics.CacheBlockHits.Add(float64(total - int64(len(missing))))
-	if len(missing) == 0 {
-		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
-	} else {
-		metrics.CacheBlockMisses.Add(float64(len(missing)))
-		metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
-	}
+	recordBlockServeMetrics(bK-b0+1, int64(len(missing)))
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
@@ -335,12 +342,25 @@ func (s *Service) serveAssembledRange(
 	return true, nil
 }
 
+// streamOutcome describes what a committed block-range stream actually did, so callers can
+// record hit/miss metrics from facts instead of assumptions.
+type streamOutcome struct {
+	fromCache int64 // block slices fully read from cache (no fetch needed)
+	fetched   int64 // blocks recovered via an inline upstream fetch-and-cache
+	remainder bool  // tail streamed from upstream in one uncached range GET (degraded serve)
+}
+
 // streamBlockRange streams object bytes [start,end] (inclusive) from a block-mode entry's
 // cached blocks, in order, into w. The caller must have committed the status line + headers.
 // A block the cache reports absent (evicted since the caller last saw it) is fetched from
-// upstream (coalesced, budget-gated) and re-read instead of failing the serve; only a fetch or
-// re-read failure returns a non-nil error, which truncates the client body since headers are
-// already sent. Returns how many blocks were inline-fetched.
+// upstream (coalesced, budget-gated) and re-read — but at most maxInlineFetchesPerServe times
+// per serve, since a meta surviving mass block eviction would otherwise turn one committed
+// serve into N serial upstream fetches. Past the cap, on a fetch decline, or on any transient
+// read failure, the serve is SALVAGED rather than truncated: the remaining bytes stream from
+// upstream in a single uncached range GET (streamRemainderFromUpstream), and a cap-tripped
+// (degenerate) entry is invalidated so the next GET re-establishes it with one streaming
+// re-split. Only stale signals (a different object version — never mixable into a committed
+// body), client write failures, and a failed remainder still truncate.
 //
 // Multi-block serves are PIPELINED: a reader goroutine prefetches block i+1 into a pooled
 // buffer while block i's bytes are being written to the client, so the cache read latency and
@@ -350,39 +370,65 @@ func (s *Service) serveAssembledRange(
 // filling), reserved against the serve-staging byte budget (never the populate budget — see
 // NewService); on decline — and for single-block serves, where there is nothing to overlap —
 // it degrades to the direct sequential path.
-func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (out streamOutcome, err error) {
 	cw := &countingWriter{w: w}
 	defer func() {
 		if cw.written > 0 {
 			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
 		}
-		if err != nil {
-			log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block stream failed mid-serve")
-		}
 	}()
 	b0, bK := coveringBlocks(start, end, meta.BlockSize)
 	if b0 == bK {
-		return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
-	}
-	weight := s.populateWeight(2 * meta.BlockSize)
-	if s.serveStagingBudget != nil {
-		if !s.serveStagingBudget.tryAcquireReadMiss(weight) {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Pipeline buffer budget declined - streaming blocks sequentially")
-			return s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+		out, err = s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+	} else if weight := s.stagingWeight(2 * meta.BlockSize); s.serveStagingBudget == nil || s.serveStagingBudget.tryAcquireReadMiss(weight) {
+		if s.serveStagingBudget != nil {
+			defer s.serveStagingBudget.release(weight)
 		}
-		defer s.serveStagingBudget.release(weight)
+		out, err = s.streamBlockRangePipelined(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+	} else {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Pipeline buffer budget declined - streaming blocks sequentially")
+		out, err = s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 	}
-	return s.streamBlockRangePipelined(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
+	if err == nil {
+		return out, nil
+	}
+	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil {
+		// The committed response can still be completed byte-exact from upstream: cw.written
+		// counts exactly the bytes delivered so far (buffered blocks are written whole; a
+		// direct-streamed partial block advances it precisely), so the remainder picks up at
+		// start+cw.written. Cap-tripped entries are additionally invalidated — they have lost
+		// too many blocks to keep serving one recovery at a time.
+		absStart := start + cw.written
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Int64("from", absStart).Msg("Block serve degraded - streaming remainder from upstream uncached")
+		if rerr := s.streamRemainderFromUpstream(ctx, cw, bucket, key, accessKey, secretKey, meta, absStart, end); rerr != nil {
+			log.Warn().Err(rerr).Str("bucket", bucket).Str("key", key).Msg("Remainder stream failed - response truncated")
+			return out, rerr
+		}
+		if errors.Is(err, errBlocksMostlyAbsent) {
+			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		}
+		out.remainder = true
+		return out, nil
+	}
+	// Not salvageable: stale signal (version must not be mixed), client write failure, or the
+	// client is already gone. Route the noise accordingly — a disconnect is routine.
+	if ctx.Err() != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block stream aborted - client gone")
+	} else {
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block stream failed mid-serve")
+	}
+	return out, err
 }
 
 // streamBlockRangePipelined is streamBlockRange's overlapped core: an unbuffered channel
 // hands each prefetched block from the reader goroutine to the write loop, so exactly one
 // block is filling while one is draining (double buffering — two pooled buffers alive at
 // peak, which is what streamBlockRange reserved). Absent blocks are recovered by the reader
-// via readBlockSlice before the handoff; the first reader error ends the stream in order,
-// exactly where the sequential path would have failed. The stop channel unwinds the reader
-// (and returns its in-flight buffer) when the write loop exits early on a client write error.
-func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+// via readBlockSlice (bounded by the shared per-serve fetch cap) before the handoff; the
+// first reader error ends the stream in order, exactly where the sequential path would have
+// failed. The stop channel unwinds the reader (and returns its in-flight buffer) when the
+// write loop exits early on a client write error.
+func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (out streamOutcome, err error) {
 	b0, bK := coveringBlocks(start, end, meta.BlockSize)
 	type blockRead struct {
 		bufp      *[]byte
@@ -394,13 +440,12 @@ func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWri
 	stop := make(chan struct{})
 	go func() {
 		defer close(results)
+		fetchesLeft := int64(maxInlineFetchesPerServe)
 		for i := b0; i <= bK; i++ {
-			bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
-			localStart := max(start, bStart) - bStart
-			localEnd := min(end, bEnd) - bStart
+			localStart, localEnd := blockLocalRange(i, start, end, meta.BlockSize, meta.ContentLength)
 			br := blockRead{n: localEnd - localStart + 1}
 			br.bufp = getBlockBuf(br.n)
-			br.fetchedIt, br.err = s.readBlockSlice(ctx, bucket, key, accessKey, secretKey, meta, i, localStart, localEnd, (*br.bufp)[:br.n])
+			br.fetchedIt, br.err = s.readBlockSlice(ctx, bucket, key, accessKey, secretKey, meta, i, localStart, localEnd, (*br.bufp)[:br.n], &fetchesLeft)
 			select {
 			case results <- br:
 			case <-stop:
@@ -414,29 +459,40 @@ func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWri
 	}()
 	defer close(stop)
 	for br := range results {
+		if br.fetchedIt {
+			out.fetched++ // counted even when the post-fetch re-read failed: the miss happened
+		}
 		if br.err != nil {
 			putBlockBuf(br.bufp)
-			return fetched, br.err
+			return out, br.err
 		}
-		if br.fetchedIt {
-			fetched++
+		if !br.fetchedIt {
+			out.fromCache++
 		}
 		_, werr := cw.Write((*br.bufp)[:br.n])
 		putBlockBuf(br.bufp)
 		if werr != nil {
-			return fetched, werr
+			return out, werr
 		}
 	}
-	return fetched, nil
+	return out, nil
 }
 
 // readBlockSlice reads block idx's local byte range [localStart,localEnd] into dst
 // (len(dst) == the range length). A block the cache reports absent is fetched from upstream
 // (coalesced, budget-gated) and re-read — dst is scratch, never client-visible, so the retry
-// can't duplicate bytes in the response the way a direct-to-client re-read could. A nil-error
-// short read is reported as an error: a present block never legitimately under-delivers an
-// in-bounds range.
-func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, idx, localStart, localEnd int64, dst []byte) (fetched bool, err error) {
+// can't duplicate bytes in the response the way a direct-to-client re-read could. A non-nil
+// fetchesLeft caps how many absent blocks the serve recovers this way (the shared per-serve
+// budget); nil means uncapped (the pre-commit first-block check, where a failure falls
+// through instead of truncating). A nil-error short read is reported as an error: a present
+// block never legitimately under-delivers an in-bounds range.
+//
+// Failures that upstream could still satisfy — cap exhausted, fetch declined or transiently
+// failed, unreadable after fetch, transient read error — are wrapped in errBlockStreamDegraded
+// so a committed caller can salvage the response with one uncached remainder stream. Stale
+// signals pass through unwrapped: a different version must never be mixed into a committed
+// body (fetchBlocksToCache has already invalidated the entry).
+func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, idx, localStart, localEnd int64, dst []byte, fetchesLeft *int64) (fetched bool, err error) {
 	read := func() error {
 		sw := &sliceWriter{dst: dst}
 		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, idx, localStart, localEnd, sw)
@@ -446,41 +502,110 @@ func (s *Service) readBlockSlice(ctx context.Context, bucket, key, accessKey, se
 		return rerr
 	}
 	rerr := read()
-	if errors.Is(rerr, cache.ErrNotFound) {
-		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{idx}); ferr != nil {
-			return false, ferr
+	switch {
+	case rerr == nil:
+		return false, nil
+	case errors.Is(rerr, cache.ErrNotFound):
+		if fetchesLeft != nil {
+			if *fetchesLeft <= 0 {
+				return false, errBlocksMostlyAbsent
+			}
+			*fetchesLeft--
 		}
-		fetched = true
-		rerr = read()
+		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{idx}); ferr != nil {
+			if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
+				return false, ferr
+			}
+			return false, fmt.Errorf("block %d inline fetch failed (%w): %w", idx, ferr, errBlockStreamDegraded)
+		}
+		if rerr = read(); rerr != nil {
+			return true, fmt.Errorf("block %d unreadable after fetch (%w): %w", idx, rerr, errBlockStreamDegraded)
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("block %d read failed (%w): %w", idx, rerr, errBlockStreamDegraded)
 	}
-	return fetched, rerr
 }
 
 // streamBlockRangeSequential is streamBlockRange's unbuffered fallback (single-block serves,
 // or the pipeline's buffer budget declined): each block streams from cache directly into the
 // client writer with no staging buffer. Because the read target IS the response body here, an
 // absent block is refetched and re-read only when its failed read delivered nothing — a
-// partial write followed by a re-read would duplicate bytes in the response.
-func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+// partial write followed by a re-read would duplicate bytes in the response (a partial write
+// followed by the remainder salvage is fine: cw.written stays byte-exact).
+func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (out streamOutcome, err error) {
 	b0, bK := coveringBlocks(start, end, meta.BlockSize)
+	fetchesLeft := int64(maxInlineFetchesPerServe)
 	for i := b0; i <= bK; i++ {
-		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
-		localStart := max(start, bStart) - bStart
-		localEnd := min(end, bEnd) - bStart
+		localStart, localEnd := blockLocalRange(i, start, end, meta.BlockSize, meta.ContentLength)
 		before := cw.written
+		wasFetched := false
 		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
 		if errors.Is(berr, cache.ErrNotFound) && cw.written == before {
-			if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{i}); ferr != nil {
-				return fetched, ferr
+			if fetchesLeft <= 0 {
+				return out, errBlocksMostlyAbsent
 			}
-			fetched++
+			fetchesLeft--
+			if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{i}); ferr != nil {
+				if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
+					return out, ferr
+				}
+				return out, fmt.Errorf("block %d inline fetch failed (%w): %w", i, ferr, errBlockStreamDegraded)
+			}
+			out.fetched++
+			wasFetched = true
 			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
 		}
 		if berr != nil {
-			return fetched, berr
+			return out, fmt.Errorf("block %d stream failed (%w): %w", i, berr, errBlockStreamDegraded)
+		}
+		if !wasFetched {
+			out.fromCache++
 		}
 	}
-	return fetched, nil
+	return out, nil
+}
+
+// streamRemainderFromUpstream salvages a committed block serve whose entry can no longer
+// produce object bytes [absStart,absEnd]: one upstream range GET streams the remaining bytes
+// straight to the client, uncached (a pass-through rescue, not a populate — no budget, no
+// block writes). The response must be a 206 for exactly the requested range carrying the
+// entry's ETag: a different version cannot be mixed into an already-committed body, so a
+// changed ETag invalidates the entry and truncates, and a missing one (unverifiable) just
+// truncates.
+func (s *Service) streamRemainderFromUpstream(ctx context.Context, cw *countingWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, absStart, absEnd int64) error {
+	resp, err := s.forwarder.DoConditionalGetRequest(ctx, bucket, key, accessKey, secretKey, "", 0, fmt.Sprintf("bytes=%d-%d", absStart, absEnd))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		return errBlockUpstreamGone
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("remainder fetch: unexpected status %d (want 206)", resp.StatusCode)
+	}
+	respETag := resp.Header.Get("ETag")
+	if respETag == "" {
+		return fmt.Errorf("remainder fetch: response missing ETag, cannot verify version")
+	}
+	if respETag != meta.ETag {
+		s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		return errBlockETagMismatch
+	}
+	if rs, re, _, ok := parseContentRange(resp.Header.Get("Content-Range")); !ok || rs != absStart || re != absEnd {
+		return fmt.Errorf("remainder fetch: content-range bounds %d-%d (ok=%t), want %d-%d", rs, re, ok, absStart, absEnd)
+	}
+	want := absEnd - absStart + 1
+	n, cerr := io.Copy(cw, resp.Body)
+	if cerr != nil {
+		return cerr
+	}
+	if n != want {
+		return fmt.Errorf("remainder fetch: body %d bytes, want %d", n, want)
+	}
+	return nil
 }
 
 // serveFullObjectFromBlockCache serves a full-object GET from a block-mode entry. A complete
@@ -507,23 +632,19 @@ func (s *Service) serveFullObjectFromBlockCache(
 	// decline the probe-first path below still serves.
 	if meta.BlocksComplete {
 		firstLen := min(meta.BlockSize, meta.ContentLength)
-		weight := s.populateWeight(firstLen)
+		weight := s.stagingWeight(firstLen)
 		if s.serveStagingBudget == nil || s.serveStagingBudget.tryAcquireReadMiss(weight) {
 			served, err = s.serveCompleteFromBlocks(ctx, w, bucket, key, accessKey, secretKey, meta, startTime)
 			if s.serveStagingBudget != nil {
 				s.serveStagingBudget.release(weight)
 			}
-			// A budget-declined first-block fetch means the populate budget is saturated; the
-			// probe path below can still assemble and serve from cache if budget frees, so
-			// retry there instead of surrendering directly to a full upstream GET.
-			if !served && errors.Is(err, errCachePopulateDeclined) {
-				log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve block fetch budget-declined - retrying via probe path")
-			} else {
-				return served, err
-			}
-		} else {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
+			// Any pre-commit failure (including a budget-declined first-block fetch) returns
+			// served=false with the response untouched and the caller forwards upstream — the
+			// probe path's fetches draw on the same populate budget, so retrying there could
+			// only repeat the outcome.
+			return served, err
 		}
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
 	}
 
 	// Stamp the promotion's write-start BEFORE the assembly work below: any invalidation that
@@ -552,19 +673,24 @@ func (s *Service) serveFullObjectFromBlockCache(
 
 	// Every block is now present: promote the entry to complete (async, tombstone-aware with
 	// the pre-assembly timestamp, so a racing invalidation blocks the write) — later full GETs
-	// then take the probe-free path instead of re-probing every block. Best-effort: a skipped
-	// or failed promotion only means the next full GET probes again.
+	// then take the probe-free path instead of re-probing every block. The rewrite carries the
+	// entry's REMAINING TTL, never a fresh one: promotion does not consult upstream, so
+	// extending the lifetime would reset the staleness clock (up to doubling the configured
+	// bound after an out-of-band overwrite) and guarantee a window where the meta outlives
+	// every block. Best-effort: a skipped or failed promotion only means the next full GET
+	// probes again.
 	if !meta.BlocksComplete {
-		promoted := *meta
-		promoted.BlocksComplete = true
-		ttl := int(s.config.Cache.TTL.Seconds())
-		go func() {
-			pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
-			defer cancel()
-			if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, ttl, writeStartTime); perr != nil {
-				log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
-			}
-		}()
+		if remaining := s.remainingMetaTTL(meta); remaining > 0 {
+			promoted := *meta
+			promoted.BlocksComplete = true
+			go func() {
+				pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
+				defer cancel()
+				if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, remaining, writeStartTime); perr != nil {
+					log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
+				}
+			}()
+		}
 	}
 
 	meta.WriteHeaders(w)
@@ -572,15 +698,24 @@ func (s *Service) serveFullObjectFromBlockCache(
 	w.WriteHeader(meta.StatusCode)
 
 	if _, berr := s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, 0, meta.ContentLength-1); berr != nil {
-		// Same rationale as the range path above: a stale signal surfaced by a mid-serve
-		// inline fetch must invalidate even though the response truncates.
-		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
-			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-		}
 		return true, berr
 	}
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
 	return true, nil
+}
+
+// remainingMetaTTL returns the seconds left of meta's original TTL, from its CachedAt stamp.
+// Returns 0 — meaning "do not rewrite" — when the entry is already past its TTL or its age is
+// unknown (CachedAt == 0: entries written before the field existed).
+func (s *Service) remainingMetaTTL(meta *cache.CachedObjectMeta) int {
+	if meta.CachedAt <= 0 {
+		return 0
+	}
+	rem := int64(s.config.Cache.TTL.Seconds()) - (time.Now().Unix() - meta.CachedAt)
+	if rem <= 0 {
+		return 0
+	}
+	return int(rem)
 }
 
 // serveCompleteFromBlocks serves a full-object GET from a BlocksComplete entry with one cache
@@ -607,28 +742,10 @@ func (s *Service) serveCompleteFromBlocks(
 	defer putBlockBuf(bufp)
 	buf := (*bufp)[:firstLen]
 
-	fetched := int64(0)
-	readFirst := func() error {
-		sw := &sliceWriter{dst: buf}
-		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, 0, 0, firstEnd, sw)
-		if rerr == nil && sw.off != firstLen {
-			return fmt.Errorf("block 0 complete-serve: short read %d of %d bytes", sw.off, firstLen)
-		}
-		return rerr
-	}
-	rerr := readFirst()
-	if errors.Is(rerr, cache.ErrNotFound) {
-		// Evicted since populate: recover pre-commit, exactly like the assembled-range path.
-		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{0}); ferr != nil {
-			if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
-				log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
-				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-			}
-			return false, ferr
-		}
-		fetched++
-		rerr = readFirst()
-	}
+	// Pre-commit first block via the shared read/recover protocol (uncapped fetch — this
+	// doubles as the existence check, and a failure here falls through with the response
+	// untouched; a stale signal has already invalidated the entry inside fetchBlocksToCache).
+	firstFetched, rerr := s.readBlockSlice(ctx, bucket, key, accessKey, secretKey, meta, 0, 0, firstEnd, buf, nil)
 	if rerr != nil {
 		return false, rerr
 	}
@@ -636,6 +753,12 @@ func (s *Service) serveCompleteFromBlocks(
 	meta.WriteHeaders(w)
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(meta.StatusCode)
+	out := streamOutcome{}
+	if firstFetched {
+		out.fetched++
+	} else {
+		out.fromCache++
+	}
 	n, werr := w.Write(buf)
 	if n > 0 {
 		metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
@@ -644,25 +767,25 @@ func (s *Service) serveCompleteFromBlocks(
 	if werr != nil {
 		berr = werr
 	} else if lastBlock > 0 {
-		var streamed int64
-		streamed, berr = s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
-		fetched += streamed
-		// A definitive stale signal from a mid-serve inline fetch must still invalidate,
-		// even though headers are committed (this response truncates either way): leaving
-		// the stale BlocksComplete entry in place would have every later full GET commit
-		// and truncate the same way until the meta TTL expires.
-		if errors.Is(berr, errBlockETagMismatch) || errors.Is(berr, errBlockUpstreamGone) {
-			log.Debug().Err(berr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
-			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-		}
+		var rest streamOutcome
+		rest, berr = s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
+		out.fromCache += rest.fromCache
+		out.fetched += rest.fetched
 	}
+	// Hit/miss reflects what actually happened: blocks read from cache are hits; inline
+	// fetches, remainder-streamed bytes, and blocks never reached on an aborted serve all
+	// count against the entry — never as hits for blocks that were never read.
 	total := lastBlock + 1
-	metrics.CacheBlockHits.Add(float64(total - fetched))
-	if fetched == 0 {
-		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
-	} else {
-		metrics.CacheBlockMisses.Add(float64(fetched))
-		metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+	metrics.CacheBlockHits.Add(float64(out.fromCache))
+	if miss := total - out.fromCache; miss > 0 {
+		metrics.CacheBlockMisses.Add(float64(miss))
+	}
+	if berr == nil {
+		if out.fromCache == total {
+			metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
+		} else {
+			metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+		}
 	}
 	if berr != nil {
 		return true, berr
@@ -706,9 +829,28 @@ func (s *Service) fetchBlocksToCache(ctx context.Context, bucket, key, accessKey
 	}
 	_ = g.Wait()
 	if stale != nil {
+		// A definitive stale signal means the cached meta describes a version upstream no
+		// longer serves. Invalidate HERE — every block fetch flows through this point — so no
+		// caller can forget it and leave the stale meta to fail again until TTL.
+		// invalidateStaleBlockMeta is ETag-guarded and idempotent, so central invocation is
+		// safe for every caller.
+		log.Debug().Err(stale).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
+		s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
 		return stale
 	}
 	return transient
+}
+
+// recordBlockServeMetrics records per-block hit/miss counts and the full/partial serve
+// counter for a committed block serve of total covering blocks, missed of which were fetched.
+func recordBlockServeMetrics(total, missed int64) {
+	metrics.CacheBlockHits.Add(float64(total - missed))
+	if missed == 0 {
+		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
+	} else {
+		metrics.CacheBlockMisses.Add(float64(missed))
+		metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+	}
 }
 
 // fetchOneBlock fetches a single block from upstream (an aligned range GET) and writes it to
@@ -884,27 +1026,18 @@ func (s *Service) ensureBlocksCached(ctx context.Context, bucket, key, accessKey
 		return errBlockAssemblyWouldAmplify
 	}
 	if len(missing) == 0 {
-		metrics.CacheBlockHits.Add(float64(total))
-		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
+		recordBlockServeMetrics(total, 0)
 		return nil
 	}
 	if err := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, missing); err != nil {
-		// A definitive "stale entry" signal — the cached version was overwritten (ETag
-		// mismatch) or the object is gone/forbidden (404/403) out of band — means the cached
-		// block-mode meta is stale. Invalidate it so the caller's fall-through re-establishes
-		// the current state, instead of repeating this failure on every read until the meta
-		// TTL expires. Transient failures (budget shed, 5xx, upstream blip) leave the
-		// still-valid meta in place to retry later.
-		if errors.Is(err, errBlockETagMismatch) || errors.Is(err, errBlockUpstreamGone) {
-			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
-			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-		}
+		// A definitive stale signal has already invalidated the entry inside
+		// fetchBlocksToCache, so the caller's fall-through re-establishes the current state.
+		// Transient failures (budget shed, 5xx, upstream blip) leave the still-valid meta in
+		// place to retry later.
 		return err
 	}
 	// Committed partial-hit serve: the covering blocks are now all present.
-	metrics.CacheBlockHits.Add(float64(total - int64(len(missing))))
-	metrics.CacheBlockMisses.Add(float64(len(missing)))
-	metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+	recordBlockServeMetrics(total, int64(len(missing)))
 	return nil
 }
 

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -48,22 +48,14 @@ var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 // isBlockEligibleSize reports whether an object of the given content length is block-cached on
 // the read-miss path (RFC 0001): block caching is enabled and the object is at least one block
 // (BlockSize is the whole-vs-block boundary — a sub-block object is whole-cached, since blocking
-// it would just store a single blob). BlockMinObjectSize raises that boundary when set: objects
-// below it are whole-cached even though they span multiple blocks, because a whole-cached warm
-// GET costs 2 cache ops while a block-mode one is linear in block count — block caching only
-// pays off once an object is large enough that whole-caching it is wasteful. A negative/unknown
-// length is not eligible. Requiring BlockSize > 0 keeps a config that enables block caching but
-// leaves BlockSize at 0 (e.g. a Config built directly, bypassing Load's normalization) from
-// dividing by zero in block arithmetic. A read miss for a block-eligible object populates
-// blocks, not a whole blob.
+// it would just store a single blob). A negative/unknown length is not eligible. Requiring
+// BlockSize > 0 keeps a config that enables block caching but leaves BlockSize at 0 (e.g. a
+// Config built directly, bypassing Load's normalization) from dividing by zero in block
+// arithmetic. A read miss for a block-eligible object populates blocks, not a whole blob.
 func (s *Service) isBlockEligibleSize(contentLength int64) bool {
-	boundary := s.config.Cache.BlockSize
-	if s.config.Cache.BlockMinObjectSize > boundary {
-		boundary = s.config.Cache.BlockMinObjectSize
-	}
 	return s.config.Cache.BlockCachingEnabled &&
 		s.config.Cache.BlockSize > 0 &&
-		contentLength >= boundary
+		contentLength >= s.config.Cache.BlockSize
 }
 
 // blockBounds returns the inclusive object-byte bounds [start,end] of block i for an object

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -362,11 +362,16 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 	return cw.written, nil
 }
 
-// serveFullObjectFromBlockCache serves a full-object GET from a block-mode entry by assembling
-// all of its blocks (fetching any missing), streaming them in order. It returns served=false,
-// without writing anything, when the blocks cannot be populated — the caller then falls through
-// to the miss path. A block-mode meta always has ContentLength >= BlockSize >= 1, so there is no
-// zero-byte case to handle here.
+// serveFullObjectFromBlockCache serves a full-object GET from a block-mode entry. A complete
+// entry (meta.BlocksComplete — every block present when the meta was written) is served
+// probe-free: the first block is read into a pooled buffer pre-commit (so a gone-first-block
+// still falls through cleanly), then the rest stream with an inline fetch recovering any block
+// evicted since populate — one cache op per block instead of the probe pass's two. Entries not
+// known complete take the probe-first path (the mostly-missing amplification bail needs the
+// up-front missing count) and are promoted to complete after a successful full assembly, so
+// they pay the probe pass at most once. It returns served=false, without writing anything, when
+// the blocks cannot be produced — the caller then falls through to the miss path. A block-mode
+// meta always has ContentLength >= BlockSize >= 1, so there is no zero-byte case to handle here.
 func (s *Service) serveFullObjectFromBlockCache(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -375,6 +380,32 @@ func (s *Service) serveFullObjectFromBlockCache(
 	startTime time.Time,
 ) (served bool, err error) {
 	lastBlock := (meta.ContentLength - 1) / meta.BlockSize
+
+	// Probe-free fast path for complete entries. The first-block buffer (<= one block) is
+	// reserved against the populate byte budget like the assembled-range path; on decline the
+	// probe-first path below still serves.
+	if meta.BlocksComplete {
+		firstLen := min(meta.BlockSize, meta.ContentLength)
+		weight := s.populateWeight(firstLen)
+		if s.populateBudget == nil || s.populateBudget.tryAcquireReadMiss(weight) {
+			served, err = s.serveCompleteFromBlocks(ctx, w, bucket, key, accessKey, secretKey, meta, startTime)
+			if s.populateBudget != nil {
+				s.populateBudget.release(weight)
+			}
+			if served || err != nil {
+				return served, err
+			}
+			// (false, nil): first block unrecoverable pre-commit — fall through to the miss
+			// path via the caller (a probe pass over an entry we already failed to read
+			// would just repeat the failure).
+			return false, nil
+		}
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
+	}
+
+	// Stamp the promotion's write-start BEFORE the assembly work below: any invalidation that
+	// lands during it is then provably newer and blocks the promoted meta write.
+	writeStartTime := startTime.UnixNano()
 
 	// A full GET must produce every block. bailIfMostlyMissing=true asks ensureBlocksCached to
 	// fall through (rather than assemble) when most blocks are absent — e.g. only a footer range
@@ -396,6 +427,23 @@ func (s *Service) serveFullObjectFromBlockCache(
 		return false, ferr
 	}
 
+	// Every block is now present: promote the entry to complete (async, tombstone-aware with
+	// the pre-assembly timestamp, so a racing invalidation blocks the write) — later full GETs
+	// then take the probe-free path instead of re-probing every block. Best-effort: a skipped
+	// or failed promotion only means the next full GET probes again.
+	if !meta.BlocksComplete {
+		promoted := *meta
+		promoted.BlocksComplete = true
+		ttl := int(s.config.Cache.TTL.Seconds())
+		go func() {
+			pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
+			defer cancel()
+			if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, ttl, writeStartTime); perr != nil {
+				log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
+			}
+		}()
+	}
+
 	meta.WriteHeaders(w)
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(meta.StatusCode)
@@ -405,6 +453,124 @@ func (s *Service) serveFullObjectFromBlockCache(
 	}
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
 	return true, nil
+}
+
+// serveCompleteFromBlocks serves a full-object GET from a BlocksComplete entry with one cache
+// op per block and no probe pass. The first block is read into a pooled buffer BEFORE headers
+// commit: if it is absent (evicted since populate) it is fetched pre-commit, and if that fails
+// the response is untouched — (false, nil) lets the caller fall through to the miss path, and a
+// definitive stale signal invalidates the entry first. After commit, the remaining blocks
+// stream with an inline fetch recovering any absent one; only a fetch failure there truncates
+// (headers are already sent), which is the same terminal behavior the probe path has for a
+// block evicted between probe and stream. Hit/miss metrics count inline-fetched blocks as
+// misses, recorded once the serve outcome is known.
+func (s *Service) serveCompleteFromBlocks(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key, accessKey, secretKey string,
+	meta *cache.CachedObjectMeta,
+	startTime time.Time,
+) (served bool, err error) {
+	lastBlock := (meta.ContentLength - 1) / meta.BlockSize
+	_, firstEnd := blockBounds(0, meta.BlockSize, meta.ContentLength)
+	firstLen := firstEnd + 1
+
+	bufp := getAssemblyBuf(firstLen)
+	defer putAssemblyBuf(bufp)
+	buf := (*bufp)[:firstLen]
+
+	fetched := int64(0)
+	readFirst := func() error {
+		sw := &sliceWriter{dst: buf}
+		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, 0, 0, firstEnd, sw)
+		if rerr == nil && sw.off != firstLen {
+			return fmt.Errorf("block 0 complete-serve: short read %d of %d bytes", sw.off, firstLen)
+		}
+		return rerr
+	}
+	rerr := readFirst()
+	if errors.Is(rerr, cache.ErrNotFound) {
+		// Evicted since populate: recover pre-commit, exactly like the assembled-range path.
+		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{0}); ferr != nil {
+			if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
+				log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
+				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+			}
+			return false, ferr
+		}
+		fetched++
+		rerr = readFirst()
+	}
+	if rerr != nil {
+		return false, rerr
+	}
+
+	meta.WriteHeaders(w)
+	writeCacheStatus(w, XCacheHit)
+	w.WriteHeader(meta.StatusCode)
+	n, werr := w.Write(buf)
+	if n > 0 {
+		metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+	}
+	var berr error
+	if werr != nil {
+		berr = werr
+	} else if lastBlock > 0 {
+		var streamed int64
+		streamed, berr = s.streamBlockRangeInlineFetch(ctx, w, bucket, key, accessKey, secretKey, meta, firstEnd+1, meta.ContentLength-1)
+		fetched += streamed
+	}
+	total := lastBlock + 1
+	metrics.CacheBlockHits.Add(float64(total - fetched))
+	if fetched == 0 {
+		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
+	} else {
+		metrics.CacheBlockMisses.Add(float64(fetched))
+		metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+	}
+	if berr != nil {
+		return true, berr
+	}
+	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	return true, nil
+}
+
+// streamBlockRangeInlineFetch streams object bytes [start,end] from a block-mode entry's
+// blocks like streamBlockRange, but a block the read reports absent is fetched from upstream
+// (coalesced, budget-gated) and re-read instead of failing the serve — recovering blocks
+// evicted after a BlocksComplete meta was written. Headers are already committed, so a fetch
+// or re-read failure still returns a non-nil error (truncated body). Returns how many blocks
+// were inline-fetched.
+func (s *Service) streamBlockRangeInlineFetch(ctx context.Context, w http.ResponseWriter, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, start, end int64) (fetched int64, err error) {
+	b0, bK := coveringBlocks(start, end, meta.BlockSize)
+	cw := &countingWriter{w: w}
+	defer func() {
+		if cw.written > 0 {
+			metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
+		}
+	}()
+	for i := b0; i <= bK; i++ {
+		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
+		localStart := max(start, bStart) - bStart
+		localEnd := min(end, bEnd) - bStart
+		before := cw.written
+		berr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+		// Retry only a block whose read delivered NOTHING (an absent key never writes): a
+		// partial write followed by a re-read would duplicate bytes in the response.
+		if errors.Is(berr, cache.ErrNotFound) && cw.written == before {
+			if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, []int64{i}); ferr != nil {
+				log.Warn().Err(ferr).Str("bucket", bucket).Str("key", key).Int64("block", i).Msg("Block vanished mid-serve and inline fetch failed")
+				return fetched, ferr
+			}
+			fetched++
+			berr = s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, cw)
+		}
+		if berr != nil {
+			log.Warn().Err(berr).Str("bucket", bucket).Str("key", key).Int64("block", i).Msg("Block unreadable mid-serve")
+			return fetched, berr
+		}
+	}
+	return fetched, nil
 }
 
 // fetchBlocksToCache fetches the given missing blocks from upstream and writes them to cache,
@@ -696,6 +862,9 @@ func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, m
 	if _, err := io.ReadFull(r, probe[:]); err != io.EOF {
 		return fmt.Errorf("block split: upstream body longer than Content-Length %d", meta.ContentLength)
 	}
+	// Every block was just written, so stamp the meta complete: full-object serves can skip
+	// the per-block probe pass and stream optimistically.
+	meta.BlocksComplete = true
 	if _, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime); err != nil {
 		return err
 	}

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -92,8 +92,11 @@ func touchedBlocks(rangeHeader string, totalSize, blockSize int64) []int64 {
 }
 
 // serveRangeFromBlockCache serves a single-range request from a block-mode cache entry
-// (meta.BlockSize > 0). It probes the covering blocks, fetches any that are missing (from
-// upstream, coalesced), then streams the requested bytes assembled from those blocks.
+// (meta.BlockSize > 0). A range no longer than one block — the hot footer/row-group pattern —
+// is assembled probe-free into a pooled buffer (serveAssembledRange): each present block is
+// read exactly once, with the read itself acting as the existence check. Larger ranges (and
+// small ones the assembly-buffer budget declines) take the probe-first path: probe the
+// covering blocks, fetch any missing, then stream.
 //
 // It returns served=true when it has produced a complete client response (a 206 body, or a
 // definitive 416). It returns served=false, without having written anything to w, when the
@@ -117,6 +120,27 @@ func (s *Service) serveRangeFromBlockCache(
 		return true, nil
 	}
 	rng := ranges[0]
+
+	// Probe-free hot path: a range no longer than one block covers at most two blocks, so the
+	// requested bytes are assembled into a pooled buffer BEFORE anything is committed. Each
+	// present block is read exactly ONCE (the read doubles as the existence probe, halving
+	// warm-serve cache ops versus the probe-then-stream path below); a missing block is
+	// discovered by that same read and fetched pre-commit, so every failure still leaves the
+	// response unwritten for a clean upstream fall-through — identical semantics, fewer ops.
+	// The buffer (<= one block) is reserved against the populate byte budget — but NOT a
+	// cacheSemaphore count slot, which bounds concurrent cache WRITES and must not be held
+	// across a (possibly slow) client write. On budget decline, serve via the probe path.
+	if rangeLen := rng.end - rng.start + 1; rangeLen <= meta.BlockSize {
+		weight := s.populateWeight(rangeLen)
+		if s.populateBudget == nil || s.populateBudget.tryAcquireReadMiss(weight) {
+			if s.populateBudget != nil {
+				defer s.populateBudget.release(weight)
+			}
+			return s.serveAssembledRange(ctx, w, bucket, key, accessKey, secretKey, meta, rng, startTime)
+		}
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Assembly buffer budget declined - serving range via probe path")
+	}
+
 	b0, bK := coveringBlocks(rng.start, rng.end, meta.BlockSize)
 
 	// Make the covering blocks present (probe + fetch any missing, coalesced/concurrent). Cap the
@@ -143,6 +167,150 @@ func (s *Service) serveRangeFromBlockCache(
 
 	if _, berr := s.streamBlockRange(ctx, w, bucket, key, meta, rng.start, rng.end); berr != nil {
 		return true, berr
+	}
+	metrics.RecordRangeFromCacheHit()
+	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	return true, nil
+}
+
+// sliceWriter writes into a fixed destination slice, failing on overflow. Used to land a
+// block's bytes at their exact offset in a pre-commit assembly buffer.
+type sliceWriter struct {
+	dst []byte
+	off int64
+}
+
+func (sw *sliceWriter) Write(p []byte) (int, error) {
+	n := copy(sw.dst[sw.off:], p)
+	sw.off += int64(n)
+	if n < len(p) {
+		return n, io.ErrShortBuffer // more bytes than the requested block-local range
+	}
+	return n, nil
+}
+
+// maxPooledAssemblyBufBytes caps the capacity of assembly buffers the pool retains, so an
+// entry written under an unusually large historical block_size can't pin oversized buffers
+// in the pool forever.
+const maxPooledAssemblyBufBytes = 4 << 20
+
+// assemblyBufPool recycles pre-commit range-assembly buffers. Buffers are handed out by
+// capacity; a request larger than a pooled buffer's capacity allocates fresh.
+var assemblyBufPool sync.Pool
+
+func getAssemblyBuf(n int64) *[]byte {
+	if v := assemblyBufPool.Get(); v != nil {
+		bp := v.(*[]byte)
+		if int64(cap(*bp)) >= n {
+			return bp
+		}
+		assemblyBufPool.Put(bp) // too small for this request; keep it for a smaller one
+	}
+	b := make([]byte, n)
+	return &b
+}
+
+func putAssemblyBuf(bp *[]byte) {
+	if int64(cap(*bp)) <= maxPooledAssemblyBufBytes {
+		assemblyBufPool.Put(bp)
+	}
+}
+
+// serveAssembledRange serves a single-range request (spanning at most two blocks) by
+// assembling the requested bytes from the entry's blocks into a pooled buffer before
+// committing anything. Present blocks are read exactly once — the read itself is the
+// existence check, there is no separate probe pass — and blocks the read reports absent are
+// fetched (coalesced, bounded) and re-read, all BEFORE headers are written. It returns
+// served=true only once the 206 is committed; any assembly failure returns served=false with
+// the response untouched, so the caller falls through to upstream exactly as the probe-first
+// path would. Block hit/miss and range-served metrics are recorded only on a committed
+// serve, and a definitive stale signal invalidates the entry — both matching
+// ensureBlocksCached.
+func (s *Service) serveAssembledRange(
+	ctx context.Context,
+	w http.ResponseWriter,
+	bucket, key, accessKey, secretKey string,
+	meta *cache.CachedObjectMeta,
+	rng byteRange,
+	startTime time.Time,
+) (served bool, err error) {
+	b0, bK := coveringBlocks(rng.start, rng.end, meta.BlockSize)
+	rangeLen := rng.end - rng.start + 1
+	bufp := getAssemblyBuf(rangeLen)
+	defer putAssemblyBuf(bufp)
+	buf := (*bufp)[:rangeLen]
+
+	// Pass 1: read every covering block's slice of the range into place. ErrNotFound marks
+	// the block missing (exactly what the old probe detected). Any other error is transient —
+	// abort with nothing committed. A nil-error short read means the cache delivered fewer
+	// bytes than the in-bounds request, which a present block never legitimately does — also
+	// treated as transient rather than as a missing block.
+	type gap struct{ idx, off, localStart, localEnd int64 }
+	var missing []gap
+	off := int64(0)
+	for i := b0; i <= bK; i++ {
+		bStart, bEnd := blockBounds(i, meta.BlockSize, meta.ContentLength)
+		localStart := max(rng.start, bStart) - bStart
+		localEnd := min(rng.end, bEnd) - bStart
+		n := localEnd - localStart + 1
+		sw := &sliceWriter{dst: buf[off : off+n]}
+		rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, sw)
+		switch {
+		case errors.Is(rerr, cache.ErrNotFound):
+			missing = append(missing, gap{idx: i, off: off, localStart: localStart, localEnd: localEnd})
+		case rerr != nil:
+			return false, rerr
+		case sw.off != n:
+			return false, fmt.Errorf("block %d assembly: short read %d of %d bytes", i, sw.off, n)
+		}
+		off += n
+	}
+
+	// Fetch whatever pass 1 found missing (coalesced across requests, bounded fan-out, stale
+	// signals prioritized over transient ones), then fill the gaps. Still pre-commit: a fetch
+	// or re-read failure falls through with the response untouched, and a definitive stale
+	// signal invalidates the entry so the fall-through re-establishes the current version.
+	if len(missing) > 0 {
+		idxs := make([]int64, len(missing))
+		for j, g := range missing {
+			idxs[j] = g.idx
+		}
+		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, idxs); ferr != nil {
+			if errors.Is(ferr, errBlockETagMismatch) || errors.Is(ferr, errBlockUpstreamGone) {
+				log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
+				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+			}
+			return false, ferr
+		}
+		for _, g := range missing {
+			n := g.localEnd - g.localStart + 1
+			sw := &sliceWriter{dst: buf[g.off : g.off+n]}
+			rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, g.idx, g.localStart, g.localEnd, sw)
+			if rerr != nil || sw.off != n {
+				return false, fmt.Errorf("block %d assembly: fetched block unreadable (err=%v, %d of %d bytes)", g.idx, rerr, sw.off, n)
+			}
+		}
+	}
+
+	// Committed serve: record hit/miss + serve metrics (only here, never on a fall-through),
+	// then write the response.
+	total := bK - b0 + 1
+	metrics.CacheBlockHits.Add(float64(total - int64(len(missing))))
+	if len(missing) == 0 {
+		metrics.CacheBlockRangeServed.WithLabelValues("full_hit").Inc()
+	} else {
+		metrics.CacheBlockMisses.Add(float64(len(missing)))
+		metrics.CacheBlockRangeServed.WithLabelValues("partial_hit").Inc()
+	}
+	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
+	writeCacheStatus(w, XCacheHit)
+	w.WriteHeader(http.StatusPartialContent)
+	n, werr := w.Write(buf)
+	if n > 0 {
+		metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
+	}
+	if werr != nil {
+		return true, werr
 	}
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1387,3 +1387,43 @@ func TestBlockCache_AssemblyBudgetContentionRetriesViaProbePath(t *testing.T) {
 		t.Error("block 1 not cached after probe-path retry")
 	}
 }
+
+// An object at or above BlockSize but below block_min_object_size is whole-cached: it never
+// pays per-block serve overhead, and warm serves come from the whole-body path.
+func TestBlockCache_MinObjectSizeWholeCachesSmallObjects(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // 10 bytes: >= BlockSize(4), < min(20)
+	svc, c := newBlockService(t, mock)
+	svc.config.Cache.BlockMinObjectSize = 20
+
+	// Cold full GET: the miss path must whole-cache, not block-split.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if w.Code != http.StatusOK || w.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("cold full GET: code=%d body=%q", w.Code, w.Body.String())
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated after cold full GET")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if meta.BlockSize != 0 {
+		t.Fatalf("meta.BlockSize = %d, want 0 (whole-cached below block_min_object_size)", meta.BlockSize)
+	}
+
+	// Warm full GET and range both serve from the whole-body entry.
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("warm full GET: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" || w2.Header().Get("X-Cache") != XCacheHit {
+		t.Fatalf("warm full GET: code=%d body=%q x-cache=%q", w2.Code, w2.Body.String(), w2.Header().Get("X-Cache"))
+	}
+	w3 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w3, blockGet(wowBucket, wowKey, "bytes=2-5")); err != nil {
+		t.Fatalf("warm range: %v", err)
+	}
+	if w3.Code != http.StatusPartialContent || w3.Body.String() != "CDEF" {
+		t.Fatalf("warm range: code=%d body=%q, want 206 CDEF", w3.Code, w3.Body.String())
+	}
+}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1633,3 +1633,124 @@ func TestBlockCache_CompleteEntryBudgetContentionRetriesViaProbePath(t *testing.
 		t.Errorf("X-Cache=%q, want %q (probe-path retry should serve from cache)", got, XCacheHit)
 	}
 }
+
+// A warm multi-block serve whose pipeline buffer reservation the budget declines degrades to
+// the direct sequential stream and still serves byte-exact from cache — budget pressure slows
+// a warm serve down, it never surrenders it to upstream. Budget of 5: the complete path's
+// first-block reservation (2) leaves 3, so the pipeline's two-buffer reservation (4) declines.
+func TestBlockCache_PipelineBudgetDeclineDegradesToSequential(t *testing.T) {
+	object := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") // 40 bytes → 20 2-byte blocks
+	mock := newBlockMock(object, `"v1"`)
+	svc, c := newBlockServiceWithBudget(t, mock, 2, 5)
+
+	// Cold full GET: the populate reserves min(40, budget)=5 and releases before the meta lands.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated after cold full GET")
+	}
+
+	before := mock.blockGets.Load()
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("warm full GET under budget pressure: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != string(object) {
+		t.Fatalf("warm full GET: code=%d body=%q, want the exact object", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q", got, XCacheHit)
+	}
+	if after := mock.blockGets.Load(); after != before {
+		t.Errorf("warm sequential serve fetched %d blocks from upstream, want 0", after-before)
+	}
+}
+
+// A warm range wider than one block takes the probe-first path and streams its covering blocks
+// through the pipeline; a block the probe found missing is fetched first, and the assembled 206
+// is byte-exact across all block boundaries.
+func TestBlockCache_WarmMultiBlockRangeServesPipelined(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // blocks [0..3][4..7][8..9]
+	svc, c := newBlockService(t, mock)
+
+	// Cold miss on bytes=0-7 populates blocks 0 and 1 (and the meta) in the background.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-7")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated")
+	}
+
+	// bytes=0-9 (10 bytes > BlockSize 4) skips the assembled-range path: probe finds block 2
+	// missing, fetches it, then the three blocks stream pipelined.
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=0-9")); err != nil {
+		t.Fatalf("warm multi-block range: %v", err)
+	}
+	if w2.Code != http.StatusPartialContent || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("multi-block range: code=%d body=%q, want 206 ABCDEFGHIJ", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q", got, XCacheHit)
+	}
+	if !c.BlockExists(context.Background(), wowBucket, wowKey, `"v1"`, 4, 2) {
+		t.Error("block 2 not cached after the probe-path fetch")
+	}
+}
+
+// failAfterWriter fails every Write once `remaining` bytes have been accepted, simulating a
+// client that disconnects mid-body.
+type failAfterWriter struct {
+	http.ResponseWriter
+	remaining int
+}
+
+func (f *failAfterWriter) Write(p []byte) (int, error) {
+	if f.remaining <= 0 {
+		return 0, errors.New("client gone")
+	}
+	if len(p) > f.remaining {
+		p = p[:f.remaining]
+	}
+	n, err := f.ResponseWriter.Write(p)
+	f.remaining -= n
+	if err != nil {
+		return n, err
+	}
+	if f.remaining == 0 {
+		return n, errors.New("client gone")
+	}
+	return n, nil
+}
+
+// A client write failure mid-pipeline must unwind the prefetching reader promptly (returning
+// its in-flight buffer) instead of leaving it blocked on the handoff forever. The serve returns
+// without hanging; -race would flag an unsynchronized unwind.
+func TestBlockCache_PipelineClientWriteFailureUnwindsCleanly(t *testing.T) {
+	object := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") // 40 bytes → 20 2-byte blocks
+	mock := newBlockMock(object, `"v1"`)
+	svc, c := newBlockServiceWithBudget(t, mock, 2, 1<<20)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated after cold full GET")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fw := &failAfterWriter{ResponseWriter: httptest.NewRecorder(), remaining: 9}
+		_ = svc.HandleGetObject(fw, fullGet(wowBucket, wowKey))
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve did not return after a mid-body client write failure (pipeline reader stuck?)")
+	}
+}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1427,3 +1427,122 @@ func TestBlockCache_MinObjectSizeWholeCachesSmallObjects(t *testing.T) {
 		t.Fatalf("warm range: code=%d body=%q, want 206 CDEF", w3.Code, w3.Body.String())
 	}
 }
+
+// A full-stream split marks the entry BlocksComplete; a block evicted afterwards is recovered
+// by an inline fetch mid-serve — the client still gets the complete, byte-exact object.
+func TestBlockCache_CompleteEntryInlineFetchRecoversEvictedBlock(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // blocks [0..3][4..7][8..9]
+	memCache := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Cold full GET → block split → complete entry.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if !meta.BlocksComplete {
+		t.Fatal("entry from full-stream split not marked BlocksComplete")
+	}
+
+	// Evict block 1 out from under the complete entry.
+	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 1)); err != nil {
+		t.Fatalf("delete block 1: %v", err)
+	}
+	before := mock.blockGets.Load()
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("warm full GET with evicted block: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("inline-fetch serve: code=%d body=%q, want 200 ABCDEFGHIJ", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q", got, XCacheHit)
+	}
+	if after := mock.blockGets.Load(); after != before+1 {
+		t.Errorf("inline fetches = %d, want exactly 1 (the evicted block)", after-before)
+	}
+}
+
+// A complete entry whose FIRST block is gone and unrecoverable (upstream failing) must fall
+// through pre-commit: the client gets a clean 200 from the miss path, never a truncated body.
+func TestBlockCache_CompleteEntryFirstBlockGoneFallsThroughCleanly(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	memCache := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+
+	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 0)); err != nil {
+		t.Fatalf("delete block 0: %v", err)
+	}
+	mock.blockGetTransient = true // the pre-commit recovery fetch fails
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("full GET with gone first block: %v", err)
+	}
+	// Served whole from the miss-path forward — a complete body, not a truncated one.
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("fall-through: code=%d body=%q, want 200 ABCDEFGHIJ", w2.Code, w2.Body.String())
+	}
+}
+
+// An entry established from a range (not complete) is promoted to BlocksComplete after its
+// first successful full assembly, so later full GETs skip the probe pass.
+func TestBlockCache_PartialEntryPromotedAfterFullAssembly(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	svc, c := newBlockService(t, mock)
+
+	// Establish blocks 0 and 1 via a cold range miss (block 2 missing → not complete).
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-7")); err != nil {
+		t.Fatalf("cold range miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if meta.BlocksComplete {
+		t.Fatal("range-established entry unexpectedly marked complete")
+	}
+
+	// Full GET assembles (fetching block 2) and serves; the promotion lands asynchronously.
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("full GET: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("full GET: code=%d body=%q", w2.Code, w2.Body.String())
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+		if found && m.BlocksComplete {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("entry not promoted to BlocksComplete after successful full assembly")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1348,3 +1348,42 @@ func TestBlockCache_WarmFullGetManyBlocksServesFromCache(t *testing.T) {
 		t.Errorf("warm serve fetched %d blocks from upstream, want 0", got)
 	}
 }
+
+// Under budget pressure where the assembly buffer's reservation leaves no room for the
+// missing-block fetch's own reservation (budget fits one but not both), the serve must not
+// give up and fall through to upstream: the assembly reservation is released and the probe
+// path retries, whose fetch can use the freed budget — the block is populated and the range
+// served from cache. Pins the double-reservation fix.
+func TestBlockCache_AssemblyBudgetContentionRetriesViaProbePath(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	// Budget of 5 bytes: the 4-byte assembly buffer reservation leaves 1 byte, so the 4-byte
+	// block-fetch reservation inside assembly must decline; once assembly releases, the probe
+	// path's fetch fits.
+	svc, c := newBlockServiceWithBudget(t, mock, 4, 5)
+
+	// Establish only block 0 (the populate's own reservation completes and releases first —
+	// metaCached gates on the meta write, which happens after the fetch releases).
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-3")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated")
+	}
+
+	// Block 1 is missing. Assembly's fetch is budget-starved by the buffer reservation; the
+	// retry via the probe path must still fetch, cache, and serve it as a HIT.
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=4-7")); err != nil {
+		t.Fatalf("partial hit under budget pressure: %v", err)
+	}
+	if w2.Code != http.StatusPartialContent || w2.Body.String() != "EFGH" {
+		t.Fatalf("partial hit: code=%d body=%q, want 206 EFGH", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q (probe-path retry should serve from cache)", got, XCacheHit)
+	}
+	if !c.BlockExists(context.Background(), wowBucket, wowKey, `"v1"`, 4, 1) {
+		t.Error("block 1 not cached after probe-path retry")
+	}
+}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1349,20 +1349,16 @@ func TestBlockCache_WarmFullGetManyBlocksServesFromCache(t *testing.T) {
 	}
 }
 
-// Under budget pressure where the assembly buffer's reservation leaves no room for the
-// missing-block fetch's own reservation (budget fits one but not both), the serve must not
-// give up and fall through to upstream: the assembly reservation is released and the probe
-// path retries, whose fetch can use the freed budget — the block is populated and the range
-// served from cache. Pins the double-reservation fix.
-func TestBlockCache_AssemblyBudgetContentionRetriesViaProbePath(t *testing.T) {
+// With the populate budget saturated by other work, an assembled range whose missing-block
+// fetch declines falls through to a clean upstream forward — no truncation, no invalidation —
+// and serves from cache again once the budget frees. (The staging and populate budgets are
+// independent pools, so a decline means real global populate pressure; retrying via the probe
+// path would draw on the same budget and just repeat it.)
+func TestBlockCache_AssemblyFetchDeclineFallsThroughToUpstream(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
-	// Budget of 5 bytes: the 4-byte assembly buffer reservation leaves 1 byte, so the 4-byte
-	// block-fetch reservation inside assembly must decline; once assembly releases, the probe
-	// path's fetch fits.
-	svc, c := newBlockServiceWithBudget(t, mock, 4, 5)
+	svc, c := newBlockServiceWithBudget(t, mock, 4, 100)
 
-	// Establish only block 0 (the populate's own reservation completes and releases first —
-	// metaCached gates on the meta write, which happens after the fetch releases).
+	// Establish only block 0.
 	w := httptest.NewRecorder()
 	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-3")); err != nil {
 		t.Fatalf("cold miss: %v", err)
@@ -1371,20 +1367,33 @@ func TestBlockCache_AssemblyBudgetContentionRetriesViaProbePath(t *testing.T) {
 		t.Fatal("block-mode meta not populated")
 	}
 
-	// Block 1 is missing. Assembly's fetch is budget-starved by the buffer reservation; the
-	// retry via the probe path must still fetch, cache, and serve it as a HIT.
+	// Saturate the populate budget so block 1's fetch declines.
+	if !svc.populateBudget.tryAcquireReadMiss(100) {
+		t.Fatal("could not saturate populate budget")
+	}
+
 	w2 := httptest.NewRecorder()
 	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=4-7")); err != nil {
-		t.Fatalf("partial hit under budget pressure: %v", err)
+		t.Fatalf("range under populate saturation: %v", err)
 	}
 	if w2.Code != http.StatusPartialContent || w2.Body.String() != "EFGH" {
-		t.Fatalf("partial hit: code=%d body=%q, want 206 EFGH", w2.Code, w2.Body.String())
+		t.Fatalf("range under saturation: code=%d body=%q, want 206 EFGH (upstream forward)", w2.Code, w2.Body.String())
 	}
-	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
-		t.Errorf("X-Cache=%q, want %q (probe-path retry should serve from cache)", got, XCacheHit)
+	if got := w2.Header().Get("X-Cache"); got == XCacheHit {
+		t.Errorf("X-Cache=%q, want a non-HIT upstream forward under populate saturation", got)
 	}
-	if !c.BlockExists(context.Background(), wowBucket, wowKey, `"v1"`, 4, 1) {
-		t.Error("block 1 not cached after probe-path retry")
+	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); !found {
+		t.Fatal("still-valid entry was invalidated by a budget decline")
+	}
+
+	// Budget freed: the fetch fits again and the range serves from cache.
+	svc.populateBudget.release(100)
+	w3 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w3, blockGet(wowBucket, wowKey, "bytes=4-7")); err != nil {
+		t.Fatalf("range after budget freed: %v", err)
+	}
+	if w3.Code != http.StatusPartialContent || w3.Body.String() != "EFGH" || w3.Header().Get("X-Cache") != XCacheHit {
+		t.Fatalf("after budget freed: code=%d body=%q x-cache=%q, want 206 EFGH HIT", w3.Code, w3.Body.String(), w3.Header().Get("X-Cache"))
 	}
 }
 
@@ -1547,24 +1556,21 @@ func TestBlockCache_CompleteEntryMidServeStaleSignalInvalidates(t *testing.T) {
 	}
 }
 
-// A budget-declined recovery fetch for the first block of a complete entry retries via the
-// probe path (whose fetch can use the freed buffer reservation) instead of surrendering the
-// serve to a full upstream GET.
-func TestBlockCache_CompleteEntryBudgetContentionRetriesViaProbePath(t *testing.T) {
+// A populate-budget decline for a block AFTER headers are committed must not truncate the
+// response: the serve salvages the remaining bytes with one uncached upstream range GET and
+// the still-valid entry survives (a transient decline is not a degenerate entry).
+func TestBlockCache_CompleteEntryFetchDeclineSalvagesViaRemainder(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
-	// Budget of 5: the 4-byte first-block buffer reservation leaves 1, so the recovery
-	// fetch's own 4-byte reservation declines inside the complete path; the probe-path
-	// retry (buffer released) fits.
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
 	cfg.Cache.BlockCachingEnabled = true
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
-	cfg.Cache.MaxPopulateMemoryBytes = 5
+	cfg.Cache.MaxPopulateMemoryBytes = 100
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
 	svc := NewService(mock, c, cfg)
 
-	// Complete entry via a cold full GET (its populate reserves and releases first).
+	// Complete entry via a cold full GET.
 	w := httptest.NewRecorder()
 	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
 		t.Fatalf("cold full GET: %v", err)
@@ -1572,25 +1578,103 @@ func TestBlockCache_CompleteEntryBudgetContentionRetriesViaProbePath(t *testing.
 	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
 		t.Fatal("meta not populated")
 	}
-	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
-	if !meta.BlocksComplete {
-		t.Fatal("entry not marked complete")
-	}
 
-	// Evict block 0 so the complete path needs a recovery fetch it cannot budget.
-	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 0)); err != nil {
-		t.Fatalf("delete block 0: %v", err)
+	// Evict a MID-stream block and saturate the populate budget: the inline recovery fetch
+	// declines only after the 200 is committed.
+	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 1)); err != nil {
+		t.Fatalf("delete block 1: %v", err)
 	}
+	if !svc.populateBudget.tryAcquireReadMiss(100) {
+		t.Fatal("could not saturate populate budget")
+	}
+	defer svc.populateBudget.release(100)
 
 	w2 := httptest.NewRecorder()
 	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
-		t.Fatalf("full GET under budget pressure: %v", err)
+		t.Fatalf("full GET under populate saturation: %v", err)
 	}
 	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
-		t.Fatalf("full GET: code=%d body=%q, want 200 ABCDEFGHIJ", w2.Code, w2.Body.String())
+		t.Fatalf("degraded serve: code=%d body=%q, want the COMPLETE object (no truncation)", w2.Code, w2.Body.String())
 	}
-	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
-		t.Errorf("X-Cache=%q, want %q (probe-path retry should serve from cache)", got, XCacheHit)
+	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); !found {
+		t.Fatal("entry invalidated by a transient budget decline")
+	}
+}
+
+// A BlocksComplete meta surviving mass block eviction must not turn one full GET into N
+// serial upstream fetches: after maxInlineFetchesPerServe recoveries the serve switches to a
+// single uncached upstream remainder stream, and the degenerate entry is invalidated so the
+// next GET re-establishes it with one streaming re-split.
+func TestBlockCache_CompleteEntryMassEvictionBoundsUpstreamFanout(t *testing.T) {
+	object := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") // 40 bytes -> 20 2-byte blocks
+	mock := newBlockMock(object, `"v1"`)
+	memCache := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 2
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+
+	// Mass-evict blocks 3..19 out from under the complete meta.
+	for i := int64(3); i <= 19; i++ {
+		if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 2, i)); err != nil {
+			t.Fatalf("delete block %d: %v", i, err)
+		}
+	}
+
+	before := mock.blockGets.Load()
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("degraded full GET: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != string(object) {
+		t.Fatalf("degraded serve: code=%d body=%q, want the exact object", w2.Code, w2.Body.String())
+	}
+	// Bounded fan-out: at most the inline-fetch cap in aligned GETs plus ONE remainder GET —
+	// never one upstream round trip per missing block (17 here).
+	if got := mock.blockGets.Load() - before; int(got) > maxInlineFetchesPerServe+1 {
+		t.Errorf("degraded serve made %d upstream requests, want <= %d", got, maxInlineFetchesPerServe+1)
+	}
+	// The degenerate entry is invalidated so the next GET re-splits in one streaming fetch.
+	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
+		t.Fatal("degenerate mass-evicted entry survived the degraded serve")
+	}
+}
+
+// Promotion must never extend an entry's lifetime: the rewritten meta carries only the
+// REMAINING TTL computed from CachedAt, and entries with unknown age (or already expired)
+// are not rewritten at all.
+func TestRemainingMetaTTL(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	svc, _ := newBlockService(t, mock)
+	svc.config.Cache.TTL = time.Hour
+	now := time.Now().Unix()
+	cases := []struct {
+		name     string
+		cachedAt int64
+		min, max int
+	}{
+		{"fresh entry keeps ~full TTL", now, 3590, 3600},
+		{"aged entry keeps only the remainder", now - 3500, 90, 110},
+		{"expired entry is not rewritten", now - 4000, 0, 0},
+		{"unknown age is not rewritten", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := svc.remainingMetaTTL(&cache.CachedObjectMeta{CachedAt: tc.cachedAt})
+			if got < tc.min || got > tc.max {
+				t.Errorf("remainingMetaTTL(age=%ds) = %d, want in [%d,%d]", now-tc.cachedAt, got, tc.min, tc.max)
+			}
+		})
 	}
 }
 

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1150,5 +1151,200 @@ func TestBlockCache_ColdLargeRangeSkipsPopulate(t *testing.T) {
 	}
 	if after := mock.blockGets.Load(); after != before {
 		t.Errorf("cold large range fanned out into per-block fetches: %d -> %d", before, after)
+	}
+}
+
+// blockReadFaultClient wraps a CacheClient and, when armed, fails every block-key range read
+// with a transient error — simulating a cluster gRPC blip during a warm serve's block reads.
+type blockReadFaultClient struct {
+	cacheclient.CacheClient
+	fail atomic.Bool
+}
+
+func (p *blockReadFaultClient) GetRangeStream(ctx context.Context, key string, start, end int64, w io.Writer) error {
+	if p.fail.Load() && strings.HasPrefix(key, "blk|") {
+		return fmt.Errorf("simulated block read blip")
+	}
+	return p.CacheClient.GetRangeStream(ctx, key, start, end, w)
+}
+
+// A warm range that spans a block boundary is assembled byte-exact from both blocks with no
+// upstream fetch (the probe-free assembled path).
+func TestBlockCache_AssembledRangeSpansBlockBoundary(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // 10 bytes → blocks [0..3][4..7][8..9]
+	svc, c := newBlockService(t, mock)
+
+	// Establish blocks 0 and 1 via a cold miss.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-7")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated after cold miss")
+	}
+
+	// bytes=2-5 (len 4 = one block) covers blocks 0 and 1: assembled across the boundary.
+	before := mock.blockGets.Load()
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=2-5")); err != nil {
+		t.Fatalf("warm boundary range: %v", err)
+	}
+	if w2.Code != http.StatusPartialContent || w2.Body.String() != "CDEF" {
+		t.Fatalf("warm boundary range: code=%d body=%q, want 206 CDEF", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q", got, XCacheHit)
+	}
+	if after := mock.blockGets.Load(); after != before {
+		t.Errorf("warm boundary range fetched blocks upstream: %d -> %d", before, after)
+	}
+	if cr := w2.Header().Get("Content-Range"); cr != "bytes 2-5/10" {
+		t.Errorf("Content-Range=%q, want bytes 2-5/10", cr)
+	}
+}
+
+// A transient fetch failure for a block discovered missing during assembly falls through to
+// upstream BEFORE anything is committed: the client gets a clean 206 from the forward and the
+// still-valid entry is not invalidated.
+func TestBlockCache_AssembledRangeTransientFetchFallsThrough(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	svc, c := newBlockService(t, mock)
+
+	// Establish only block 0.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-3")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated")
+	}
+
+	// Block 1 is missing and its fetch fails transiently → clean upstream fall-through.
+	mock.blockGetTransient = true
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=4-7")); err != nil {
+		t.Fatalf("range with failing block fetch: %v", err)
+	}
+	if w2.Code != http.StatusPartialContent || w2.Body.String() != "EFGH" {
+		t.Fatalf("fall-through: code=%d body=%q, want 206 EFGH", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheMiss {
+		t.Errorf("X-Cache=%q, want %q (upstream fall-through)", got, XCacheMiss)
+	}
+	// The entry survives: a transient failure never invalidates.
+	if m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); !found || m.BlockSize != 4 {
+		t.Fatalf("entry lost after transient fetch failure: found=%v", found)
+	}
+}
+
+// A transient CACHE read failure during assembly (e.g. a cluster gRPC blip) aborts with
+// nothing committed — the client is served via the upstream fall-through and the still-valid
+// entry is not invalidated. Pins that a read error is treated as transient, never as a
+// missing block.
+func TestBlockCache_AssemblyCacheReadFailureFallsThroughWithoutInvalidating(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Establish a block-mode entry with block 0 present.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-3")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated")
+	}
+
+	// Arm block-read failures: the warm serve's assembly read fails → upstream fall-through.
+	faulty.fail.Store(true)
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, blockGet(wowBucket, wowKey, "bytes=0-3")); err != nil {
+		t.Fatalf("range with failing cache reads: %v", err)
+	}
+	if w2.Code != http.StatusPartialContent || w2.Body.String() != "ABCD" {
+		t.Fatalf("fall-through: code=%d body=%q, want 206 ABCD", w2.Code, w2.Body.String())
+	}
+	faulty.fail.Store(false)
+	if m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); !found || m.BlockSize != 4 {
+		t.Fatalf("entry lost after transient cache read failure: found=%v", found)
+	}
+}
+
+// The probe-first path (full-object serves, oversized ranges) must surface a transient probe
+// failure as an error from ensureBlocksCached — never as "blocks missing". If failed probes
+// were counted as absent, the full-object caller's mostly-missing bail would fire and DELETE
+// a still-valid entry on a network blip.
+func TestBlockCache_ProbePathTransientFailureAbortsWithoutInvalidating(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Establish a fully-populated block-mode entry (all three blocks + meta).
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-9")); err != nil {
+		t.Fatalf("cold miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated after cold miss")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+
+	faulty.fail.Store(true)
+	err := svc.ensureBlocksCached(context.Background(), wowBucket, wowKey, "ak", "sk", meta, 0, 2, true, 0)
+	if err == nil {
+		t.Fatal("ensureBlocksCached returned nil despite probe failures")
+	}
+	if errors.Is(err, errBlockAssemblyWouldAmplify) {
+		t.Fatal("transient probe failure misreported as amplify-bail (would delete a valid entry)")
+	}
+	if !strings.Contains(err.Error(), "simulated block read blip") {
+		t.Fatalf("ensureBlocksCached error = %v, want the injected read error", err)
+	}
+	if m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); !found || m.BlockSize != 4 {
+		t.Fatalf("entry lost after transient probe failure: found=%v", found)
+	}
+}
+
+// A warm full GET over many blocks still serves byte-exact from cache via the probe-first
+// path (full-object serves are unchanged by the assembled-range path).
+func TestBlockCache_WarmFullGetManyBlocksServesFromCache(t *testing.T) {
+	object := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") // 40 bytes
+	mock := newBlockMock(object, `"v1"`)
+	svc, c := newBlockServiceWithBudget(t, mock, 2, 1<<20) // 2-byte blocks → 20 blocks
+
+	// Cold full GET: the miss path streams from upstream and block-splits into cache.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if w.Code != http.StatusOK || w.Body.String() != string(object) {
+		t.Fatalf("cold full GET: code=%d body=%q", w.Code, w.Body.String())
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("block-mode meta not populated after cold full GET")
+	}
+
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("warm full GET: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != string(object) {
+		t.Fatalf("warm full GET: code=%d body=%q, want cache-assembled object", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q", got, XCacheHit)
+	}
+	if got := mock.blockGets.Load(); got != 0 {
+		t.Errorf("warm serve fetched %d blocks from upstream, want 0", got)
 	}
 }

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1798,3 +1798,30 @@ func TestBlockCache_PipelineClientWriteFailureUnwindsCleanly(t *testing.T) {
 		t.Fatal("serve did not return after a mid-body client write failure (pipeline reader stuck?)")
 	}
 }
+
+// A client write failure on the SEQUENTIAL stream path (where cache bytes write straight
+// into the client connection) must not trigger the upstream remainder salvage: the client is
+// broken, not the cache, so retrying from upstream would waste a round trip on a dead
+// connection. Pins the clientWriteTracker classification.
+func TestBlockCache_SequentialClientWriteFailureDoesNotFetchRemainder(t *testing.T) {
+	object := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") // 40 bytes → 20 2-byte blocks
+	mock := newBlockMock(object, `"v1"`)
+	// Budget 5: the complete path's first-block reservation (2) leaves 3, so the pipeline's
+	// two-buffer reservation (4) declines and the stream takes the sequential path.
+	svc, c := newBlockServiceWithBudget(t, mock, 2, 5)
+
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+
+	before := mock.blockGets.Load()
+	fw := &failAfterWriter{ResponseWriter: httptest.NewRecorder(), remaining: 9}
+	_ = svc.HandleGetObject(fw, fullGet(wowBucket, wowKey))
+	if got := mock.blockGets.Load() - before; got != 0 {
+		t.Errorf("client write failure triggered %d upstream requests, want 0 (no remainder salvage)", got)
+	}
+}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1388,46 +1388,6 @@ func TestBlockCache_AssemblyBudgetContentionRetriesViaProbePath(t *testing.T) {
 	}
 }
 
-// An object at or above BlockSize but below block_min_object_size is whole-cached: it never
-// pays per-block serve overhead, and warm serves come from the whole-body path.
-func TestBlockCache_MinObjectSizeWholeCachesSmallObjects(t *testing.T) {
-	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // 10 bytes: >= BlockSize(4), < min(20)
-	svc, c := newBlockService(t, mock)
-	svc.config.Cache.BlockMinObjectSize = 20
-
-	// Cold full GET: the miss path must whole-cache, not block-split.
-	w := httptest.NewRecorder()
-	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
-		t.Fatalf("cold full GET: %v", err)
-	}
-	if w.Code != http.StatusOK || w.Body.String() != "ABCDEFGHIJ" {
-		t.Fatalf("cold full GET: code=%d body=%q", w.Code, w.Body.String())
-	}
-	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
-		t.Fatal("meta not populated after cold full GET")
-	}
-	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
-	if meta.BlockSize != 0 {
-		t.Fatalf("meta.BlockSize = %d, want 0 (whole-cached below block_min_object_size)", meta.BlockSize)
-	}
-
-	// Warm full GET and range both serve from the whole-body entry.
-	w2 := httptest.NewRecorder()
-	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
-		t.Fatalf("warm full GET: %v", err)
-	}
-	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" || w2.Header().Get("X-Cache") != XCacheHit {
-		t.Fatalf("warm full GET: code=%d body=%q x-cache=%q", w2.Code, w2.Body.String(), w2.Header().Get("X-Cache"))
-	}
-	w3 := httptest.NewRecorder()
-	if err := svc.HandleGetObject(w3, blockGet(wowBucket, wowKey, "bytes=2-5")); err != nil {
-		t.Fatalf("warm range: %v", err)
-	}
-	if w3.Code != http.StatusPartialContent || w3.Body.String() != "CDEF" {
-		t.Fatalf("warm range: code=%d body=%q, want 206 CDEF", w3.Code, w3.Body.String())
-	}
-}
-
 // A full-stream split marks the entry BlocksComplete; a block evicted afterwards is recovered
 // by an inline fetch mid-serve — the client still gets the complete, byte-exact object.
 func TestBlockCache_CompleteEntryInlineFetchRecoversEvictedBlock(t *testing.T) {

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1546,3 +1546,90 @@ func TestBlockCache_PartialEntryPromotedAfterFullAssembly(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 }
+
+// A definitive stale signal (upstream 404) surfacing from a mid-serve inline fetch must
+// invalidate the BlocksComplete entry even though headers are already committed — otherwise
+// every later full GET commits and truncates the same way until the meta TTL expires.
+func TestBlockCache_CompleteEntryMidServeStaleSignalInvalidates(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	memCache := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Complete entry via a cold full GET.
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+
+	// Evict block 1, then delete the object out of band: the mid-serve inline fetch 404s.
+	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 1)); err != nil {
+		t.Fatalf("delete block 1: %v", err)
+	}
+	mock.blockGet404 = true
+
+	w2 := httptest.NewRecorder()
+	err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey))
+	if err == nil {
+		t.Fatal("mid-serve stale fetch: want a (truncation) error, got nil")
+	}
+	// The stale entry must be gone so the next GET re-resolves upstream instead of
+	// repeating the truncation.
+	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
+		t.Fatal("stale BlocksComplete entry survived a definitive mid-serve stale signal")
+	}
+}
+
+// A budget-declined recovery fetch for the first block of a complete entry retries via the
+// probe path (whose fetch can use the freed buffer reservation) instead of surrendering the
+// serve to a full upstream GET.
+func TestBlockCache_CompleteEntryBudgetContentionRetriesViaProbePath(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	// Budget of 5: the 4-byte first-block buffer reservation leaves 1, so the recovery
+	// fetch's own 4-byte reservation declines inside the complete path; the probe-path
+	// retry (buffer released) fits.
+	memCache := cacheclient.NewMemoryCache()
+	cfg := config.NewDefault()
+	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	cfg.Cache.MaxPopulateMemoryBytes = 5
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Complete entry via a cold full GET (its populate reserves and releases first).
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("cold full GET: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+	meta, _, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+	if !meta.BlocksComplete {
+		t.Fatal("entry not marked complete")
+	}
+
+	// Evict block 0 so the complete path needs a recovery fetch it cannot budget.
+	if err := memCache.Delete(context.Background(), cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 0)); err != nil {
+		t.Fatalf("delete block 0: %v", err)
+	}
+
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("full GET under budget pressure: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("full GET: code=%d body=%q, want 200 ABCDEFGHIJ", w2.Code, w2.Body.String())
+	}
+	if got := w2.Header().Get("X-Cache"); got != XCacheHit {
+		t.Errorf("X-Cache=%q, want %q (probe-path retry should serve from cache)", got, XCacheHit)
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -120,10 +120,17 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		serveStagingBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, 0, perPopulateCap)
 	}
 
+	// The block buffer pool's retention cap must track the configured block size, or every
+	// block staging buffer in a larger-block deployment would be allocated fresh and dropped.
+	if bs := cfg.Cache.BlockSize; bs > maxPooledBlockBufBytes.Load() {
+		maxPooledBlockBufBytes.Store(bs)
+	}
+
 	log.Info().
 		Int("max_concurrent_writes", cfg.Cache.MaxConcurrentWrites).
 		Int64("max_populate_memory_bytes", cfg.Cache.MaxPopulateMemoryBytes).
 		Int64("per_populate_buffer_cap_bytes", perPopulateCap).
+		Int64("serve_staging_budget_bytes", cfg.Cache.MaxPopulateMemoryBytes).
 		Msg("Cache-populate limits configured")
 
 	return &Service{
@@ -178,6 +185,24 @@ func (s *Service) populateWeight(contentLength int64) int64 {
 		w = budget
 	}
 	return w
+}
+
+// stagingWeight is the byte weight a block-serve staging buffer reserves against the
+// serve-staging budget: the buffer's ACTUAL size, clamped only by the total budget (so a
+// buffer larger than the whole budget still serves one-at-a-time, mirroring populateWeight).
+// Unlike populateWeight it is NOT capped at perPopulateCap — that ceiling models the
+// broadcast pipeline's buffering, which has no relationship to raw block-sized staging
+// buffers; clamping to it would let the budget admit more bytes than are actually allocated
+// (e.g. two 64 MiB pipeline buffers reserved as one 80 MiB cap), silently breaking the very
+// bound the budget exists to enforce.
+func (s *Service) stagingWeight(n int64) int64 {
+	if n < 1 {
+		n = 1
+	}
+	if budget := s.config.Cache.MaxPopulateMemoryBytes; budget > 0 && n > budget {
+		n = budget
+	}
+	return n
 }
 
 // populatePriority classifies a cache-populate for admission against the byte

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -68,6 +68,7 @@ type Service struct {
 	config                  *config.Config
 	cacheSemaphore          chan struct{}      // Count ceiling on concurrent cache-populate ops (nil = unlimited)
 	populateBudget          *byteBudget        // Byte budget bounding aggregate populate buffering (nil = unlimited)
+	serveStagingBudget      *byteBudget        // Byte budget bounding block-serve staging buffers (nil = unlimited)
 	perPopulateCap          int64              // Max bytes a single populate can buffer (reservation ceiling)
 	broadcastManager        *broadcast.Manager // For streaming request coalescing
 	activeBackgroundFetches sync.Map           // Dedup for background full-object fetches (range caching)
@@ -98,6 +99,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 	perPopulateCap := perPopulateBufferBytes(cfg)
 
 	var populateBudget *byteBudget
+	var serveStagingBudget *byteBudget
 	if cfg.Cache.MaxPopulateMemoryBytes > 0 {
 		// Reserve a share of the budget for warm-on-write only when it's enabled;
 		// otherwise there's no warm path to protect.
@@ -106,6 +108,16 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 			reserveFraction = cfg.Cache.WarmOnWriteReservedFraction
 		}
 		populateBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, reserveFraction, perPopulateCap)
+		// Block-serve staging buffers (pre-commit range/first-block assembly, the
+		// streaming pipeline's double buffers) get their OWN budget of the same size,
+		// never the populate budget: a warm multi-block serve holds its staging bytes
+		// for the whole (possibly multi-second) response, and at high concurrency
+		// those long holds would crowd cold-miss populates out of a shared budget —
+		// objects get served but never cached, and the working set stays cold
+		// (measured as a ~3x warm-GET collapse). Staging memory is still bounded (by
+		// this budget — declines degrade the serve, never fail it); it just cannot
+		// starve populates. Warm-on-write reservation semantics don't apply here.
+		serveStagingBudget = newByteBudget(cfg.Cache.MaxPopulateMemoryBytes, 0, perPopulateCap)
 	}
 
 	log.Info().
@@ -115,13 +127,14 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		Msg("Cache-populate limits configured")
 
 	return &Service{
-		forwarder:        forwarder,
-		cache:            cache,
-		config:           cfg,
-		cacheSemaphore:   cacheSem,
-		populateBudget:   populateBudget,
-		perPopulateCap:   perPopulateCap,
-		broadcastManager: broadcast.NewManager(channelBuf),
+		forwarder:          forwarder,
+		cache:              cache,
+		config:             cfg,
+		cacheSemaphore:     cacheSem,
+		populateBudget:     populateBudget,
+		serveStagingBudget: serveStagingBudget,
+		perPopulateCap:     perPopulateCap,
+		broadcastManager:   broadcast.NewManager(channelBuf),
 	}
 }
 

--- a/tests/benchmark/clean-buckets.sh
+++ b/tests/benchmark/clean-buckets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Deletes a per-run warp benchmark bucket (when BUCKET is set) and sweeps leaked
+# tag-warp-ci-* buckets older than MAX_AGE_HOURS. Benchmark CI runs this after every run;
+# it is also runnable locally (with AWS credentials in the environment) to reproduce or
+# debug the sweep — the logic deliberately does NOT live inline in workflow YAML.
+#
+# Env:
+#   BUCKET         per-run bucket to delete first (optional)
+#   ENDPOINT       S3 endpoint            (default https://t3.storage.dev)
+#   MAX_AGE_HOURS  sweep age threshold    (default 24)
+#
+# Best-effort by design: individual delete failures are ignored (another run may have
+# already removed a bucket), but an unparseable CreationDate is logged loudly instead of
+# silently skipped — a format/locale drift would otherwise turn the sweep into a permanent
+# no-op while leaked buckets accumulate.
+set -u
+
+ENDPOINT="${ENDPOINT:-https://t3.storage.dev}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-24}"
+
+if [ -n "${BUCKET:-}" ]; then
+  aws --endpoint-url "$ENDPOINT" s3 rm "s3://$BUCKET" --recursive --only-show-errors || true
+  aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$BUCKET" || true
+fi
+
+cutoff=$(($(date -u +%s) - MAX_AGE_HOURS * 3600))
+aws --endpoint-url "$ENDPOINT" s3api list-buckets \
+  --query 'Buckets[?starts_with(Name, `tag-warp-ci-`)].[Name,CreationDate]' --output text |
+  while read -r name created; do
+    [ -n "$name" ] && [ "$name" != "None" ] || continue
+    if ! ts=$(date -u -d "$created" +%s 2>/dev/null); then
+      echo "WARNING: cannot parse CreationDate '$created' for bucket $name - skipping" >&2
+      continue
+    fi
+    [ "$ts" -lt "$cutoff" ] || continue
+    echo "Sweeping leaked benchmark bucket: $name (created $created)"
+    aws --endpoint-url "$ENDPOINT" s3 rm "s3://$name" --recursive --only-show-errors || true
+    aws --endpoint-url "$ENDPOINT" s3api delete-bucket --bucket "$name" || true
+  done || true
+
+exit 0


### PR DESCRIPTION
## Summary

Block-mode serves were 3–4x slower than whole-object caching on full GETs: every warm serve paid two cache ops per block (an existence probe of every covering block, then a second read to stream it), and blocks streamed strictly sequentially — the cache read of block *i+1* never overlapped the client write of block *i*. This PR removes the redundant ops and overlaps the rest:

- **Probe-free assembled ranges** (`serveAssembledRange`): a range no longer than one block — the SlateDB/Parquet-footer pattern, at most two covering blocks — is assembled into a pooled buffer before anything is committed. Each present block is read exactly once (the read is the existence check); missing blocks are discovered by that same read and fetched pre-commit; every failure leaves the response unwritten for a clean upstream fall-through. Larger ranges and budget declines take the probe-first path (amplification bail intact).
- **Probe-free full-object serves for complete entries**: the block splitter stamps the meta `blocks_complete` (it just wrote every block); full GETs on such entries skip the probe pass (`2N+1 → N+1` ops). Partial entries keep the probe path and are promoted to complete (async, tombstone-aware) after their first successful full assembly — the promotion rewrite carries the entry's **remaining** TTL (via a new `cached_at` meta stamp), never a fresh one, so it cannot extend the staleness window or let the meta outlive its blocks.
- **Pipelined block streaming** (`streamBlockRange`): warm multi-block serves prefetch block *i+1* into a pooled buffer while block *i* writes to the client (double-buffered reader goroutine, unbuffered-channel handoff), so cache-read and client-write latency overlap instead of adding up. Degrades to the direct sequential stream on budget decline or single-block serves.
- **Bounded, salvageable degraded serves**: `blocks_complete` is a hint — blocks and meta evict independently — so committed serves recover at most `maxInlineFetchesPerServe` absent blocks via per-block upstream fetches. Past that cap, on a fetch decline, or on a transient read failure, the committed response is completed **byte-exact from one uncached upstream remainder stream** (ETag- and range-validated) instead of truncating, and a mass-evicted (degenerate) entry is invalidated so the next GET re-splits in a single streaming fetch. Only stale signals (version change — never mixable into a committed body), client write failures, and a failed remainder still truncate. Stale-signal invalidation is centralized in the shared fetch path.
- **Dedicated serve-staging byte budget**: block-serve staging buffers (range assembly, first block, pipeline double buffers) draw from their own budget rather than the populate budget — a warm serve holds staging bytes for its whole response, and those long holds must not starve cold-miss populates. Reservations use each buffer's **actual size** (not the populate weight's broadcast-derived clamp), so the bound is honest at any `block_size`; the block buffer pool's retention cap tracks the configured `block_size`.
- **Benchmark CI**: per-run buckets (`tag-warp-ci-<run id>`) with always() cleanup + a leaked-bucket sweep that lives in a locally runnable script (`make bench-clean-buckets`); new workflow inputs (`duration`, `obj_size`, `max_populate_memory`, `range_objects`, `range_obj_size`) for warm-dominated, large-object, and budget-diagnostic configurations.

No new configuration surface: the whole-vs-block boundary remains `block_size` (RFC 0001), and the serve-staging budget is sized by the existing `cache.max_populate_memory_bytes` (negative still disables both pools; aggregate bound is up to 2x that value — documented in config and docs/configuration.md).

## Benchmark results (isolated serialized runs; `put` throughput used as the bandwidth control between windows)

**Small objects — full-object GET** (100 × 4 MiB, 64 concurrent, 30s):

| Configuration | get throughput | TTFB avg |
|---|---|---|
| main, 64 KiB blocks (runs ``[55](https://github.com/tigrisdata/tag/actions/runs/30884351386)/[58](https://github.com/tigrisdata/tag/actions/runs/30959638334)/[59](https://github.com/tigrisdata/tag/actions/runs/30960591151)/[60](https://github.com/tigrisdata/tag/actions/runs/30962325926))`` | 1,090–1,356 MiB/s | 84–116 ms |
| This PR, 64 KiB blocks ([65](https://github.com/tigrisdata/tag/actions/runs/30964946691)) | **1,557 MiB/s** | **53 ms** |
| This PR, 65535-byte blocks ([68](https://github.com/tigrisdata/tag/actions/runs/30964974796)) | **1,810 MiB/s** | **44 ms** |

Direct main-vs-PR A/B at identical config (blocks, 64 KiB block size, stock everything; runs [59](https://github.com/tigrisdata/tag/actions/runs/30960591151) vs [84](https://github.com/tigrisdata/tag/actions/runs/30982713119)): get 1,246 → 2,357 MiB/s (+89% raw, ~+54% put-normalized), request p50 halved (214 → 93 ms), median TTFB 93 → 21 ms, get-range unchanged.

**Large objects — blocks vs whole-object** (100 × 64 MiB = 16 blocks/object, 4 GiB populate budget, put controls within 12%; [full record](https://github.com/tigrisdata/tag/pull/141#issuecomment-5187816160)):

| Mode | get throughput | TTFB p50 |
|---|---|---|
| Blocks ([77](https://github.com/tigrisdata/tag/actions/runs/30975850458)) | 2,656 MiB/s (put-normalized parity) | **73 ms** |
| Whole-object ([79](https://github.com/tigrisdata/tag/actions/runs/30976892656)) | 2,966 MiB/s | 1,589 ms |

**Mid-size objects** (100 × 16 MiB = 4 blocks/object, put controls within 1.2%; [A/B record](https://github.com/tigrisdata/tag/pull/141#issuecomment-5188084382)): block mode reaches 4,492 MiB/s / 56 ms TTFB p50 vs the whole-object path's 4,810 MiB/s / 42 ms — within ~7% of the whole-object ceiling.

**Warm range reads** — A/B isolating the assembled path (1 × 64 MiB object, 64 KiB reads, ~96% warm; configs differ by one byte of block size purely to select the code path):

| Serve path | Throughput | obj/s | req avg | p50 |
|---|---|---|---|---|
| Probe-first (65535, [68](https://github.com/tigrisdata/tag/actions/runs/30964974796)) | 109.3 MiB/s | 1,749 | 38.6 ms | 24.5 ms |
| Assembled, probe-free (65536, [70](https://github.com/tigrisdata/tag/actions/runs/30967918142)) | **134.1 MiB/s** | **2,145** | **33.8 ms** | **21.0 ms** |

Net: block-mode full GETs go from 3–4x slower than whole-object caching to throughput parity across the measured size range, with median TTFB up to ~22x better on large objects (fine-grained block interleaving vs whole-body head-of-line blocking); +23% throughput / −14% p50 on warm small-range reads. `put`/`head`/`list` unchanged throughout. Deployment note: on large-object workloads, size `max_populate_memory_bytes` near `concurrency × min(object_size, per-populate cap)` — the stock 1 GiB is the cold-ramp limiter for every mode at 64 MiB objects.

## Testing

- New unit/integration coverage: boundary-spanning assembly; transient fetch and cache-read failures fall through cleanly without invalidation (read errors are never "missing"); probe-path transient-failure pin for `ensureBlocksCached`; populate-budget saturation falls through cleanly pre-commit and salvages the committed response via the upstream remainder stream post-commit (no truncation, entry kept); mass eviction under a complete meta bounds upstream fan-out to the inline cap + one remainder GET and invalidates the degenerate entry; promotion TTL preservation (`remainingMetaTTL`); split-marks-complete + inline-fetch eviction recovery; gone-first-block pre-commit fall-through; mid-serve stale signal invalidates; partial-entry promotion; pipeline budget-decline degradation to the sequential stream; warm multi-block range through the pipeline; mid-body client-disconnect unwinds the pipeline reader cleanly.
- Existing block-mode suites (cold populate, partial hit, stale invalidation, 416/multi-range, large-range fan-out cap) pass unchanged and now exercise the new paths.
- `go vet`, full `proxy`/`cache`/`config` suites, and `go test ./proxy -race` pass; all four s3-compat CI suites (single-node + cluster, default + blocks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ2etgSTZP3hMAgZdnsU7P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GET/range serving and committed-response recovery in `proxy/block_cache.go`; mistakes could truncate bodies or serve stale bytes, though extensive integration tests cover fall-through, salvage, and invalidation paths.
> 
> **Overview**
> **Block-cache serve path** is reworked so warm full GETs and footer-style range reads no longer pay two cache ops per block or stall on strictly sequential block reads.
> 
> - **Probe-free paths**: Sub-block ranges assemble in a pooled buffer pre-commit (`serveAssembledRange`); entries stamped **`blocks_complete`** (full split or post-assembly promotion) skip the per-block probe on full GETs. **`cached_at`** on meta lets promotion rewrite only **remaining TTL**, not extend lifetime.
> - **Pipelined streaming**: Multi-block spans prefetch the next block while the current one writes to the client; declines fall back to sequential streaming.
> - **Degraded committed serves**: After headers are sent, absent blocks are recovered inline (capped at **`maxInlineFetchesPerServe`**), then byte-exact **remainder** upstream range GETs; mass-evicted entries invalidate. Stale invalidation is centralized in **`fetchBlocksToCache`**.
> - **Memory**: A second **`serveStagingBudget`** (same size as **`max_populate_memory_bytes`**, up to **2×** aggregate buffering) isolates long-held serve buffers from populate pressure; block buffers use **`sync.Pool`** with cap tied to **`block_size`**.
> 
> **CI / benchmarks**: Per-run buckets `tag-warp-ci-<run_id>`, **`bench-clean-buckets`** sweep, and workflow inputs for duration, object sizes, populate budget, and range-read working set. RFC 0001 and config docs updated to reflect implemented serve behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45940640e57887eb985c3940b70b34de904241e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->