### PR TITLE
perf(proxy): avoid cache populate completion wait

### DIFF
--- a/proxy/broadcast/broadcaster.go
+++ b/proxy/broadcast/broadcaster.go
@@ -94,13 +94,24 @@ type Listener struct {
 	disconnected bool          // True if disconnected due to slow consumption
 }
 
-// WaitForHeaders blocks until headers are available.
+// WaitForHeaders blocks until headers are available. If headers and context
+// cancellation become ready together, headers win. A cache listener can be
+// scheduled after its request handler returns, when both are already ready; it
+// must still consume the completed response and publish the cache entry.
 func (l *Listener) WaitForHeaders(ctx context.Context) (int, http.Header, error) {
 	select {
-	case <-ctx.Done():
-		return 0, nil, ctx.Err()
 	case <-l.headerCh:
 		return l.status, l.headers, nil
+	case <-ctx.Done():
+		// A select chooses randomly when both channels are ready. Re-check the
+		// headers so a completed response wins over concurrent cancellation, while
+		// still honoring cancellation when headers have not arrived.
+		select {
+		case <-l.headerCh:
+			return l.status, l.headers, nil
+		default:
+			return 0, nil, ctx.Err()
+		}
 	}
 }
 

--- a/proxy/broadcast/broadcaster_test.go
+++ b/proxy/broadcast/broadcaster_test.go
@@ -247,10 +247,36 @@ func TestBroadcasterContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	// WaitForHeaders should return context error
+	// WaitForHeaders should return context error before headers arrive.
 	_, _, err := listener.WaitForHeaders(ctx)
 	if err != context.Canceled {
 		t.Errorf("Expected context.Canceled, got %v", err)
+	}
+}
+
+func TestBroadcasterHeadersWinOverConcurrentCancellation(t *testing.T) {
+	b := NewBroadcaster(DefaultChannelBuffer)
+	listener := b.Subscribe()
+	if listener == nil {
+		t.Fatal("Subscribe returned nil")
+	}
+
+	headers := make(http.Header)
+	headers.Set("ETag", `"ready"`)
+	b.SetHeaders(http.StatusOK, headers)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, gotHeaders, err := listener.WaitForHeaders(ctx)
+	if err != nil {
+		t.Fatalf("WaitForHeaders: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want %d", status, http.StatusOK)
+	}
+	if got := gotHeaders.Get("ETag"); got != `"ready"` {
+		t.Errorf("ETag = %q, want %q", got, `"ready"`)
 	}
 }
 

--- a/proxy/cache_populate_benchmark_test.go
+++ b/proxy/cache_populate_benchmark_test.go
@@ -1,0 +1,157 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+func cacheableGetResponse(body, etag string) *http.Response {
+	headers := make(http.Header)
+	headers.Set("Content-Length", strconv.Itoa(len(body)))
+	headers.Set("Content-Type", "text/plain")
+	headers.Set("ETag", etag)
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        headers,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+// waitForCacheMeta observes publication through the cache's public read path.
+// Cache writes commit the body before metadata, so a visible metadata entry can
+// safely serve a later GET.
+func waitForCacheMeta(t testing.TB, cacheStore *cache.Cache, bucket, key string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, found, err := cacheStore.GetMeta(context.Background(), bucket, key)
+		if err != nil {
+			t.Fatalf("read cache metadata for %s/%s: %v", bucket, key, err)
+		}
+		if found {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("cache metadata was not published for %s/%s", bucket, key)
+		case <-ticker.C:
+		}
+	}
+}
+
+// handlerCompletionTracker records the point at which a serial test request's
+// TAG handler has returned. A Content-Length lets a client finish reading the
+// first body before that point, so this records completion separately.
+type handlerCompletionTracker struct {
+	done chan error
+}
+
+func newHandlerCompletionTracker() *handlerCompletionTracker {
+	return &handlerCompletionTracker{done: make(chan error, 1)}
+}
+
+func (t *handlerCompletionTracker) complete(err error) {
+	t.done <- err
+}
+
+// newCacheableGetCompletionBenchmark constructs a real HTTP boundary around a
+// cacheable full-GET miss. The benchmark waits for the handler return while its
+// timer is running, then waits for asynchronous cache publication with timing
+// stopped so each iteration starts with the same admitted-populate state.
+func newCacheableGetCompletionBenchmark(b *testing.B) (string, *http.Client, func(), *handlerCompletionTracker, *cache.Cache) {
+	b.Helper()
+
+	const body = "cacheable full GET benchmark body"
+	cfg := config.NewDefault()
+	cacheStore := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	forwarder := &mockForwarder{
+		doRequestFunc: func(_ context.Context, _ *http.Request, _ string, _ string) (*http.Response, error) {
+			return cacheableGetResponse(body, `"cacheable-get-benchmark"`), nil
+		},
+	}
+	svc := NewService(forwarder, cacheStore, cfg)
+	completions := newHandlerCompletionTracker()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := svc.HandleGetObject(w, r)
+		completions.complete(err)
+	}))
+	// Keep the connection alive after the Content-Length body is read so the
+	// request context remains available while the cache listener starts.
+	client := &http.Client{
+		Transport: &http.Transport{},
+		Timeout:   5 * time.Second,
+	}
+
+	return server.URL, client, func() {
+		client.CloseIdleConnections()
+		server.Close()
+	}, completions, cacheStore
+}
+
+// BenchmarkCacheableGetHandlerCompletion measures a cacheable full GET miss
+// through an HTTP server. It includes the first client's body read and waits
+// until TAG's handler has returned; it validates eventual cache publication
+// outside the timed region before issuing the next unique-key miss.
+func BenchmarkCacheableGetHandlerCompletion(b *testing.B) {
+	const (
+		bucket = "benchmark-bucket"
+		body   = "cacheable full GET benchmark body"
+	)
+	serverURL, client, cleanup, completions, cacheStore := newCacheableGetCompletionBenchmark(b)
+	defer cleanup()
+
+	for i := 0; b.Loop(); i++ {
+		key := strconv.Itoa(i)
+		path := "/" + bucket + "/" + key
+		resp, err := client.Get(serverURL + path)
+		if err != nil {
+			b.Fatalf("GET %s: %v", path, err)
+		}
+		got, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			resp.Body.Close()
+			b.Fatalf("read %s: %v", path, readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			b.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+		if string(got) != body {
+			b.Fatalf("GET %s body = %q, want %q", path, got, body)
+		}
+		select {
+		case handlerErr := <-completions.done:
+			if handlerErr != nil {
+				resp.Body.Close()
+				b.Fatalf("handler %s: %v", path, handlerErr)
+			}
+		case <-time.After(5 * time.Second):
+			resp.Body.Close()
+			b.Fatalf("handler did not complete for %s", path)
+		}
+		if err := resp.Body.Close(); err != nil {
+			b.Fatalf("close %s: %v", path, err)
+		}
+
+		// Cache publication is asynchronous and not paid by the first client.
+		// Waiting with timing stopped both validates the eventual cache hit and
+		// prevents outstanding populates from changing the next iteration's work.
+		b.StopTimer()
+		waitForCacheMeta(b, cacheStore, bucket, key, 5*time.Second)
+		b.StartTimer()
+	}
+}

--- a/proxy/cache_populate_completion_test.go
+++ b/proxy/cache_populate_completion_test.go
@@ -1,0 +1,304 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/proxy/broadcast"
+)
+
+func readCompletionResponse(t *testing.T, client *http.Client, url string) (http.Header, string) {
+	t.Helper()
+
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want %d", url, resp.StatusCode, http.StatusOK)
+	}
+	return resp.Header, string(body)
+}
+
+func waitForHandlerReturn(t *testing.T, requestName string, done <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handler %s: %v", requestName, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handler did not complete for %s", requestName)
+	}
+}
+
+// TestCacheableFullGet_SubsequentRequestHitsCache verifies that a cacheable
+// full-GET populate remains live after the first HTTP handler returns. The
+// requests use independent HTTP connections and share a cache key, so the later
+// request must be served from the published entry instead of upstream.
+func TestCacheableFullGet_SubsequentRequestHitsCache(t *testing.T) {
+	const (
+		bucket = "completion-bucket"
+		key    = "completion-key"
+		body   = "cacheable completion body"
+	)
+
+	var originGets atomic.Int32
+	forwarder := &mockForwarder{
+		doRequestFunc: func(_ context.Context, _ *http.Request, _ string, _ string) (*http.Response, error) {
+			originGets.Add(1)
+			return cacheableGetResponse(body, `"completion-etag"`), nil
+		},
+	}
+	cfg := config.NewDefault()
+	cacheStore := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	svc := NewService(forwarder, cacheStore, cfg)
+	completions := newHandlerCompletionTracker()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := svc.HandleGetObject(w, r)
+		completions.complete(err)
+	}))
+	defer server.Close()
+
+	// Separate transports give the two GETs independent connections without
+	// closing the first connection before its cache listener has started.
+	firstClient := &http.Client{
+		Transport: &http.Transport{},
+		Timeout:   time.Second,
+	}
+	defer firstClient.CloseIdleConnections()
+	secondClient := &http.Client{
+		Transport: &http.Transport{},
+		Timeout:   time.Second,
+	}
+	defer secondClient.CloseIdleConnections()
+
+	path := "/" + bucket + "/" + key
+	firstHeaders, firstBody := readCompletionResponse(t, firstClient, server.URL+path)
+	if firstBody != body {
+		t.Errorf("first response body = %q, want %q", firstBody, body)
+	}
+	if got := firstHeaders.Get("X-Cache"); got != XCacheMiss {
+		t.Errorf("first response X-Cache = %q, want %q", got, XCacheMiss)
+	}
+
+	// The body is complete, but cache publication is intentionally detached from
+	// the request. Wait for its metadata commit, then use a separate connection to
+	// verify that the completed populate serves the next request.
+	waitForHandlerReturn(t, "first request", completions.done)
+	waitForCacheMeta(t, cacheStore, bucket, key, time.Second)
+
+	secondHeaders, secondBody := readCompletionResponse(t, secondClient, server.URL+path)
+	if secondBody != body {
+		t.Errorf("second response body = %q, want %q", secondBody, body)
+	}
+	if got := secondHeaders.Get("X-Cache"); got != XCacheHit {
+		t.Errorf("second response X-Cache = %q, want %q", got, XCacheHit)
+	}
+	if got := originGets.Load(); got != 1 {
+		t.Errorf("origin GETs = %d, want 1", got)
+	}
+
+	waitForHandlerReturn(t, "second request", completions.done)
+}
+
+// TestSetupCacheListener_PublishesWhenHeadersReadyAtRequestCancellation covers
+// the scheduling boundary where streamFromUpstream has already published headers
+// but the cache goroutine first runs after the HTTP handler returns. The request
+// context is then canceled even though the cache listener has a complete response
+// to consume, so headers must win over cancellation and the detached write must
+// still publish the entry.
+func TestSetupCacheListener_PublishesWhenHeadersReadyAtRequestCancellation(t *testing.T) {
+	const (
+		bucket = "header-cancel-bucket"
+		key    = "header-cancel-key"
+		body   = "cache listener survives request cancellation"
+		etag   = `"header-cancel-etag"`
+	)
+
+	cfg := config.NewDefault()
+	cfg.Cache.MaxConcurrentWrites = 1
+	cacheStore := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	svc := NewService(&mockForwarder{}, cacheStore, cfg)
+	broadcaster := broadcast.NewBroadcaster(cfg.Broadcast.ChannelBuffer)
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	broadcaster.SetHeaders(http.StatusOK, cacheableGetResponse(body, etag).Header)
+	cancelRequest()
+
+	_, cacheErrCh := svc.setupCacheListener(
+		requestCtx,
+		bucket,
+		key,
+		broadcaster,
+		false,
+		svc.populateWeight(int64(len(body))),
+		time.Now().UnixNano(),
+	)
+	if cacheErrCh == nil {
+		t.Fatal("setupCacheListener did not create a cache listener")
+	}
+
+	broadcaster.Broadcast([]byte(body))
+	broadcaster.Complete(nil)
+
+	select {
+	case err, ok := <-cacheErrCh:
+		if !ok {
+			t.Fatal("cache listener closed its result channel without a result")
+		}
+		if err != nil {
+			t.Fatalf("cache listener: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cache listener did not finish")
+	}
+
+	meta, found, err := cacheStore.GetMeta(context.Background(), bucket, key)
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if !found {
+		t.Fatal("cache metadata was not published")
+	}
+	var cachedBody bytes.Buffer
+	if err := cacheStore.GetBodyStream(context.Background(), bucket, key, meta.ETag, &cachedBody); err != nil {
+		t.Fatalf("GetBodyStream: %v", err)
+	}
+	if got := cachedBody.String(); got != body {
+		t.Errorf("cached body = %q, want %q", got, body)
+	}
+
+	if !svc.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
+		t.Fatal("cache populate slot was not released")
+	}
+	svc.releaseCacheSlot(1)
+}
+
+// lateFailingStreamCache waits until the test has observed the client handler
+// return, then fails the stream write. This forces the cache error to arrive
+// after broadcaster completion rather than before the upstream EOF path returns.
+type lateFailingStreamCache struct {
+	cacheclient.CacheClient
+	release <-chan struct{}
+	err     error
+}
+
+func (c *lateFailingStreamCache) PutStream(ctx context.Context, _ string, r io.Reader, _ int64) error {
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return err
+	}
+	select {
+	case <-c.release:
+		return c.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type lateErrorLogWriter struct {
+	errorText string
+	logged    chan struct{}
+}
+
+func (w *lateErrorLogWriter) Write(p []byte) (int, error) {
+	entry := string(p)
+	if strings.Contains(entry, "Cache write failed") && strings.Contains(entry, w.errorText) {
+		select {
+		case w.logged <- struct{}{}:
+		default:
+		}
+	}
+	return len(p), nil
+}
+
+// TestStreamFromUpstream_LogsLateCacheWriteFailure ensures an asynchronous
+// populate failure remains visible after the client handler is allowed to finish.
+func TestStreamFromUpstream_LogsLateCacheWriteFailure(t *testing.T) {
+	const body = "late cache write failure"
+	injectedErr := errors.New("injected cache write failure")
+	release := make(chan struct{})
+	cacheClient := &lateFailingStreamCache{
+		CacheClient: cacheclient.NewMemoryCache(),
+		release:     release,
+		err:         injectedErr,
+	}
+	cfg := config.NewDefault()
+	cfg.Cache.MaxConcurrentWrites = 1
+	svc := NewService(&mockForwarder{
+		doRequestFunc: func(_ context.Context, _ *http.Request, _ string, _ string) (*http.Response, error) {
+			return cacheableGetResponse(body, `"late-error-etag"`), nil
+		},
+	}, cache.NewCacheWithClient(cacheClient, &cfg.Cache), cfg)
+
+	logs := &lateErrorLogWriter{
+		errorText: injectedErr.Error(),
+		logged:    make(chan struct{}, 1),
+	}
+	previousLogger := log.Logger
+	log.Logger = zerolog.New(logs).Level(zerolog.WarnLevel)
+	t.Cleanup(func() {
+		log.Logger = previousLogger
+	})
+
+	handlerReturned := make(chan error, 1)
+	writer := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/late-bucket/late-key", nil)
+	go func() {
+		handlerReturned <- svc.HandleGetObject(writer, request)
+	}()
+
+	select {
+	case err := <-handlerReturned:
+		if err != nil {
+			t.Fatalf("HandleGetObject: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return")
+	}
+	if got := writer.Body.String(); got != body {
+		t.Fatalf("response body = %q, want %q", got, body)
+	}
+
+	close(release)
+	select {
+	case <-logs.logged:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for late cache write error")
+	}
+
+	// setupCacheListener owns the reserved slot even after the request handler
+	// returns. Once its late error is observed, the slot must be available again.
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for !svc.acquireCacheSlot(context.Background(), 1, priorityReadMiss) {
+		select {
+		case <-deadline.C:
+			t.Fatal("timed out waiting for cache populate slot release")
+		case <-ticker.C:
+		}
+	}
+	svc.releaseCacheSlot(1)
+}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -376,15 +376,13 @@ func (s *Service) streamFromUpstream(
 		!s.hasNoCacheHeaders(resp.Header) &&
 		s.isWithinSizeThreshold(resp)
 
-	// Set up cache listener if caching (streams directly to cache via pipe)
-	var cachePipeWriter *io.PipeWriter
+	// Set up cache listener if caching (streams directly to cache via pipe).
 	var cacheErrCh chan error
-
 	if shouldCache {
 		// Reserve against the memory budget by the object's actual size (capped at
 		// the buffer ceiling), so small objects don't each reserve the worst case.
 		weight := s.populateWeight(resp.ContentLength)
-		cachePipeWriter, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false, weight, writeStartTime)
+		_, cacheErrCh = s.setupCacheListener(ctx, bucket, key, broadcaster, false, weight, writeStartTime)
 	}
 
 	// If an anonymous GET succeeded and Tigris didn't set an explicit per-object ACL,
@@ -429,23 +427,25 @@ func (s *Service) streamFromUpstream(
 		}
 	}
 
-	// Wait briefly for cache write to complete (the goroutine in setupCacheListener handles closing the pipe)
-	// We don't close cachePipeWriter here - the cache listener goroutine closes it when it finishes.
+	// A cache listener cannot report completion until broadcaster.Complete closes
+	// its chunk channel. fetchAndBroadcast calls Complete after this method returns,
+	// so waiting here delays completion without giving the cache writer a chance to
+	// finish. Observe an already-ready result, and otherwise log any late error
+	// without holding the broadcaster open.
 	if cacheErrCh != nil {
-		// Wait up to 100ms for cache write to complete, otherwise continue
 		select {
-		case cacheWriteErr := <-cacheErrCh:
-			if cacheWriteErr != nil {
+		case cacheWriteErr, ok := <-cacheErrCh:
+			if ok && cacheWriteErr != nil {
 				log.Warn().Err(cacheWriteErr).Str("bucket", bucket).Str("key", key).Msg("Cache write failed")
 			}
-		case <-time.After(100 * time.Millisecond):
-			// Don't block too long waiting for cache - it will complete in background
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache write still in progress, continuing")
+		default:
+			go func() {
+				if cacheWriteErr, ok := <-cacheErrCh; ok && cacheWriteErr != nil {
+					log.Warn().Err(cacheWriteErr).Str("bucket", bucket).Str("key", key).Msg("Cache write failed")
+				}
+			}()
 		}
 	}
-	// Ignore unused cachePipeWriter - it's managed by the cache listener goroutine
-	_ = cachePipeWriter
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Return a cacheable full-GET fetcher after upstream EOF instead of blocking on detached cache population.
- Let broadcaster completion close cache listeners while preserving immediate cache-write error observation and late-error logging.
- Prefer ready broadcast headers over concurrent request cancellation so a completed response can still publish its cache entry, with regression coverage for the cancellation boundary, cache hit, late error, and slot release.

## Behavior

Cache publication remains asynchronous and subject to the existing admission and write-timeout limits. A follow-up request can still be a miss until the detached populate finishes.

## Testing

- `make lint-ci`
- `make test-proxy`
- `go test -race -timeout 120s ./proxy/...`
- `go vet ./proxy/...`

**Workload:** `cacheable-full-get-miss-handler-completion`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 101216495 | 572750 | 99.4% lower |
All 4 declared correctness checks passed.

---

Authored and verified by [Perfloop](https://app.perfloop.ai): every claim above was co-measured on both trees and independently re-verified before submission — the full record is public: [case_mtzbwvz133](https://app.perfloop.ai/t/oss/case_mtzbwvz133). Replies from this account are human-approved, and a human operator is accountable for this contribution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and cancellation behavior on the hot GET/cache-populate path; correctness relies on detached listeners and late-error handling, with substantial new tests but real production concurrency edge cases.
> 
> **Overview**
> Cacheable full-GET misses now finish the upstream streaming path as soon as the body is read, instead of waiting up to **100ms** (or longer) for detached cache population.
> 
> In **`streamFromUpstream`**, the handler no longer blocks on `cacheErrCh`; it logs an immediate cache-write error if one is already available, otherwise spawns a goroutine to log late failures. **`fetchAndBroadcast`** can call **`broadcaster.Complete`** after upstream EOF so listeners close promptly while populate continues in the background.
> 
> **`Listener.WaitForHeaders`** re-checks `headerCh` when `ctx` is already canceled, so a cache listener scheduled after the HTTP handler returns still sees ready headers and can publish the entry instead of losing the race to cancellation.
> 
> Regression coverage adds benchmarks and tests for handler completion timing, a follow-up cache hit on a separate connection, the header-vs-cancel boundary, late cache-write logging, and populate slot release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80112907fdebf08426ace9cc2494b742c02eceb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->