### PR TITLE
feat: enable block-aligned caching by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,13 +39,15 @@ const (
 	// DefaultCacheSizeThreshold is the max object size to cache (1GB).
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
 
-	// DefaultCacheBlockSize (4 MiB) is the block granularity AND the read-side whole-vs-block
+	// DefaultCacheBlockSize (1 MiB) is the block granularity AND the read-side whole-vs-block
 	// boundary: a read miss for an object SMALLER than one block is cached as a whole blob
 	// (block-caching a sub-block object is identical to whole-caching it), while an object
-	// this size or LARGER is cached at block granularity. It must stay below ocache's 64 MB
-	// CompactThreshold so blocks pack into shared segments rather than each becoming a
-	// standalone file (see RFC 0001).
-	DefaultCacheBlockSize = 4 * 1024 * 1024
+	// this size or LARGER is cached at block granularity. Sized to typical analytics read
+	// granularity (Parquet footers/row-groups, SST blocks); tune it to your workload's read
+	// size, since an oversized block over-fetches on every miss and amplifies upstream. It must
+	// stay below ocache's 64 MB CompactThreshold so blocks pack into shared segments rather than
+	// each becoming a standalone file (see RFC 0001).
+	DefaultCacheBlockSize = 1 * 1024 * 1024
 
 	// DefaultCacheDiskPath is the default disk path for embedded cache storage.
 	DefaultCacheDiskPath = "/var/cache/tag"
@@ -236,7 +238,7 @@ type CacheConfig struct {
 	// BlockSize is the block granularity AND the read-side whole-vs-block boundary: a read
 	// miss for an object smaller than one block is whole-cached, an object this size or larger
 	// is block-cached. It must stay below ocache's 64 MB CompactThreshold so blocks pack into
-	// shared segments. 0 or unset uses DefaultCacheBlockSize (4 MiB). Only meaningful when
+	// shared segments. 0 or unset uses DefaultCacheBlockSize (1 MiB). Only meaningful when
 	// BlockCachingEnabled is true.
 	BlockSize int64 `yaml:"block_size"`
 	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget

--- a/config/config.go
+++ b/config/config.go
@@ -229,8 +229,10 @@ type CacheConfig struct {
 	// BlockCachingEnabled turns on block-aligned caching for large objects (RFC 0001):
 	// objects at or above BlockSize are cached at BlockSize granularity on read, so a range
 	// read (e.g. a Parquet footer) populates and serves only the blocks it touches instead of
-	// the whole object. Defaults to false (opt-in rollout).
-	BlockCachingEnabled bool `yaml:"block_caching_enabled"`
+	// the whole object. Defaults to true when nil; set false to disable. Read via
+	// IsBlockCachingEnabled(). Size BlockSize to your workload's read granularity — an
+	// oversized block amplifies upstream traffic on every miss.
+	BlockCachingEnabled *bool `yaml:"block_caching_enabled"`
 	// BlockSize is the block granularity AND the read-side whole-vs-block boundary: a read
 	// miss for an object smaller than one block is whole-cached, an object this size or larger
 	// is block-cached. It must stay below ocache's 64 MB CompactThreshold so blocks pack into
@@ -256,6 +258,19 @@ func (c *CacheConfig) IsEnabled() bool {
 		return true // Default to enabled
 	}
 	return *c.Enabled
+}
+
+// IsBlockCachingEnabled returns whether block-aligned caching is enabled (default: true when nil).
+func (c *CacheConfig) IsBlockCachingEnabled() bool {
+	if c.BlockCachingEnabled == nil {
+		return true // Default to enabled
+	}
+	return *c.BlockCachingEnabled
+}
+
+// SetBlockCachingEnabled sets the BlockCachingEnabled field to the given value.
+func (c *CacheConfig) SetBlockCachingEnabled(enabled bool) {
+	c.BlockCachingEnabled = &enabled
 }
 
 // SetEnabled sets the Enabled field to the given value.
@@ -569,7 +584,7 @@ func applyEnvOverrides(cfg *Config) {
 		}
 		// Override block-aligned caching from environment (accepts true/false/1/0).
 		if b, ok := envBool("TAG_CACHE_BLOCK_CACHING_ENABLED"); ok {
-			cfg.Cache.BlockCachingEnabled = b
+			cfg.Cache.SetBlockCachingEnabled(b)
 		}
 		// Override the block granularity from environment (0/unset keeps the default).
 		if n, ok := envInt64("TAG_CACHE_BLOCK_SIZE"); ok && n > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -533,7 +533,7 @@ func TestLoad_BlockCachingEnabledOverrideByEnv(t *testing.T) {
 		env  string
 		want bool
 	}{
-		{"default off", "cache:\n  enabled: true\n", "", false},
+		{"default on", "cache:\n  enabled: true\n", "", true},
 		{"yaml on", "cache:\n  enabled: true\n  block_caching_enabled: true\n", "", true},
 		{"env enables", "cache:\n  enabled: true\n", "true", true},
 		{"env disables over yaml", "cache:\n  enabled: true\n  block_caching_enabled: true\n", "false", false},
@@ -553,8 +553,8 @@ func TestLoad_BlockCachingEnabledOverrideByEnv(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Load() error = %v", err)
 			}
-			if cfg.Cache.BlockCachingEnabled != tc.want {
-				t.Errorf("BlockCachingEnabled = %v, want %v", cfg.Cache.BlockCachingEnabled, tc.want)
+			if cfg.Cache.IsBlockCachingEnabled() != tc.want {
+				t.Errorf("BlockCachingEnabled = %v, want %v", cfg.Cache.IsBlockCachingEnabled(), tc.want)
 			}
 		})
 	}

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -75,7 +75,7 @@ var errBlocksMostlyAbsent = fmt.Errorf("too many absent blocks: %w", errBlockStr
 // Config built directly, bypassing Load's normalization) from dividing by zero in block
 // arithmetic. A read miss for a block-eligible object populates blocks, not a whole blob.
 func (s *Service) isBlockEligibleSize(contentLength int64) bool {
-	return s.config.Cache.BlockCachingEnabled &&
+	return s.config.Cache.IsBlockCachingEnabled() &&
 		s.config.Cache.BlockSize > 0 &&
 		contentLength >= s.config.Cache.BlockSize
 }

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -134,7 +134,7 @@ func fullGet(bucket, key string) *http.Request {
 func newBlockService(t *testing.T, mock *blockMockForwarder) (*Service, *cache.Cache) {
 	t.Helper()
 	svc, c := newTestService(mock, true)
-	svc.config.Cache.BlockCachingEnabled = true
+	svc.config.Cache.SetBlockCachingEnabled(true)
 	svc.config.Cache.BlockSize = 4 // boundary: the 10-byte test object (>= 4) is block-mode
 	svc.config.Cache.SizeThreshold = 1 << 20
 	return svc, c
@@ -145,7 +145,7 @@ func newBlockService(t *testing.T, mock *blockMockForwarder) (*Service, *cache.C
 func newBlockServiceWithBudget(t *testing.T, mock *blockMockForwarder, blockSize, budget int64) (*Service, *cache.Cache) {
 	t.Helper()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = blockSize
 	cfg.Cache.SizeThreshold = 1 << 20
 	cfg.Cache.MaxPopulateMemoryBytes = budget
@@ -337,7 +337,7 @@ func TestBlockCache_WarmOnWriteBlockSplitsBlockEligible(t *testing.T) {
 	}
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
-	svc.config.Cache.BlockCachingEnabled = true
+	svc.config.Cache.SetBlockCachingEnabled(true)
 	svc.config.Cache.BlockSize = 4 // the 10-byte object is block-eligible (>= 4)
 	svc.config.Cache.SizeThreshold = 1 << 20
 
@@ -1245,7 +1245,7 @@ func TestBlockCache_AssemblyCacheReadFailureFallsThroughWithoutInvalidating(t *t
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
@@ -1283,7 +1283,7 @@ func TestBlockCache_ProbePathTransientFailureAbortsWithoutInvalidating(t *testin
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
@@ -1403,7 +1403,7 @@ func TestBlockCache_CompleteEntryInlineFetchRecoversEvictedBlock(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // blocks [0..3][4..7][8..9]
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1448,7 +1448,7 @@ func TestBlockCache_CompleteEntryFirstBlockGoneFallsThroughCleanly(t *testing.T)
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1523,7 +1523,7 @@ func TestBlockCache_CompleteEntryMidServeStaleSignalInvalidates(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1563,7 +1563,7 @@ func TestBlockCache_CompleteEntryFetchDeclineSalvagesViaRemainder(t *testing.T) 
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	cfg.Cache.MaxPopulateMemoryBytes = 100
@@ -1610,7 +1610,7 @@ func TestBlockCache_CompleteEntryMassEvictionBoundsUpstreamFanout(t *testing.T) 
 	mock := newBlockMock(object, `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 2
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)


### PR DESCRIPTION
Flips `block_caching_enabled` default from **false → true**.

## Implementation
Follows the existing default-true bool pattern in this codebase (`transparent_proxy`, `cache.enabled`, `grpc_auth`):
- `BlockCachingEnabled` becomes `*bool` (nil = default true), read via a new **`IsBlockCachingEnabled()`** accessor, set via `SetBlockCachingEnabled()`.
- `TAG_CACHE_BLOCK_CACHING_ENABLED` env and `block_caching_enabled: false` in YAML still disable it explicitly.
- Consumers updated (proxy `isBlockEligibleSize`, env override, tests). config + proxy suites pass; lint clean.

## ⚠️ Reviewer note: default `block_size` interaction
The default `block_size` stays **4 MiB**. Block caching only wins when `block_size` matches the workload's read granularity. For **small-range workloads** (Parquet footers, SST blocks — sub-MB reads), a 4 MiB block over-fetches and **amplifies upstream** — we observed **21×** on Parseable prod at 4 MiB before tuning to 1 MiB (see `docs/deploy.md#block-aligned-caching-optional`).

So enabling by default means either:
1. deployments with small reads must set `block_size` to their read size (documented), **or**
2. we also lower the default `block_size` (not done here — out of scope for this flip, but worth deciding).

Wanted this called out explicitly before merge.

## Docs
Per the plan, README/config docs still say "default false" — those update in the docs PR (#144) after this merges and releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on block caching changes read-miss behavior and upstream fetch patterns for every deployment without explicit opt-out; wrong block_size for a workload can still over-fetch on misses despite the 1 MiB default.
> 
> **Overview**
> **Block-aligned caching is on by default** for new and unset configs: `block_caching_enabled` is now a `*bool` (nil → enabled), with **`IsBlockCachingEnabled()`** / **`SetBlockCachingEnabled()`** matching other default-true knobs. YAML `block_caching_enabled: false` and **`TAG_CACHE_BLOCK_CACHING_ENABLED`** still opt out.
> 
> The default **`block_size`** drops from **4 MiB to 1 MiB**, with docs stressing that misses fetch whole blocks—oversized blocks amplify upstream traffic on analytics-style small range reads.
> 
> Proxy eligibility (`isBlockEligibleSize`) and tests use the accessor instead of assigning the bool directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e360f56cc5cac4cc03273fe4df6b4bb9d7cef5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->