### PR TITLE
Release

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,11 +7,11 @@ on:
         description: "Cache mode to benchmark"
         type: choice
         options:
-          - default # whole-object caching (default path)
-          - blocks # block-aligned caching (RFC 0001)
-        default: default
+          - blocks # block-aligned caching (RFC 0001) — the product default
+          - whole # whole-object caching (block caching disabled) — baseline
+        default: blocks
       block_size:
-        description: "Block size in bytes for blocks mode (empty = 4 MiB default). e.g. 65536 to match the 64 KiB GET RANGE size."
+        description: "Block size in bytes for blocks mode (empty = 1 MiB default). e.g. 65536 to match the 64 KiB GET RANGE size."
         type: string
         default: ""
       duration:
@@ -23,7 +23,7 @@ on:
         type: string
         default: ""
       max_populate_memory:
-        description: "Populate memory budget in bytes (empty = 1GiB default). Diagnostic knob for budget-contention hypotheses."
+        description: "Populate memory budget in bytes (empty = 2GiB default). Diagnostic knob for budget-contention hypotheses."
         type: string
         default: ""
       range_objects:
@@ -37,11 +37,11 @@ on:
   workflow_call:
     inputs:
       cache_mode:
-        description: "Cache mode to benchmark: default | blocks"
+        description: "Cache mode to benchmark: blocks (default) | whole"
         type: string
-        default: default
+        default: blocks
       block_size:
-        description: "Block size in bytes for blocks mode (empty = 4 MiB default)"
+        description: "Block size in bytes for blocks mode (empty = 1 MiB default)"
         type: string
         default: ""
       duration:
@@ -53,7 +53,7 @@ on:
         type: string
         default: ""
       max_populate_memory:
-        description: "Populate memory budget in bytes (empty = 1GiB default)"
+        description: "Populate memory budget in bytes (empty = 2GiB default)"
         type: string
         default: ""
       range_objects:
@@ -65,7 +65,7 @@ on:
         type: string
         default: ""
   schedule:
-    # Nightly at 07:00 UTC (runs the default-mode benchmark)
+    # Nightly at 07:00 UTC (runs the product default: block-aligned caching)
     - cron: "0 7 * * *"
 
 # Each run benchmarks against its own bucket (tag-warp-ci-<run id>): warp clears its bucket
@@ -102,17 +102,17 @@ jobs:
       - name: Install system dependencies
         run: make install-deps
 
-      # cache_mode='blocks' enables block-aligned caching. block_size tunes the granularity: empty
-      # uses the 4 MiB production default, but warp GET RANGE reads 64 KiB ranges from 256 MiB
-      # objects (the SlateDB pattern), so at 4 MiB blocks each 64 KiB read pulls a full 4 MiB block
-      # (~64x read amplification). Pass block_size=65536 to size blocks to the range (1:1, no
-      # amplification) and measure where block caching actually wins. Anything else (default, or the
-      # empty cache_mode on scheduled/push runs) uses the whole-object path.
+      # Block-aligned caching is the product default (v1.16.0+), so the default run — and the
+      # scheduled/push nightly (empty cache_mode) — enables it, tracking what ships. cache_mode='whole'
+      # disables it to benchmark the whole-object baseline. block_size tunes the granularity: empty
+      # uses the 1 MiB default. warp GET RANGE reads 64 KiB ranges from 256 MiB objects (the SlateDB
+      # pattern), so at 1 MiB blocks each 64 KiB read pulls a 1 MiB block (~16x read amplification);
+      # pass block_size=65536 to size blocks to the range (1:1) and measure where block caching wins.
       - name: Start TAG (local mode)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          TAG_CACHE_BLOCK_CACHING_ENABLED: ${{ inputs.cache_mode == 'blocks' && 'true' || 'false' }}
+          TAG_CACHE_BLOCK_CACHING_ENABLED: ${{ inputs.cache_mode == 'whole' && 'false' || 'true' }}
           TAG_CACHE_BLOCK_SIZE: ${{ inputs.block_size }}
           TAG_CACHE_MAX_POPULATE_MEMORY: ${{ inputs.max_populate_memory }}
         run: make s3-test-local

--- a/config/config.go
+++ b/config/config.go
@@ -39,13 +39,15 @@ const (
 	// DefaultCacheSizeThreshold is the max object size to cache (1GB).
 	DefaultCacheSizeThreshold = 1024 * 1024 * 1024
 
-	// DefaultCacheBlockSize (4 MiB) is the block granularity AND the read-side whole-vs-block
+	// DefaultCacheBlockSize (1 MiB) is the block granularity AND the read-side whole-vs-block
 	// boundary: a read miss for an object SMALLER than one block is cached as a whole blob
 	// (block-caching a sub-block object is identical to whole-caching it), while an object
-	// this size or LARGER is cached at block granularity. It must stay below ocache's 64 MB
-	// CompactThreshold so blocks pack into shared segments rather than each becoming a
-	// standalone file (see RFC 0001).
-	DefaultCacheBlockSize = 4 * 1024 * 1024
+	// this size or LARGER is cached at block granularity. Sized to typical analytics read
+	// granularity (Parquet footers/row-groups, SST blocks); tune it to your workload's read
+	// size, since an oversized block over-fetches on every miss and amplifies upstream. It must
+	// stay below ocache's 64 MB CompactThreshold so blocks pack into shared segments rather than
+	// each becoming a standalone file (see RFC 0001).
+	DefaultCacheBlockSize = 1 * 1024 * 1024
 
 	// DefaultCacheDiskPath is the default disk path for embedded cache storage.
 	DefaultCacheDiskPath = "/var/cache/tag"
@@ -229,12 +231,14 @@ type CacheConfig struct {
 	// BlockCachingEnabled turns on block-aligned caching for large objects (RFC 0001):
 	// objects at or above BlockSize are cached at BlockSize granularity on read, so a range
 	// read (e.g. a Parquet footer) populates and serves only the blocks it touches instead of
-	// the whole object. Defaults to false (opt-in rollout).
-	BlockCachingEnabled bool `yaml:"block_caching_enabled"`
+	// the whole object. Defaults to true when nil; set false to disable. Read via
+	// IsBlockCachingEnabled(). Size BlockSize to your workload's read granularity — an
+	// oversized block amplifies upstream traffic on every miss.
+	BlockCachingEnabled *bool `yaml:"block_caching_enabled"`
 	// BlockSize is the block granularity AND the read-side whole-vs-block boundary: a read
 	// miss for an object smaller than one block is whole-cached, an object this size or larger
 	// is block-cached. It must stay below ocache's 64 MB CompactThreshold so blocks pack into
-	// shared segments. 0 or unset uses DefaultCacheBlockSize (4 MiB). Only meaningful when
+	// shared segments. 0 or unset uses DefaultCacheBlockSize (1 MiB). Only meaningful when
 	// BlockCachingEnabled is true.
 	BlockSize int64 `yaml:"block_size"`
 	// WarmOnWriteReservedFraction caps the fraction of the populate memory budget
@@ -256,6 +260,19 @@ func (c *CacheConfig) IsEnabled() bool {
 		return true // Default to enabled
 	}
 	return *c.Enabled
+}
+
+// IsBlockCachingEnabled returns whether block-aligned caching is enabled (default: true when nil).
+func (c *CacheConfig) IsBlockCachingEnabled() bool {
+	if c.BlockCachingEnabled == nil {
+		return true // Default to enabled
+	}
+	return *c.BlockCachingEnabled
+}
+
+// SetBlockCachingEnabled sets the BlockCachingEnabled field to the given value.
+func (c *CacheConfig) SetBlockCachingEnabled(enabled bool) {
+	c.BlockCachingEnabled = &enabled
 }
 
 // SetEnabled sets the Enabled field to the given value.
@@ -569,7 +586,7 @@ func applyEnvOverrides(cfg *Config) {
 		}
 		// Override block-aligned caching from environment (accepts true/false/1/0).
 		if b, ok := envBool("TAG_CACHE_BLOCK_CACHING_ENABLED"); ok {
-			cfg.Cache.BlockCachingEnabled = b
+			cfg.Cache.SetBlockCachingEnabled(b)
 		}
 		// Override the block granularity from environment (0/unset keeps the default).
 		if n, ok := envInt64("TAG_CACHE_BLOCK_SIZE"); ok && n > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -533,7 +533,7 @@ func TestLoad_BlockCachingEnabledOverrideByEnv(t *testing.T) {
 		env  string
 		want bool
 	}{
-		{"default off", "cache:\n  enabled: true\n", "", false},
+		{"default on", "cache:\n  enabled: true\n", "", true},
 		{"yaml on", "cache:\n  enabled: true\n  block_caching_enabled: true\n", "", true},
 		{"env enables", "cache:\n  enabled: true\n", "true", true},
 		{"env disables over yaml", "cache:\n  enabled: true\n  block_caching_enabled: true\n", "false", false},
@@ -553,8 +553,8 @@ func TestLoad_BlockCachingEnabledOverrideByEnv(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Load() error = %v", err)
 			}
-			if cfg.Cache.BlockCachingEnabled != tc.want {
-				t.Errorf("BlockCachingEnabled = %v, want %v", cfg.Cache.BlockCachingEnabled, tc.want)
+			if cfg.Cache.IsBlockCachingEnabled() != tc.want {
+				t.Errorf("BlockCachingEnabled = %v, want %v", cfg.Cache.IsBlockCachingEnabled(), tc.want)
 			}
 		})
 	}

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -75,7 +75,7 @@ var errBlocksMostlyAbsent = fmt.Errorf("too many absent blocks: %w", errBlockStr
 // Config built directly, bypassing Load's normalization) from dividing by zero in block
 // arithmetic. A read miss for a block-eligible object populates blocks, not a whole blob.
 func (s *Service) isBlockEligibleSize(contentLength int64) bool {
-	return s.config.Cache.BlockCachingEnabled &&
+	return s.config.Cache.IsBlockCachingEnabled() &&
 		s.config.Cache.BlockSize > 0 &&
 		contentLength >= s.config.Cache.BlockSize
 }

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -134,7 +134,7 @@ func fullGet(bucket, key string) *http.Request {
 func newBlockService(t *testing.T, mock *blockMockForwarder) (*Service, *cache.Cache) {
 	t.Helper()
 	svc, c := newTestService(mock, true)
-	svc.config.Cache.BlockCachingEnabled = true
+	svc.config.Cache.SetBlockCachingEnabled(true)
 	svc.config.Cache.BlockSize = 4 // boundary: the 10-byte test object (>= 4) is block-mode
 	svc.config.Cache.SizeThreshold = 1 << 20
 	return svc, c
@@ -145,7 +145,7 @@ func newBlockService(t *testing.T, mock *blockMockForwarder) (*Service, *cache.C
 func newBlockServiceWithBudget(t *testing.T, mock *blockMockForwarder, blockSize, budget int64) (*Service, *cache.Cache) {
 	t.Helper()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = blockSize
 	cfg.Cache.SizeThreshold = 1 << 20
 	cfg.Cache.MaxPopulateMemoryBytes = budget
@@ -337,7 +337,7 @@ func TestBlockCache_WarmOnWriteBlockSplitsBlockEligible(t *testing.T) {
 	}
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
-	svc.config.Cache.BlockCachingEnabled = true
+	svc.config.Cache.SetBlockCachingEnabled(true)
 	svc.config.Cache.BlockSize = 4 // the 10-byte object is block-eligible (>= 4)
 	svc.config.Cache.SizeThreshold = 1 << 20
 
@@ -1245,7 +1245,7 @@ func TestBlockCache_AssemblyCacheReadFailureFallsThroughWithoutInvalidating(t *t
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
@@ -1283,7 +1283,7 @@ func TestBlockCache_ProbePathTransientFailureAbortsWithoutInvalidating(t *testin
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	faulty := &blockReadFaultClient{CacheClient: cacheclient.NewMemoryCache()}
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(faulty, &cfg.Cache)
@@ -1403,7 +1403,7 @@ func TestBlockCache_CompleteEntryInlineFetchRecoversEvictedBlock(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`) // blocks [0..3][4..7][8..9]
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1448,7 +1448,7 @@ func TestBlockCache_CompleteEntryFirstBlockGoneFallsThroughCleanly(t *testing.T)
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1523,7 +1523,7 @@ func TestBlockCache_CompleteEntryMidServeStaleSignalInvalidates(t *testing.T) {
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
@@ -1563,7 +1563,7 @@ func TestBlockCache_CompleteEntryFetchDeclineSalvagesViaRemainder(t *testing.T) 
 	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 4
 	cfg.Cache.SizeThreshold = 1 << 20
 	cfg.Cache.MaxPopulateMemoryBytes = 100
@@ -1610,7 +1610,7 @@ func TestBlockCache_CompleteEntryMassEvictionBoundsUpstreamFanout(t *testing.T) 
 	mock := newBlockMock(object, `"v1"`)
 	memCache := cacheclient.NewMemoryCache()
 	cfg := config.NewDefault()
-	cfg.Cache.BlockCachingEnabled = true
+	cfg.Cache.SetBlockCachingEnabled(true)
 	cfg.Cache.BlockSize = 2
 	cfg.Cache.SizeThreshold = 1 << 20
 	c := cache.NewCacheWithClient(memCache, &cfg.Cache)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Default-on block caching changes miss/populate behavior for every deployment without explicit opt-out; lower block size also shifts upstream fetch patterns on range reads.
> 
> **Overview**
> **Block-aligned caching (RFC 0001) is now on by default** for new and unset configs: `block_caching_enabled` is a nullable `*bool` (default **true** when omitted), accessed via `IsBlockCachingEnabled()` / `SetBlockCachingEnabled()`, matching how other cache toggles work. Set `block_caching_enabled: false` or `TAG_CACHE_BLOCK_CACHING_ENABLED=false` to restore whole-object caching.
> 
> The default **block size drops from 4 MiB to 1 MiB**, with docs stressing tuning to read granularity (e.g. Parquet/SST) to limit miss amplification.
> 
> CI **warp benchmarks** align with shipping defaults: `cache_mode` choices are `blocks` (default) vs `whole` (baseline); nightly runs use block mode; `TAG_CACHE_BLOCK_CACHING_ENABLED` is true unless `whole` is selected. Workflow text reflects 1 MiB blocks and 2 GiB populate memory defaults.
> 
> Proxy read-miss eligibility and integration tests use the new helpers instead of assigning the bool field directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b313aba889927583381392500350c330e8ecdeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->