### PR TITLE
docs: block caching default-on (1 MiB) + bump deploy pins to v1.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigri
 - **Embedded Cache**: High-performance RocksDB-based cache with automatic cluster discovery
 - **Request Coalescing**: Streaming broadcast pattern reduces duplicate upstream requests under concurrent load
 - **Range Request Caching**: Background fetch of full objects on range cache miss for optimal ML training workloads
+- **Block-Aligned Caching** *(opt-in)*: Cache large objects as fixed-size blocks (RFC 0001) so a small range read fetches and caches only the covering blocks instead of the whole object — ideal for sparse reads of large files (Parquet footers/row-groups, SST blocks). Size `block_size` to your workload's read granularity.
 - **Conditional Requests**: Supports If-None-Match and If-Modified-Since for efficient cache validation
 - **AWS SigV4 Authentication**: Full AWS Signature Version 4 validation and re-signing
 - **Prometheus Metrics**: Comprehensive metrics for monitoring cache efficiency and performance
@@ -99,9 +100,10 @@ When configuring S3 clients, ensure path-style addressing is enabled. See [docs/
 - Objects larger than `size_threshold` are not cached
 - Objects with `Cache-Control: no-store` or `private` are not cached
 - Range requests trigger background fetch of full object (if within threshold)
+- With block caching enabled (`block_caching_enabled`), objects at/above `block_size` are instead cached as fixed-size blocks, so a range read fetches only the covering blocks
 - PUT/DELETE operations invalidate the cache entry
 
-See [docs/cache-control.md](docs/cache-control.md) for detailed cache control and revalidation documentation.
+See [docs/cache-control.md](docs/cache-control.md) for detailed cache control and revalidation documentation. For enabling and sizing block caching in production, see [docs/deploy.md](docs/deploy.md#block-aligned-caching-optional).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each release publishes the install script, run script, and a matching `config.ya
 curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # A specific release
-curl -fsSL https://tag-releases.t3.storage.dev/v1.14.0/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/v1.17.0/install.sh | bash
 ```
 
 The script installs the `tag` binary to `/usr/local/bin` and a default config to `/etc/tag/config.yaml`.
@@ -99,7 +99,7 @@ When configuring S3 clients, ensure path-style addressing is enabled. See [docs/
 
 - Objects larger than `size_threshold` are not cached
 - Objects with `Cache-Control: no-store` or `private` are not cached
-- Objects at or above `block_size` are cached as fixed-size blocks (block caching, on by default), so a range read fetches only the covering blocks; smaller objects are whole-cached
+- Among cacheable objects (within `size_threshold`), those at or above `block_size` are cached as fixed-size blocks (block caching, on by default), so a range read fetches only the covering blocks; smaller objects are whole-cached
 - Set `block_caching_enabled: false` to cache whole objects instead — a range request then triggers a background fetch of the full object (if within threshold)
 - PUT/DELETE operations invalidate the cache entry
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TAG is a high-performance S3-compatible caching proxy for [Tigris](https://tigri
 - **Embedded Cache**: High-performance RocksDB-based cache with automatic cluster discovery
 - **Request Coalescing**: Streaming broadcast pattern reduces duplicate upstream requests under concurrent load
 - **Range Request Caching**: Background fetch of full objects on range cache miss for optimal ML training workloads
-- **Block-Aligned Caching** *(opt-in)*: Cache large objects as fixed-size blocks (RFC 0001) so a small range read fetches and caches only the covering blocks instead of the whole object — ideal for sparse reads of large files (Parquet footers/row-groups, SST blocks). Size `block_size` to your workload's read granularity.
+- **Block-Aligned Caching** *(default)*: Caches large objects as fixed-size blocks (RFC 0001) so a small range read fetches and caches only the covering blocks instead of the whole object — ideal for sparse reads of large files (Parquet footers/row-groups, SST blocks). Enabled by default at 1 MiB blocks; size `block_size` to your read granularity, or set `block_caching_enabled: false` to cache whole objects.
 - **Conditional Requests**: Supports If-None-Match and If-Modified-Since for efficient cache validation
 - **AWS SigV4 Authentication**: Full AWS Signature Version 4 validation and re-signing
 - **Prometheus Metrics**: Comprehensive metrics for monitoring cache efficiency and performance
@@ -99,11 +99,11 @@ When configuring S3 clients, ensure path-style addressing is enabled. See [docs/
 
 - Objects larger than `size_threshold` are not cached
 - Objects with `Cache-Control: no-store` or `private` are not cached
-- Range requests trigger background fetch of full object (if within threshold)
-- With block caching enabled (`block_caching_enabled`), objects at/above `block_size` are instead cached as fixed-size blocks, so a range read fetches only the covering blocks
+- Objects at or above `block_size` are cached as fixed-size blocks (block caching, on by default), so a range read fetches only the covering blocks; smaller objects are whole-cached
+- Set `block_caching_enabled: false` to cache whole objects instead — a range request then triggers a background fetch of the full object (if within threshold)
 - PUT/DELETE operations invalidate the cache entry
 
-See [docs/cache-control.md](docs/cache-control.md) for detailed cache control and revalidation documentation. For enabling and sizing block caching in production, see [docs/deploy.md](docs/deploy.md#block-aligned-caching-optional).
+See [docs/cache-control.md](docs/cache-control.md) for detailed cache control and revalidation documentation. For tuning and sizing block caching in production, see [docs/deploy.md](docs/deploy.md#block-aligned-caching).
 
 ## Configuration
 

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.16.0
+    newTag: v1.17.0

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.14.0
+    newTag: v1.16.0

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.14.0
+          image: tigrisdata/tag:v1.16.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.16.0
+          image: tigrisdata/tag:v1.17.0
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/deploy/native/install.sh
+++ b/deploy/native/install.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TAG_VERSION="${TAG_VERSION:-v1.14.0}"
+TAG_VERSION="${TAG_VERSION:-v1.17.0}"
 TAG_RELEASES_URL="https://tag-releases.t3.storage.dev"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 

--- a/deploy/native/run.sh
+++ b/deploy/native/run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
-TAG_VERSION="${TAG_VERSION:-v1.14.0}"
+TAG_VERSION="${TAG_VERSION:-v1.17.0}"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,8 +18,8 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
-| `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `false`                  |
-| `TAG_CACHE_BLOCK_SIZE`             | Block granularity **and** the read-side whole-vs-block boundary (bytes): a read miss below this is whole-cached, at/above it is block-cached; must stay below ocache's 64 MB compaction threshold | `4194304` (4 MiB)        |
+| `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
+| `TAG_CACHE_BLOCK_SIZE`             | Block granularity **and** the read-side whole-vs-block boundary (bytes): a read miss below this is whole-cached, at/above it is block-cached; must stay below ocache's 64 MB compaction threshold | `1048576` (1 MiB)        |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -155,17 +155,18 @@ cache:
   # negative disables. Override with TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION env var.
   warm_on_write_reserved_fraction: 0.5
 
-  # Block-aligned caching for large objects (RFC 0001). When enabled, any object at or above
-  # block_size is cached at block granularity regardless of how it was fetched (range read,
-  # full GET, or warm-on-write), so a range read populates and serves only the blocks it
-  # touches. Off by default (opt-in rollout).
-  block_caching_enabled: false
+  # Block-aligned caching for large objects (RFC 0001). Any object at or above block_size is
+  # cached at block granularity regardless of how it was fetched (range read, full GET, or
+  # warm-on-write), so a range read populates and serves only the blocks it touches. On by
+  # default; set false to cache whole objects instead.
+  block_caching_enabled: true
 
   # Block granularity AND the whole-vs-block boundary for every populate path: an object
-  # smaller than one block is whole-cached, one this size or larger is block-cached. Must stay
+  # smaller than one block is whole-cached, one this size or larger is block-cached. Size it to
+  # your workload's read granularity — an oversized block over-fetches on every miss. Must stay
   # below ocache's 64 MB compaction threshold so blocks pack into shared segments. 0/unset =
-  # default. Override with TAG_CACHE_BLOCK_SIZE env var.
-  block_size: 4194304
+  # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
+  block_size: 1048576
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -338,8 +339,8 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `enabled`               | bool     | `true`           | Enable caching                                                                      |
 | `ttl`                   | duration | `24h`            | Default TTL for cached objects                                                      |
 | `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
-| `block_caching_enabled` | bool     | `false`          | Enable block-aligned caching for large objects (RFC 0001)                           |
-| `block_size`            | int64    | `4194304`        | Block granularity **and** the read-side whole-vs-block boundary (must stay below ocache's 64 MB compaction threshold) |
+| `block_caching_enabled` | bool     | `true`           | Enable block-aligned caching for large objects (RFC 0001)                           |
+| `block_size`            | int64    | `1048576`        | Block granularity **and** the read-side whole-vs-block boundary (must stay below ocache's 64 MB compaction threshold) |
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -109,7 +109,7 @@ env:
 
 Start near your median read size; the `1048576` (1 MiB) default suits typical analytics footers/row-groups — raise it for larger reads, or lower it (e.g. `65536` for 64 KiB reads). Then verify with Prometheus:
 
-- **Upstream amplification** — `sum(rate(tag_bytes_transferred_total{direction="in"}[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))`. Aim for **≤ 1** (the cache serves more than it fetches); a value well above 1 means the block size is too large for the read pattern.
+- **Upstream read amplification** — `sum(rate(tag_cache_block_bytes_populated_total[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))` — bytes fetched from upstream into blocks vs bytes served to clients. Aim for **≤ 1**; well above 1 means the block size is too large for the read pattern. (Do **not** use `tag_bytes_transferred_total{direction="in"}` — that counts client upload bodies, not upstream fetches.)
 - **Block hit ratio** — `tag_cache_block_hits_total / (tag_cache_block_hits_total + tag_cache_block_misses_total)`.
 - **Serve latency** — `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.16.0
+    newTag: v1.17.0
 ```
 
 ## Production Considerations
@@ -88,16 +88,18 @@ images:
 
 > **Memory note:** high pod memory is expected and healthy — most of it is reclaimable Linux page cache over the on-disk RocksDB cache, not the TAG process (its RSS is typically well under 1 GiB). It plateaus below the pod limit; treat it as page cache, not a leak. Only raise the memory limit (never lower the disk cache) if the working set trends up to the limit.
 
-### Block-aligned caching (optional)
+### Block-aligned caching
 
-By default TAG caches whole objects. For workloads that read **small ranges of large objects** (Parquet footers/row-groups, SlateDB/SST blocks, columnar analytics), enable **block-aligned caching** ([RFC 0001](rfcs/0001-block-aligned-caching.md)) so a range read fetches and caches only the covering blocks instead of the whole object:
+**Block-aligned caching is on by default** ([RFC 0001](rfcs/0001-block-aligned-caching.md)): any object at or above `block_size` is cached as fixed-size blocks, so a range read fetches and caches only the covering blocks instead of the whole object — ideal for **small ranges of large objects** (Parquet footers/row-groups, SlateDB/SST blocks, columnar analytics). The one knob that matters is `block_size`:
 
 ```yaml
 env:
-  - name: TAG_CACHE_BLOCK_CACHING_ENABLED
-    value: "true"
+  # Block caching is on by default at 1 MiB. Tune block_size to your read granularity:
   - name: TAG_CACHE_BLOCK_SIZE
-    value: "1048576" # 1 MiB — size to your read granularity (see below)
+    value: "1048576" # 1 MiB (default)
+  # ...or opt out entirely to cache whole objects:
+  # - name: TAG_CACHE_BLOCK_CACHING_ENABLED
+  #   value: "false"
 ```
 
 **Sizing `block_size` to your workload's dominant read size is the critical tuning knob:**
@@ -105,7 +107,7 @@ env:
 - **Too large** and every cache miss pulls a full block to serve a small range — upstream **read amplification**. A 4 MiB block serving ~400 KB reads amplifies upstream traffic several-fold and can be *worse* than whole-object caching.
 - **Too small** adds per-block bookkeeping and more fetches per read.
 
-Start near your median read size (often 256 KiB–1 MiB for analytics footers/row-groups; the `4194304` default is tuned for larger reads). Then verify with Prometheus:
+Start near your median read size; the `1048576` (1 MiB) default suits typical analytics footers/row-groups — raise it for larger reads, or lower it (e.g. `65536` for 64 KiB reads). Then verify with Prometheus:
 
 - **Upstream amplification** — `sum(rate(tag_bytes_transferred_total{direction="in"}[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))`. Aim for **≤ 1** (the cache serves more than it fetches); a value well above 1 means the block size is too large for the read pattern.
 - **Block hit ratio** — `tag_cache_block_hits_total / (tag_cache_block_hits_total + tag_cache_block_misses_total)`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.14.0
+    newTag: v1.16.0
 ```
 
 ## Production Considerations
@@ -85,6 +85,33 @@ images:
 **Horizontal:** The HPA scales from 3 to 10 replicas based on CPU (70%) and memory (80%) utilization. New nodes join the cache cluster automatically. Scaling down may temporarily reduce cache hit ratio.
 
 **Vertical:** Adjust resource requests/limits in the StatefulSet. The default is 2-4 CPUs and 4-8 GiB memory per pod. SSD storage is recommended for cache performance. If you change the PVC volume size, also update `TAG_CACHE_MAX_DISK_USAGE` in the StatefulSet to match (value is in bytes).
+
+> **Memory note:** high pod memory is expected and healthy — most of it is reclaimable Linux page cache over the on-disk RocksDB cache, not the TAG process (its RSS is typically well under 1 GiB). It plateaus below the pod limit; treat it as page cache, not a leak. Only raise the memory limit (never lower the disk cache) if the working set trends up to the limit.
+
+### Block-aligned caching (optional)
+
+By default TAG caches whole objects. For workloads that read **small ranges of large objects** (Parquet footers/row-groups, SlateDB/SST blocks, columnar analytics), enable **block-aligned caching** ([RFC 0001](rfcs/0001-block-aligned-caching.md)) so a range read fetches and caches only the covering blocks instead of the whole object:
+
+```yaml
+env:
+  - name: TAG_CACHE_BLOCK_CACHING_ENABLED
+    value: "true"
+  - name: TAG_CACHE_BLOCK_SIZE
+    value: "1048576" # 1 MiB — size to your read granularity (see below)
+```
+
+**Sizing `block_size` to your workload's dominant read size is the critical tuning knob:**
+
+- **Too large** and every cache miss pulls a full block to serve a small range — upstream **read amplification**. A 4 MiB block serving ~400 KB reads amplifies upstream traffic several-fold and can be *worse* than whole-object caching.
+- **Too small** adds per-block bookkeeping and more fetches per read.
+
+Start near your median read size (often 256 KiB–1 MiB for analytics footers/row-groups; the `4194304` default is tuned for larger reads). Then verify with Prometheus:
+
+- **Upstream amplification** — `sum(rate(tag_bytes_transferred_total{direction="in"}[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))`. Aim for **≤ 1** (the cache serves more than it fetches); a value well above 1 means the block size is too large for the read pattern.
+- **Block hit ratio** — `tag_cache_block_hits_total / (tag_cache_block_hits_total + tag_cache_block_misses_total)`.
+- **Serve latency** — `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
+
+Cache buffering memory (populate + block-serve staging) is bounded by `TAG_CACHE_MAX_POPULATE_MEMORY` — one honest total (default 2 GiB). See the [Configuration Reference](configuration.md).
 
 ### Health Checks
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.16.0
+    image: tigrisdata/tag:v1.17.0
     ports:
       - "8080:8080"
     environment:

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -44,7 +44,7 @@ Mount the certificate and key files into the container and set the environment v
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.14.0
+    image: tigrisdata/tag:v1.16.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Docs for **v1.17.0**, where block-aligned caching became the **default at 1 MiB** (#145).

## Defaults updated (block caching is now on)
- **`docs/configuration.md`**: `block_caching_enabled` default **false → true**, `block_size` default **4194304 (4 MiB) → 1048576 (1 MiB)** — across the env table, YAML example, and struct table; with a note that `block_size` should match the workload's read granularity.
- **README**: the feature reframed **opt-in → default**; Cache Behavior now describes block caching as the default with the whole-object opt-out (`block_caching_enabled: false`).
- **`docs/deploy.md`**: "Block-aligned caching (optional)" → "Block-aligned caching" (it's the default); the example shows the 1 MiB default and how to disable; fixed the stale "4194304 default" note; kept the `block_size` sizing guidance + Prometheus verification queries and the page-cache memory note. README anchor updated to match.

## Version pins
- Bump pinned image **v1.16.0 → v1.17.0** in the kustomize/statefulset manifests and the `deploy.md`/`tls.md` examples (they were behind).

Sequenced after the v1.17.0 release, as planned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version string changes only; no runtime or configuration code is modified in this diff.
> 
> **Overview**
> Documentation now matches **v1.17.0** product defaults: **block-aligned caching is on by default** at **1 MiB** (`block_caching_enabled` **true**, `block_size` **1048576**), with whole-object caching described as the opt-out via `block_caching_enabled: false`.
> 
> **README** and **`docs/configuration.md`** reframe block caching from opt-in to default and update cache-behavior wording (block vs whole-object paths). **`docs/deploy.md`** treats block caching as the production default, adds a **page-cache memory** note for Kubernetes pods, and keeps **`block_size`** tuning guidance plus Prometheus checks for read amplification and block hit ratio.
> 
> **Version pins** move from **v1.14.0** to **v1.17.0** across Kubernetes manifests, native **install/run** scripts, README install example, **`docs/deploy.md`**, and **`docs/tls.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56b9e320277813425f73a8510b50c13a3291325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->