### PR TITLE
perf(proxy): serve fetched blocks from memory, detach remote cache write

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -382,6 +382,17 @@ func (c *Cache) recordServeLocality(bodyKey string) {
 	}
 }
 
+// IsBlockLocal reports whether the given block is owned by this node. known is
+// false when the underlying client cannot report ownership, in which case
+// callers must keep their existing synchronous write behavior.
+func (c *Cache) IsBlockLocal(bucket, key, etag string, blockSize, blockIdx int64) (local, known bool) {
+	lc, ok := c.client.(localityChecker)
+	if !ok {
+		return false, false
+	}
+	return lc.IsLocal(MakeBlockKey(bucket, key, etag, blockSize, blockIdx)), true
+}
+
 // ============================================================================
 // Range request support
 // ============================================================================

--- a/cache/locality_test.go
+++ b/cache/locality_test.go
@@ -168,3 +168,27 @@ func TestServeLocality_NoCapabilityRecordsNothing(t *testing.T) {
 		t.Errorf("non-cluster client recorded locality (local %v, remote %v), want (0, 0)", ld, rd)
 	}
 }
+
+// IsBlockLocal exposes the ownership answer only when the embedded client can
+// report one. Callers use unknown ownership to preserve their synchronous path.
+func TestIsBlockLocal(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		client    cacheclient.CacheClient
+		wantLocal bool
+		wantKnown bool
+	}{
+		{"local owner", &localityMockClient{CacheClient: cacheclient.NewMemoryCache(), local: true}, true, true},
+		{"remote owner", &localityMockClient{CacheClient: cacheclient.NewMemoryCache(), local: false}, false, true},
+		{"unknown owner", cacheclient.NewMemoryCache(), false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewDefault()
+			c := NewCacheWithClient(tc.client, &cfg.Cache)
+			local, known := c.IsBlockLocal("b", "k", `"v1"`, 4, 2)
+			if local != tc.wantLocal || known != tc.wantKnown {
+				t.Fatalf("IsBlockLocal = (local=%t, known=%t), want (%t, %t)", local, known, tc.wantLocal, tc.wantKnown)
+			}
+		})
+	}
+}

--- a/handlers/remote_block_miss_benchmark_test.go
+++ b/handlers/remote_block_miss_benchmark_test.go
@@ -1,0 +1,839 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	runtimemetrics "runtime/metrics"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	cacheclient "github.com/tigrisdata/ocache/client"
+	pb "github.com/tigrisdata/ocache/proto"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/proxy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const remoteBlockMissBenchmarkSize = 1 << 20
+
+const goUserCPUMetric = "/cpu/classes/user:cpu-seconds"
+
+// goUserCPUCounter samples Go's process-wide user CPU accounting. The
+// benchmark runs one request at a time and samples through remote put
+// completion, so this includes CPU used by the detached gateway writer and the
+// in-process peer fixture rather than only CPU before the HTTP response.
+type goUserCPUCounter struct {
+	samples []runtimemetrics.Sample
+}
+
+func newGoUserCPUCounter(tb testing.TB) *goUserCPUCounter {
+	tb.Helper()
+	counter := &goUserCPUCounter{samples: []runtimemetrics.Sample{{Name: goUserCPUMetric}}}
+	_ = counter.nanoseconds(tb)
+	return counter
+}
+
+func (c *goUserCPUCounter) nanoseconds(tb testing.TB) int64 {
+	tb.Helper()
+	runtimemetrics.Read(c.samples)
+	if c.samples[0].Value.Kind() != runtimemetrics.KindFloat64 {
+		tb.Fatalf("runtime metric %q kind = %v, want float64", goUserCPUMetric, c.samples[0].Value.Kind())
+		return 0
+	}
+	return int64(c.samples[0].Value.Float64() * float64(time.Second))
+}
+
+// remoteBlockMissBenchmarkServer is a distinct cache-owner node for the
+// end-to-end assembled-range miss workload. Metadata remains local to the
+// gateway fixture while versioned block keys are served over this gRPC boundary.
+type remoteBlockMissBenchmarkServer struct {
+	pb.UnimplementedCacheServiceServer
+
+	mu sync.RWMutex
+
+	blocks map[string][]byte
+
+	putStarted chan struct{}
+	putDone    chan struct{}
+	putGate    <-chan struct{}
+
+	rpcs atomic.Int64
+	gets atomic.Int64
+}
+
+func newRemoteBlockMissBenchmarkServer() *remoteBlockMissBenchmarkServer {
+	s := &remoteBlockMissBenchmarkServer{blocks: make(map[string][]byte)}
+	s.beginMiss()
+	return s
+}
+
+// beginMiss clears per-miss counters without clearing other keys. Every timed
+// iteration uses a new key, so a finishing detached writer can never join or
+// populate the next iteration's cold miss.
+func (s *remoteBlockMissBenchmarkServer) beginMiss() {
+	s.mu.Lock()
+	s.putStarted = make(chan struct{}, 1)
+	s.putDone = make(chan struct{})
+	s.putGate = nil
+	s.mu.Unlock()
+	s.rpcs.Store(0)
+	s.gets.Store(0)
+}
+
+// blockPuts holds a remote write before it reaches storage. It lets the trace
+// test prove that a client response does not wait for remote persistence.
+func (s *remoteBlockMissBenchmarkServer) blockPuts() func() {
+	gate := make(chan struct{})
+	var once sync.Once
+	s.mu.Lock()
+	s.putGate = gate
+	s.mu.Unlock()
+	return func() { once.Do(func() { close(gate) }) }
+}
+
+func (s *remoteBlockMissBenchmarkServer) waitForGate(ctx context.Context) error {
+	s.mu.RLock()
+	gate := s.putGate
+	s.mu.RUnlock()
+	if gate == nil {
+		return nil
+	}
+	select {
+	case <-gate:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *remoteBlockMissBenchmarkServer) signalPutStarted() {
+	s.mu.RLock()
+	started := s.putStarted
+	s.mu.RUnlock()
+	select {
+	case started <- struct{}{}:
+	default:
+	}
+}
+
+func (s *remoteBlockMissBenchmarkServer) store(key string, data []byte) {
+	copyData := append([]byte(nil), data...)
+	s.mu.Lock()
+	s.blocks[key] = copyData
+	done := s.putDone
+	select {
+	case <-done:
+	default:
+		close(done)
+	}
+	s.mu.Unlock()
+}
+
+func (s *remoteBlockMissBenchmarkServer) Put(stream pb.CacheService_PutServer) error {
+	s.rpcs.Add(1)
+	s.signalPutStarted()
+	if err := s.waitForGate(stream.Context()); err != nil {
+		return err
+	}
+
+	var key string
+	var data []byte
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if key == "" {
+			key = req.Key
+		}
+		data = append(data, req.Data...)
+	}
+	s.store(key, data)
+	return stream.SendAndClose(&pb.PutResponse{Success: true})
+}
+
+func (s *remoteBlockMissBenchmarkServer) PutObject(ctx context.Context, req *pb.PutRequest) (*pb.PutResponse, error) {
+	s.rpcs.Add(1)
+	s.signalPutStarted()
+	if err := s.waitForGate(ctx); err != nil {
+		return nil, err
+	}
+	s.store(req.Key, req.Data)
+	return &pb.PutResponse{Success: true}, nil
+}
+
+func (s *remoteBlockMissBenchmarkServer) Get(req *pb.GetRequest, stream pb.CacheService_GetServer) error {
+	s.rpcs.Add(1)
+	s.gets.Add(1)
+	s.mu.RLock()
+	data, ok := s.blocks[req.Key]
+	s.mu.RUnlock()
+	if !ok {
+		return status.Error(codes.NotFound, "key not found")
+	}
+
+	start, end := req.Start, req.End
+	if end <= 0 {
+		end = int64(len(data)) - 1
+	}
+	if start < 0 || start >= int64(len(data)) || start > end {
+		return status.Error(codes.InvalidArgument, "invalid range")
+	}
+	if end >= int64(len(data)) {
+		end = int64(len(data)) - 1
+	}
+	return stream.Send(&pb.GetResponse{Data: data[start : end+1]})
+}
+
+func (s *remoteBlockMissBenchmarkServer) waitForPut(tb testing.TB) {
+	tb.Helper()
+	s.mu.RLock()
+	done := s.putDone
+	s.mu.RUnlock()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		tb.Fatal("remote cache write did not complete")
+	}
+}
+
+func (s *remoteBlockMissBenchmarkServer) waitForPutStart(tb testing.TB) {
+	tb.Helper()
+	s.mu.RLock()
+	started := s.putStarted
+	s.mu.RUnlock()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		tb.Fatal("remote cache write did not start")
+	}
+}
+
+func (s *remoteBlockMissBenchmarkServer) hasBlock(key string, want []byte) bool {
+	s.mu.RLock()
+	got := s.blocks[key]
+	s.mu.RUnlock()
+	return bytes.Equal(got, want)
+}
+
+func (s *remoteBlockMissBenchmarkServer) deleteBlock(key string) {
+	s.mu.Lock()
+	delete(s.blocks, key)
+	s.mu.Unlock()
+}
+
+type remoteMissStageEvent struct {
+	name      string
+	completed time.Duration
+	duration  time.Duration
+}
+
+// remoteMissStageTrace records the cache probe/recheck/reread, upstream range,
+// and remote cache write as timed spans. The sum deliberately includes the
+// detached write, while ns/op remains the client-visible end-to-end GET time.
+type remoteMissStageTrace struct {
+	mu sync.Mutex
+
+	started    time.Time
+	cacheReads int
+	events     []remoteMissStageEvent
+	sum        time.Duration
+}
+
+func (t *remoteMissStageTrace) reset() {
+	t.mu.Lock()
+	t.started = time.Now()
+	t.cacheReads = 0
+	t.events = t.events[:0]
+	t.sum = 0
+	t.mu.Unlock()
+}
+
+func (t *remoteMissStageTrace) recordCacheRead(start time.Time) {
+	t.record("cache-read", start, true)
+}
+
+func (t *remoteMissStageTrace) record(name string, start time.Time, cacheRead bool) {
+	end := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if cacheRead {
+		t.cacheReads++
+		switch t.cacheReads {
+		case 1:
+			name = "cache-miss-probe"
+		case 2:
+			name = "fetch-presence-recheck"
+		case 3:
+			name = "post-fetch-cache-reread"
+		default:
+			name = "cache-read"
+		}
+	}
+	t.events = append(t.events, remoteMissStageEvent{
+		name:      name,
+		completed: end.Sub(t.started),
+		duration:  end.Sub(start),
+	})
+	t.sum += end.Sub(start)
+}
+
+func (t *remoteMissStageTrace) mark(name string) {
+	t.mu.Lock()
+	t.events = append(t.events, remoteMissStageEvent{name: name, completed: time.Since(t.started)})
+	t.mu.Unlock()
+}
+
+func (t *remoteMissStageTrace) snapshot() (events []remoteMissStageEvent, stageSum time.Duration, cacheReads int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	events = append([]remoteMissStageEvent(nil), t.events...)
+	sort.SliceStable(events, func(i, j int) bool { return events[i].completed < events[j].completed })
+	return events, t.sum, t.cacheReads
+}
+
+func (t *remoteMissStageTrace) postFetchRereads() int {
+	events, _, _ := t.snapshot()
+	var rereads int
+	for _, event := range events {
+		if event.name == "post-fetch-cache-reread" {
+			rereads++
+		}
+	}
+	return rereads
+}
+
+func (t *remoteMissStageTrace) requireOrder(tb testing.TB, want ...string) {
+	tb.Helper()
+	events, _, _ := t.snapshot()
+	next := 0
+	for _, event := range events {
+		if next < len(want) && event.name == want[next] {
+			next++
+		}
+	}
+	if next != len(want) {
+		tb.Fatalf("waterfall = %s, missing ordered sequence %s", t.String(), strings.Join(want, " -> "))
+	}
+}
+
+func (t *remoteMissStageTrace) String() string {
+	events, _, _ := t.snapshot()
+	parts := make([]string, 0, len(events))
+	for _, event := range events {
+		if event.duration == 0 {
+			parts = append(parts, fmt.Sprintf("%s@%s", event.name, event.completed))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s@%s+%s", event.name, event.completed, event.duration))
+	}
+	return strings.Join(parts, " -> ")
+}
+
+// remoteBlockOwnerClient sends block keys to the remote cache owner while
+// keeping metadata and tombstones local. That isolates the intended topology:
+// this gateway has the object metadata, but the requested versioned block is
+// owned by a peer.
+type remoteBlockOwnerClient struct {
+	cacheclient.CacheClient
+	local cacheclient.CacheClient
+	rpc   pb.CacheServiceClient
+	trace *remoteMissStageTrace
+
+	mu          sync.Mutex
+	putReturned chan struct{}
+}
+
+func newRemoteBlockOwnerClient(remote, local cacheclient.CacheClient, rpc pb.CacheServiceClient, trace *remoteMissStageTrace) *remoteBlockOwnerClient {
+	c := &remoteBlockOwnerClient{CacheClient: remote, local: local, rpc: rpc, trace: trace}
+	c.beginMiss()
+	return c
+}
+
+func (c *remoteBlockOwnerClient) beginMiss() {
+	c.mu.Lock()
+	c.putReturned = make(chan struct{})
+	c.mu.Unlock()
+}
+
+func (c *remoteBlockOwnerClient) signalPutReturned() {
+	c.mu.Lock()
+	returned := c.putReturned
+	select {
+	case <-returned:
+	default:
+		close(returned)
+	}
+	c.mu.Unlock()
+}
+
+func (c *remoteBlockOwnerClient) waitForPutReturn(tb testing.TB) {
+	tb.Helper()
+	c.mu.Lock()
+	returned := c.putReturned
+	c.mu.Unlock()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		tb.Fatal("remote cache write did not return to the gateway")
+	}
+}
+
+func isRemoteBenchmarkBlock(key string) bool { return strings.HasPrefix(key, "blk|") }
+
+func (c *remoteBlockOwnerClient) IsLocal(string) bool { return false }
+
+func (c *remoteBlockOwnerClient) Get(ctx context.Context, key string) ([]byte, error) {
+	if !isRemoteBenchmarkBlock(key) {
+		return c.local.Get(ctx, key)
+	}
+	return c.CacheClient.Get(ctx, key)
+}
+
+func (c *remoteBlockOwnerClient) Put(ctx context.Context, key string, data []byte, ttlSeconds int64) error {
+	if !isRemoteBenchmarkBlock(key) {
+		return c.local.Put(ctx, key, data, ttlSeconds)
+	}
+	return c.putRemoteBlock(ctx, key, data, ttlSeconds)
+}
+
+func (c *remoteBlockOwnerClient) GetRangeStream(ctx context.Context, key string, start, end int64, w io.Writer) error {
+	started := time.Now()
+	err := c.CacheClient.GetRangeStream(ctx, key, start, end, w)
+	c.trace.recordCacheRead(started)
+	return err
+}
+
+func (c *remoteBlockOwnerClient) PutBlockBytes(ctx context.Context, key string, data []byte, ttlSeconds int64) (bool, error) {
+	return true, c.putRemoteBlock(ctx, key, data, ttlSeconds)
+}
+
+func (c *remoteBlockOwnerClient) putRemoteBlock(ctx context.Context, key string, data []byte, ttlSeconds int64) error {
+	started := time.Now()
+	resp, err := c.rpc.PutObject(ctx, &pb.PutRequest{Key: key, Data: data, TtlSeconds: ttlSeconds})
+	c.trace.record("remote-cache-put", started, false)
+	c.signalPutReturned()
+	if err != nil {
+		return err
+	}
+	if resp != nil && !resp.Success {
+		return fmt.Errorf("put failed: %s", resp.Error)
+	}
+	return nil
+}
+
+type timedReadCloser struct {
+	io.ReadCloser
+	onClose   func()
+	remaining int64
+	once      sync.Once
+}
+
+func (r *timedReadCloser) finish() { r.once.Do(r.onClose) }
+
+func (r *timedReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if r.remaining > 0 {
+		r.remaining -= int64(n)
+		if r.remaining == 0 {
+			r.finish()
+		}
+	}
+	if err != nil {
+		r.finish()
+	}
+	return n, err
+}
+
+func (r *timedReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.finish()
+	return err
+}
+
+// benchmarkRangeForwarder supplies a real local HTTP upstream hop for aligned
+// range fetches. The response span ends only after fetchOneBlock has consumed
+// the body, so it includes the upstream payload transfer rather than just
+// request construction.
+type benchmarkRangeForwarder struct {
+	upstreamURL string
+	client      *http.Client
+	trace       *remoteMissStageTrace
+}
+
+func (f *benchmarkRangeForwarder) Forward(context.Context, http.ResponseWriter, *http.Request) error {
+	return errors.New("unexpected direct upstream forward")
+}
+
+func (f *benchmarkRangeForwarder) ForwardWithCapture(context.Context, http.ResponseWriter, *http.Request) (*proxy.ResponseCapture, error) {
+	return nil, errors.New("unexpected captured upstream forward")
+}
+
+func (*benchmarkRangeForwarder) ValidateAndGetCredentials(*http.Request) (proxy.AuthResult, string, string, error) {
+	return proxy.AuthValidated, "access", "secret", nil
+}
+
+func (*benchmarkRangeForwarder) DoRequestWithCreds(context.Context, *http.Request, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected request with credentials")
+}
+
+func (*benchmarkRangeForwarder) DoFullObjectRequest(context.Context, string, string, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected full object request")
+}
+
+func (*benchmarkRangeForwarder) DoAnonymousFullObjectRequest(context.Context, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected anonymous full object request")
+}
+
+func (f *benchmarkRangeForwarder) DoConditionalGetRequest(ctx context.Context, bucket, key, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
+	started := time.Now()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.upstreamURL+"/"+url.PathEscape(bucket)+"/"+url.PathEscape(key), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Range", rangeHeader)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &timedReadCloser{ReadCloser: resp.Body, remaining: resp.ContentLength, onClose: func() {
+		f.trace.record("upstream-fetch", started, false)
+	}}
+	return resp, nil
+}
+
+func (*benchmarkRangeForwarder) DoConditionalHeadRequest(context.Context, string, string, string, string, string, int64) (*http.Response, error) {
+	return nil, errors.New("unexpected conditional head request")
+}
+
+type remoteBlockMissBenchmarkFixture struct {
+	owner        *remoteBlockMissBenchmarkServer
+	remoteClient *remoteBlockOwnerClient
+	cache        *cache.Cache
+	gateway      *httptest.Server
+	client       *http.Client
+	trace        *remoteMissStageTrace
+	body         []byte
+	etag         string
+	blockLen     int64
+}
+
+func newRemoteBlockMissBenchmarkFixture(tb testing.TB) *remoteBlockMissBenchmarkFixture {
+	tb.Helper()
+
+	trace := &remoteMissStageTrace{}
+	owner := newRemoteBlockMissBenchmarkServer()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	grpcServer := grpc.NewServer(grpc.MaxRecvMsgSize(cacheclient.MaxMessageSize))
+	pb.RegisterCacheServiceServer(grpcServer, owner)
+	go func() { _ = grpcServer.Serve(listener) }()
+	tb.Cleanup(grpcServer.Stop)
+	tb.Cleanup(func() { _ = listener.Close() })
+
+	readClient, err := cacheclient.NewSimpleClient(&cacheclient.ClientConfig{
+		Addrs:              []string{listener.Addr().String()},
+		Mode:               cacheclient.ModeSimple,
+		ConnectionPoolSize: 1,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = readClient.Close() })
+
+	conn, err := grpc.Dial(listener.Addr().String(), cacheclient.DefaultDialOptions()...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = conn.Close() })
+
+	body := make([]byte, remoteBlockMissBenchmarkSize)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	const etag = `"benchmark"`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, end, err := parseBenchmarkRange(r.Header.Get("Range"), int64(len(body)))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(body)))
+		w.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body[start : end+1])
+	}))
+	tb.Cleanup(upstream.Close)
+	upstreamClient := upstream.Client()
+	tb.Cleanup(upstreamClient.CloseIdleConnections)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = int64(len(body))
+	cfg.Cache.SizeThreshold = int64(len(body))
+	remoteClient := newRemoteBlockOwnerClient(readClient, cacheclient.NewMemoryCache(), pb.NewCacheServiceClient(conn), trace)
+	cacheStore := cache.NewCacheWithClient(remoteClient, &cfg.Cache)
+	forwarder := &benchmarkRangeForwarder{upstreamURL: upstream.URL, client: upstreamClient, trace: trace}
+	service := proxy.NewService(forwarder, cacheStore, cfg)
+	gateway := httptest.NewServer(NewServer(service, "127.0.0.1", 0, false, 0).Router())
+	tb.Cleanup(gateway.Close)
+
+	return &remoteBlockMissBenchmarkFixture{
+		owner:        owner,
+		remoteClient: remoteClient,
+		cache:        cacheStore,
+		gateway:      gateway,
+		client:       gateway.Client(),
+		trace:        trace,
+		body:         body,
+		etag:         etag,
+		blockLen:     int64(len(body)),
+	}
+}
+
+func (f *remoteBlockMissBenchmarkFixture) beginMiss() {
+	f.owner.beginMiss()
+	f.remoteClient.beginMiss()
+}
+
+func parseBenchmarkRange(header string, size int64) (int64, int64, error) {
+	if !strings.HasPrefix(header, "bytes=") {
+		return 0, 0, fmt.Errorf("missing byte range %q", header)
+	}
+	parts := strings.Split(strings.TrimPrefix(header, "bytes="), "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid byte range %q", header)
+	}
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	if start < 0 || end < start || end >= size {
+		return 0, 0, fmt.Errorf("range %d-%d outside %d-byte object", start, end, size)
+	}
+	return start, end, nil
+}
+
+func (f *remoteBlockMissBenchmarkFixture) seedMeta(tb testing.TB, bucket, key string) *cache.CachedObjectMeta {
+	tb.Helper()
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          f.etag,
+		ContentLength: f.blockLen,
+		StatusCode:    http.StatusOK,
+		BlockSize:     f.blockLen,
+	}
+	if wrote, err := f.cache.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+		tb.Fatalf("seed block metadata = (wrote=%t, err=%v)", wrote, err)
+	}
+	return meta
+}
+
+func (f *remoteBlockMissBenchmarkFixture) getRange(ctx context.Context, bucket, key string) (status int, cacheStatus string, body []byte, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.gateway.URL+"/"+url.PathEscape(bucket)+"/"+url.PathEscape(key), nil)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=0-%d", f.blockLen-1))
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	f.trace.mark("response-headers")
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	f.trace.mark("response-complete")
+	if readErr != nil {
+		return resp.StatusCode, resp.Header.Get("X-Cache"), body, readErr
+	}
+	if closeErr != nil {
+		return resp.StatusCode, resp.Header.Get("X-Cache"), body, closeErr
+	}
+	return resp.StatusCode, resp.Header.Get("X-Cache"), body, nil
+}
+
+func (f *remoteBlockMissBenchmarkFixture) requireResponse(tb testing.TB, status int, cacheStatus string, got []byte) {
+	tb.Helper()
+	if status != http.StatusPartialContent || cacheStatus != proxy.XCacheHit || !bytes.Equal(got, f.body) {
+		tb.Fatalf("response = (status=%d, cache=%q, bytes=%d), want (206, HIT, %d exact bytes)", status, cacheStatus, len(got), len(f.body))
+	}
+}
+
+// warm establishes the gateway HTTP, upstream HTTP, and remote cache gRPC
+// connections without sharing a block or fetch state with a timed iteration.
+func (f *remoteBlockMissBenchmarkFixture) warm(tb testing.TB) {
+	tb.Helper()
+	const (
+		bucket = "benchmark"
+		key    = "warmup"
+	)
+	meta := f.seedMeta(tb, bucket, key)
+	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, 0)
+	f.beginMiss()
+	f.trace.reset()
+	statusCode, cacheStatus, got, err := f.getRange(context.Background(), bucket, key)
+	if err != nil {
+		tb.Fatalf("warm handler GET = %v", err)
+	}
+	f.requireResponse(tb, statusCode, cacheStatus, got)
+	f.owner.waitForPut(tb)
+	f.remoteClient.waitForPutReturn(tb)
+	f.owner.deleteBlock(blockKey)
+}
+
+// TestRemoteBlockMissTraceStages emits the ordinary handler-path waterfall for
+// both sides of the comparison. Before direct assembly it includes the serial
+// presence recheck and post-fetch reread; the known-missing assembled path
+// reports both redundant reads as absent.
+func TestRemoteBlockMissTraceStages(t *testing.T) {
+	fixture := newRemoteBlockMissBenchmarkFixture(t)
+	const (
+		bucket = "benchmark"
+		key    = "trace-stages"
+	)
+	meta := fixture.seedMeta(t, bucket, key)
+	fixture.beginMiss()
+	fixture.trace.reset()
+
+	statusCode, cacheStatus, got, err := fixture.getRange(context.Background(), bucket, key)
+	if err != nil {
+		t.Fatalf("GET through handlers.Server = %v", err)
+	}
+	fixture.requireResponse(t, statusCode, cacheStatus, got)
+	fixture.owner.waitForPut(t)
+	fixture.remoteClient.waitForPutReturn(t)
+	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, 0)
+	if !fixture.owner.hasBlock(blockKey, fixture.body) {
+		t.Fatal("remote owner was not populated")
+	}
+
+	events, stageSum, cacheReads := fixture.trace.snapshot()
+	rereads := fixture.trace.postFetchRereads()
+	switch rereads {
+	case 0:
+		if cacheReads != 1 {
+			t.Fatalf("cache reads without redundant rereads = %d, want 1", cacheReads)
+		}
+		fixture.trace.requireOrder(t, "cache-miss-probe", "upstream-fetch", "remote-cache-put")
+	case 1:
+		if cacheReads != 3 {
+			t.Fatalf("cache reads with a presence recheck and post-fetch reread = %d, want 3", cacheReads)
+		}
+		fixture.trace.requireOrder(t, "cache-miss-probe", "fetch-presence-recheck", "upstream-fetch", "remote-cache-put", "post-fetch-cache-reread", "response-complete")
+	default:
+		t.Fatalf("post-fetch cache rereads = %d, want 0 or 1", rereads)
+	}
+	if gotGets := fixture.owner.gets.Load(); gotGets != int64(cacheReads) {
+		t.Fatalf("remote cache get RPCs = %d, trace reads = %d", gotGets, cacheReads)
+	}
+	if len(events) == 0 || stageSum <= 0 {
+		t.Fatalf("trace = (events=%d, stage sum=%s), want timed stages", len(events), stageSum)
+	}
+	t.Logf("remote range-miss waterfall: %s; summed stage latency: %s; remote cache RPCs: %d", fixture.trace.String(), stageSum, fixture.owner.rpcs.Load())
+}
+
+// BenchmarkHandleGetObjectRemoteBlockMiss sends a normal range GET through
+// handlers.Server.handleObject and proxy.Service.HandleGetObject. It uses a
+// local metadata owner, a separate gRPC block owner, and a separate HTTP
+// upstream. The per-iteration key prevents a finishing detached write from
+// sharing state with the next cold miss. ns/op remains client-visible latency;
+// go_user_cpu_ns/op separately covers CPU through detached put completion.
+func BenchmarkHandleGetObjectRemoteBlockMiss(b *testing.B) {
+	oldLogger := log.Logger
+	log.Logger = log.Logger.Level(zerolog.WarnLevel)
+	b.Cleanup(func() { log.Logger = oldLogger })
+
+	fixture := newRemoteBlockMissBenchmarkFixture(b)
+	fixture.warm(b)
+	const bucket = "benchmark"
+
+	userCPU := newGoUserCPUCounter(b)
+	var totalRPCs, totalGets, totalRereads, totalUserCPUNS int64
+	var totalStageSum time.Duration
+	b.SetBytes(fixture.blockLen)
+	b.ResetTimer()
+	for iteration := 0; b.Loop(); iteration++ {
+		b.StopTimer()
+		key := fmt.Sprintf("block-%d", iteration)
+		meta := fixture.seedMeta(b, bucket, key)
+		blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, 0)
+		fixture.beginMiss()
+		fixture.trace.reset()
+		cpuStart := userCPU.nanoseconds(b)
+
+		b.StartTimer()
+		statusCode, cacheStatus, got, err := fixture.getRange(context.Background(), bucket, key)
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		fixture.requireResponse(b, statusCode, cacheStatus, got)
+
+		// The remote put is detached from ns/op, but it is part of the full
+		// miss-stage accounting and must finish before this key is discarded.
+		fixture.owner.waitForPut(b)
+		fixture.remoteClient.waitForPutReturn(b)
+		cpuEnd := userCPU.nanoseconds(b)
+		if cpuEnd < cpuStart {
+			b.Fatalf("Go user CPU moved backwards: start=%d end=%d", cpuStart, cpuEnd)
+		}
+		totalUserCPUNS += cpuEnd - cpuStart
+		if !fixture.owner.hasBlock(blockKey, fixture.body) {
+			b.Fatal("remote cache owner did not retain the fetched block")
+		}
+		events, stageSum, cacheReads := fixture.trace.snapshot()
+		if len(events) == 0 || stageSum <= 0 || cacheReads < 1 {
+			b.Fatalf("incomplete miss trace: events=%d stage_sum=%s cache_reads=%d", len(events), stageSum, cacheReads)
+		}
+		rereads := fixture.trace.postFetchRereads()
+		switch {
+		case rereads == 0 && cacheReads == 1:
+		case rereads == 1 && cacheReads == 3:
+		default:
+			b.Fatalf("cache read shape = (reads=%d, post-fetch rereads=%d), want (1, 0) or (3, 1)", cacheReads, rereads)
+		}
+		totalRereads += int64(rereads)
+		if gotGets := fixture.owner.gets.Load(); gotGets != int64(cacheReads) {
+			b.Fatalf("remote cache get RPCs = %d, trace reads = %d", gotGets, cacheReads)
+		}
+		totalRPCs += fixture.owner.rpcs.Load()
+		totalGets += fixture.owner.gets.Load()
+		totalStageSum += stageSum
+		fixture.owner.deleteBlock(blockKey)
+		b.StartTimer()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(totalUserCPUNS)/float64(b.N), "go_user_cpu_ns/op")
+	b.ReportMetric(float64(totalStageSum.Nanoseconds())/float64(b.N), "miss_stage_sum_ns/op")
+	b.ReportMetric(float64(totalRereads)/float64(b.N), "post_fetch_cache_rereads/op")
+	b.ReportMetric(float64(totalGets)/float64(b.N), "remote_block_cache_get_rpcs/op")
+	b.ReportMetric(float64(totalRPCs)/float64(b.N), "remote_cache_rpcs/op")
+}

--- a/handlers/remote_block_miss_trace_test.go
+++ b/handlers/remote_block_miss_trace_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// TestRemoteBlockMissWaterfall exercises the ordinary GET router path while a
+// remote cache owner is deliberately stalled. It records the full timed
+// waterfall and proves that the 206 completes before the remote put does.
+func TestRemoteBlockMissWaterfall(t *testing.T) {
+	fixture := newRemoteBlockMissBenchmarkFixture(t)
+	const (
+		bucket = "benchmark"
+		key    = "waterfall"
+	)
+	meta := fixture.seedMeta(t, bucket, key)
+	fixture.beginMiss()
+	releasePut := fixture.owner.blockPuts()
+	defer releasePut()
+	fixture.trace.reset()
+
+	type result struct {
+		status      int
+		cacheStatus string
+		body        []byte
+		err         error
+	}
+	results := make(chan result, 1)
+	go func() {
+		status, cacheStatus, body, err := fixture.getRange(context.Background(), bucket, key)
+		results <- result{status: status, cacheStatus: cacheStatus, body: body, err: err}
+	}()
+
+	fixture.owner.waitForPutStart(t)
+	select {
+	case got := <-results:
+		if got.err != nil {
+			t.Fatalf("GET through handlers.Server = %v", got.err)
+		}
+		fixture.requireResponse(t, got.status, got.cacheStatus, got.body)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GET waited for the stalled remote cache write")
+	}
+
+	releasePut()
+	fixture.owner.waitForPut(t)
+	fixture.remoteClient.waitForPutReturn(t)
+	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, 0)
+	if !fixture.owner.hasBlock(blockKey, fixture.body) {
+		t.Fatal("remote owner was not populated after the detached write completed")
+	}
+	fixture.trace.requireOrder(t, "cache-miss-probe", "upstream-fetch", "response-complete", "remote-cache-put")
+	if rereads := fixture.trace.postFetchRereads(); rereads != 0 {
+		t.Fatalf("post-fetch cache rereads = %d, want 0", rereads)
+	}
+	events, stageSum, cacheReads := fixture.trace.snapshot()
+	if cacheReads != 1 || len(events) == 0 || stageSum <= 0 {
+		t.Fatalf("trace = (cache reads=%d, events=%d, stage sum=%s), want one miss probe and timed stages", cacheReads, len(events), stageSum)
+	}
+	t.Logf("remote range-miss waterfall: %s; summed stage latency: %s", fixture.trace.String(), stageSum)
+}

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -260,8 +260,9 @@ func putBlockBuf(bp *[]byte) {
 // assembling the requested bytes from the entry's blocks into a pooled buffer before
 // committing anything. Present blocks are read exactly once — the read itself is the
 // existence check, there is no separate probe pass — and blocks the read reports absent are
-// fetched (coalesced, bounded) and re-read, all BEFORE headers are written. It returns
-// served=true only once the 206 is committed; any assembly failure returns served=false with
+// fetched (coalesced, bounded) into retained validated buffers. A block another writer wins is
+// re-read; a block this request fetched is copied directly from memory, all BEFORE headers are
+// written. It returns served=true only once the 206 is committed; any assembly failure returns served=false with
 // the response untouched, so the caller falls through to upstream exactly as the probe-first
 // path would. Block hit/miss and range-served metrics are recorded only on a committed
 // serve, and a definitive stale signal invalidates the entry — both matching
@@ -305,17 +306,33 @@ func (s *Service) serveAssembledRange(
 
 	// Fetch whatever pass 1 found missing (coalesced across requests, bounded fan-out, stale
 	// signals prioritized over transient ones — a stale signal also invalidates the entry
-	// inside fetchBlocksToCache), then fill the gaps. Still pre-commit: a fetch or re-read
-	// failure falls through with the response untouched.
+	// inside fetchBlocksForAssembly). A validated buffer fetched by this request is copied
+	// straight into the response assembly, avoiding a remote post-put cache read. Only a
+	// block another writer made present while we waited is re-read. Still pre-commit: a fetch
+	// or re-read failure falls through with the response untouched.
 	if len(missing) > 0 {
-		if ferr := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, missing); ferr != nil {
+		fetched, ferr := s.fetchBlocksForAssembly(ctx, bucket, key, accessKey, secretKey, meta, missing)
+		if ferr != nil {
 			return false, ferr
 		}
+		defer func() {
+			for _, lease := range fetched {
+				lease.release()
+			}
+		}()
 		for _, i := range missing {
 			localStart, localEnd := blockLocalRange(i, rng.start, rng.end, meta.BlockSize, meta.ContentLength)
 			bStart, _ := blockBounds(i, meta.BlockSize, meta.ContentLength)
 			goff := bStart + localStart - rng.start
 			n := localEnd - localStart + 1
+			if lease := fetched[i]; lease != nil {
+				if copied := copy(buf[goff:goff+n], lease.data[localStart:localEnd+1]); int64(copied) != n {
+					return false, fmt.Errorf("block %d assembly: fetched buffer short read %d of %d bytes", i, copied, n)
+				}
+				lease.release()
+				delete(fetched, i)
+				continue
+			}
 			sw := &sliceWriter{dst: buf[goff : goff+n]}
 			rerr := s.cache.GetBlockRangeStream(ctx, bucket, key, meta.ETag, meta.BlockSize, i, localStart, localEnd, sw)
 			if rerr != nil || sw.off != n {
@@ -878,126 +895,355 @@ func recordBlockServeMetrics(total, missed int64) {
 	}
 }
 
-// fetchOneBlock fetches a single block from upstream (an aligned range GET) and writes it to
-// cache. Concurrent fetches of the same block (across requests) are coalesced via singleflight.
-// The populate budget is reserved by the block's actual size (read-miss priority, non-blocking);
-// on decline the block is not cached and errCachePopulateDeclined is returned. The fetched
-// block's ETag must match meta.ETag or it is rejected (a concurrent overwrite).
-// The shared fetch (the singleflight leader) runs under a DETACHED, timeout-bounded context,
-// not the caller's: binding it to one caller's context would let that caller's cancellation
-// fail the block for every waiter. But the caller does not block on it indefinitely — via
-// DoChan we select on the caller's ctx, so a caller that goes away (e.g. a disconnected
-// client on the synchronous serve path) stops waiting immediately and returns, while the
-// detached fetch keeps running to populate the cache for any other waiters.
-func (s *Service) fetchOneBlock(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdx int64) error {
-	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, blockIdx)
-	ch := s.blockFetch.DoChan(blockKey, func() (interface{}, error) {
-		fetchCtx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
-		defer cancel()
+// blockFetchState owns a validated staged block while callers either wait for its
+// cache write or copy it into a pre-commit assembled response. A state stays in
+// Service.blockFetches through a detached remote write, so late overlapping
+// callers join the same upstream fetch instead of re-fetching a block that has
+// not reached its owner yet.
+type blockFetchState struct {
+	mu sync.Mutex
 
-		// Re-check presence inside the singleflight leader: a prior fetch may have landed.
-		if s.cache.BlockExists(fetchCtx, bucket, key, meta.ETag, meta.BlockSize, blockIdx) {
+	serveDone chan struct{} // closed after validation makes data usable by an assembler
+	cacheDone chan struct{} // closed after the cache write (if any) has finished
+
+	consumers     int // callers that joined the state and have not released it
+	serveErr      error
+	cacheErr      error
+	cacheFinished bool
+
+	bufp *[]byte // returned to blockBufPool only after cache + every consumer finish
+	data []byte
+}
+
+// blockFetchLease grants an assembled-range serve read-only access to a staged
+// block. The lease must be released after the assembler has copied the relevant
+// slice; it keeps a pooled buffer out of reuse while a detached writer may still
+// marshal it to a remote cache owner.
+type blockFetchLease struct {
+	service *Service
+	state   *blockFetchState
+	data    []byte
+	once    sync.Once
+}
+
+func (l *blockFetchLease) release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() { l.service.releaseBlockFetchConsumer(l.state) })
+}
+
+// beginBlockFetch joins or starts a detached block fetch. knownMissing is set
+// only by an assembled serve whose initial range read returned ErrNotFound, so
+// a new leader can avoid asking the same remote owner to prove that miss again.
+// Every caller reserves one consumer before the fetch can publish its buffer,
+// which makes ownership exact even when a fast remote write finishes before
+// waiters wake up.
+func (s *Service) beginBlockFetch(blockKey, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdx int64, knownMissing bool) *blockFetchState {
+	s.blockFetchMu.Lock()
+	if s.blockFetches == nil {
+		s.blockFetches = make(map[string]*blockFetchState)
+	}
+	if state := s.blockFetches[blockKey]; state != nil {
+		state.mu.Lock()
+		state.consumers++
+		state.mu.Unlock()
+		s.blockFetchMu.Unlock()
+		return state
+	}
+
+	state := &blockFetchState{
+		serveDone: make(chan struct{}),
+		cacheDone: make(chan struct{}),
+		consumers: 1,
+	}
+	s.blockFetches[blockKey] = state
+	s.blockFetchMu.Unlock()
+
+	go s.runBlockFetch(state, blockKey, bucket, key, accessKey, secretKey, meta, blockIdx, knownMissing)
+	return state
+}
+
+func (state *blockFetchState) completeServe(bufp *[]byte, data []byte, err error) {
+	state.mu.Lock()
+	state.bufp = bufp
+	state.data = data
+	state.serveErr = err
+	close(state.serveDone)
+	state.mu.Unlock()
+}
+
+// finishBlockFetch removes the state only after its cache write no longer reads
+// data. Existing consumers can still hold leases; the last one returns the
+// buffer to the pool. A later caller therefore either joins an in-flight write
+// or probes a write that has already completed.
+func (s *Service) finishBlockFetch(blockKey string, state *blockFetchState, cacheErr error) {
+	s.blockFetchMu.Lock()
+	if s.blockFetches[blockKey] == state {
+		delete(s.blockFetches, blockKey)
+	}
+	s.blockFetchMu.Unlock()
+
+	var bufp *[]byte
+	state.mu.Lock()
+	state.cacheErr = cacheErr
+	state.cacheFinished = true
+	close(state.cacheDone)
+	if state.consumers == 0 {
+		bufp = state.bufp
+		state.bufp = nil
+		state.data = nil
+	}
+	state.mu.Unlock()
+	if bufp != nil {
+		putBlockBuf(bufp)
+	}
+}
+
+func (s *Service) releaseBlockFetchConsumer(state *blockFetchState) {
+	var bufp *[]byte
+	state.mu.Lock()
+	state.consumers--
+	if state.cacheFinished && state.consumers == 0 {
+		bufp = state.bufp
+		state.bufp = nil
+		state.data = nil
+	}
+	state.mu.Unlock()
+	if bufp != nil {
+		putBlockBuf(bufp)
+	}
+}
+
+// fetchOneBlockForAssembly returns a lease only when this fetch read validated
+// bytes from upstream. A nil lease means another writer won the race and the
+// caller must re-read the now-present block from cache.
+func (s *Service) fetchOneBlockForAssembly(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdx int64) (*blockFetchLease, error) {
+	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, blockIdx)
+	// fetchBlocksForAssembly calls this only for a block its pre-commit range
+	// read already established as absent. The first leader can therefore skip
+	// the otherwise redundant remote presence recheck.
+	state := s.beginBlockFetch(blockKey, bucket, key, accessKey, secretKey, meta, blockIdx, true)
+
+	select {
+	case <-state.serveDone:
+		state.mu.Lock()
+		err := state.serveErr
+		data := state.data
+		state.mu.Unlock()
+		if err != nil {
+			s.releaseBlockFetchConsumer(state)
+			return nil, err
+		}
+		if data == nil {
+			s.releaseBlockFetchConsumer(state)
 			return nil, nil
 		}
-		bStart, bEnd := blockBounds(blockIdx, meta.BlockSize, meta.ContentLength)
-		blockLen := bEnd - bStart + 1
+		return &blockFetchLease{service: s, state: state, data: data}, nil
+	case <-ctx.Done():
+		s.releaseBlockFetchConsumer(state)
+		return nil, ctx.Err()
+	}
+}
 
-		// Reserve populate budget by the block size, clamped via populateWeight so a block
-		// larger than the whole budget still acquires (one-at-a-time) instead of being shed
-		// forever. Non-blocking read-miss: on decline the block isn't cached and the caller
-		// falls through to a direct upstream range.
-		reserveWeight := s.populateWeight(blockLen)
-		if !s.acquireCacheSlot(fetchCtx, reserveWeight, priorityReadMiss) {
-			metrics.RecordCachePopulateSkipped(priorityReadMiss.metricSource())
-			return nil, errCachePopulateDeclined
-		}
-		defer s.releaseCacheSlot(reserveWeight)
+// fetchOneBlock waits for both validation and durability, preserving the
+// established behavior for probe-first and background populate callers. A
+// remote assembled serve can use fetchOneBlockForAssembly instead and return
+// after validation while this same state keeps the bounded writer alive.
+func (s *Service) fetchOneBlock(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdx int64) error {
+	blockKey := cache.MakeBlockKey(bucket, key, meta.ETag, meta.BlockSize, blockIdx)
+	state := s.beginBlockFetch(blockKey, bucket, key, accessKey, secretKey, meta, blockIdx, false)
 
-		resp, rerr := s.forwarder.DoConditionalGetRequest(fetchCtx, bucket, key, accessKey, secretKey, "", 0, fmt.Sprintf("bytes=%d-%d", bStart, bEnd))
-		if rerr != nil {
-			return nil, rerr
+	select {
+	case <-state.cacheDone:
+		state.mu.Lock()
+		err := state.cacheErr
+		state.mu.Unlock()
+		s.releaseBlockFetchConsumer(state)
+		return err
+	case <-ctx.Done():
+		s.releaseBlockFetchConsumer(state)
+		return ctx.Err()
+	}
+}
+
+// fetchBlocksForAssembly fetches the missing blocks needed by a pre-commit
+// assembled range and retains their validated bytes for direct assembly. It
+// preserves fetchBlocksToCache's stale-signal priority and invalidation rules.
+func (s *Service) fetchBlocksForAssembly(ctx context.Context, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdxs []int64) (map[int64]*blockFetchLease, error) {
+	var g errgroup.Group
+	g.SetLimit(maxConcurrentBlockFetches)
+	var mu sync.Mutex
+	leases := make(map[int64]*blockFetchLease, len(blockIdxs))
+	var stale, transient error
+	for _, idx := range blockIdxs {
+		g.Go(func() error {
+			lease, err := s.fetchOneBlockForAssembly(ctx, bucket, key, accessKey, secretKey, meta, idx)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if errors.Is(err, errBlockETagMismatch) || errors.Is(err, errBlockUpstreamGone) {
+					if stale == nil {
+						stale = err
+					}
+				} else if transient == nil {
+					transient = err
+				}
+				return nil
+			}
+			if lease != nil {
+				leases[idx] = lease
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	if stale != nil {
+		for _, lease := range leases {
+			lease.release()
 		}
-		defer resp.Body.Close()
-		// A 404 is an object-level "gone" — the cached entry is stale, so signal it for
-		// invalidation. A 403 is NOT: it is principal/permission-level (these credentials can't
-		// read the object right now), not proof the object is gone, so it must not invalidate the
-		// block-mode entry shared across all principals — otherwise one caller's denial would wipe
-		// a valid entry for everyone. A 403 falls through to the generic non-206 failure below
-		// (fail this fetch, no invalidation); the caller then forwards the request upstream.
-		if resp.StatusCode == http.StatusNotFound {
-			return nil, errBlockUpstreamGone
+		log.Debug().Err(stale).Str("bucket", bucket).Str("key", key).Msg("Invalidating stale block-mode meta")
+		s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+		return nil, stale
+	}
+	if transient != nil {
+		for _, lease := range leases {
+			lease.release()
 		}
-		// A block fetch must be a 206 whose body is exactly the requested block bytes. A 200
-		// means upstream ignored the Range and returned the whole object (whose byte 0 is the
-		// object start, not this block's offset), and a length that differs from the requested
-		// block means the 206 bounds don't match — storing either would corrupt block offsets.
-		// Reject both; the caller falls through to a direct upstream range.
-		if resp.StatusCode != http.StatusPartialContent {
-			return nil, fmt.Errorf("block %d fetch: unexpected status %d (want 206)", blockIdx, resp.StatusCode)
-		}
-		// ETag guard FIRST: the block must belong to the exact version meta describes. Checking
-		// this before the length/bounds guards ensures an out-of-band overwrite (which changes
-		// the ETag, and may also change the touched block's length) is reported as
-		// errBlockETagMismatch — so ensureBlocksCached invalidates the stale entry — rather than
-		// masked by a plain length/bounds error that leaves the stale meta to retry until TTL.
-		// A block-mode entry is only established from a range response that carried an ETag, so
-		// meta.ETag is always set. If a per-block fetch OMITS its ETag we cannot confirm the
-		// version: a same-size overwrite would otherwise be stored under the old meta.ETag,
-		// mixing versions across blocks. Treat missing-ETag as a transient failure (don't cache,
-		// don't invalidate — it's unconfirmed, not a definitive mismatch); the caller falls
-		// through to a direct upstream range that serves the current bytes.
-		respETag := resp.Header.Get("ETag")
-		if respETag == "" {
-			return nil, fmt.Errorf("block %d fetch: response missing ETag, cannot verify version", blockIdx)
-		}
-		if respETag != meta.ETag {
-			return nil, errBlockETagMismatch
-		}
-		// Same version (ETag matches): the response length must be exactly the requested block.
-		// This rejects a 200 (whole object) and any 206 whose length differs — including an
-		// unknown/chunked length (ContentLength < 0), which we can't validate and so must not
-		// store (a short/long body would be served at fixed block-local offsets, corrupting
-		// reads). S3/Tigris always set Content-Length on a 206, so a well-formed fetch passes.
-		if resp.ContentLength != blockLen {
-			return nil, fmt.Errorf("block %d fetch: content-length %d, want %d", blockIdx, resp.ContentLength, blockLen)
-		}
-		// Validate the 206's Content-Range bounds match the block we asked for. A same-length
-		// response at a different offset (a non-conformant upstream) would otherwise be stored
-		// under this block index and served at the wrong object offset.
-		if rs, re, _, ok := parseContentRange(resp.Header.Get("Content-Range")); !ok || rs != bStart || re != bEnd {
-			return nil, fmt.Errorf("block %d fetch: content-range bounds %d-%d (ok=%t), want %d-%d", blockIdx, rs, re, ok, bStart, bEnd)
-		}
-		// Read the full block into memory before storing: the guards above validate the 206's
-		// headers, not that the body actually delivered blockLen bytes. A body that ends short
-		// (truncated response) streamed straight into PutBlockStream could persist a short block,
-		// which BlockExists can't distinguish from a complete one — so it would later serve
-		// truncated bytes. io.ReadFull errors on a short body, so a partial block is never stored.
-		// blockLen <= block_size, bounded by maxConcurrentBlockFetches concurrent fetches. The
-		// buffer is pooled and safely returned on exit: PutBlock consumes the fully validated
-		// slice before returning, so nothing references it afterwards.
-		bufp := getBlockBuf(blockLen)
-		defer putBlockBuf(bufp)
-		blockBuf := (*bufp)[:blockLen]
-		if _, rerr := io.ReadFull(resp.Body, blockBuf); rerr != nil {
-			return nil, fmt.Errorf("block %d fetch: short body (%w), want %d bytes", blockIdx, rerr, blockLen)
-		}
-		ttl := int(s.config.Cache.TTL.Seconds())
-		if perr := s.cache.PutBlock(fetchCtx, bucket, key, meta.ETag, meta.BlockSize, blockIdx, blockBuf, ttl); perr != nil {
+		return nil, transient
+	}
+	return leases, nil
+}
+
+// runBlockFetch fetches and validates one aligned block under a detached,
+// timeout-bounded context. It transfers the acquired populate slot and staged
+// buffer to a remote writer only after io.ReadFull has completed. Local owners
+// (and clients that cannot report ownership) retain the prior synchronous write
+// behavior; remote owners publish the immutable bytes to assemblers first.
+func (s *Service) runBlockFetch(state *blockFetchState, blockKey, bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, blockIdx int64, knownMissing bool) {
+	fetchCtx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	fail := func(err error) {
+		state.completeServe(nil, nil, err)
+		cancel()
+		s.finishBlockFetch(blockKey, state, err)
+	}
+
+	// A generic coalesced fetch may have been preceded by an unrelated writer,
+	// so it retains the presence recheck. The assembled path reaches here only
+	// after its own range read returned ErrNotFound; repeating that remote probe
+	// adds a serial RPC without making the staged bytes safer. A writer that
+	// races after that observed miss can at most receive an idempotent put of the
+	// same ETag-versioned block.
+	if !knownMissing && s.cache.BlockExists(fetchCtx, bucket, key, meta.ETag, meta.BlockSize, blockIdx) {
+		state.completeServe(nil, nil, nil)
+		cancel()
+		s.finishBlockFetch(blockKey, state, nil)
+		return
+	}
+	bStart, bEnd := blockBounds(blockIdx, meta.BlockSize, meta.ContentLength)
+	blockLen := bEnd - bStart + 1
+
+	// Reserve populate budget by the block size, clamped via populateWeight so a block
+	// larger than the whole budget still acquires (one-at-a-time) instead of being shed
+	// forever. The reservation stays held by a detached remote writer, bounding both
+	// the number of writers and the staged bytes after the client response is sent.
+	reserveWeight := s.populateWeight(blockLen)
+	if !s.acquireCacheSlot(fetchCtx, reserveWeight, priorityReadMiss) {
+		metrics.RecordCachePopulateSkipped(priorityReadMiss.metricSource())
+		fail(errCachePopulateDeclined)
+		return
+	}
+
+	abort := func(err error) {
+		s.releaseCacheSlot(reserveWeight)
+		fail(err)
+	}
+	resp, rerr := s.forwarder.DoConditionalGetRequest(fetchCtx, bucket, key, accessKey, secretKey, "", 0, fmt.Sprintf("bytes=%d-%d", bStart, bEnd))
+	if rerr != nil {
+		abort(rerr)
+		return
+	}
+	defer resp.Body.Close()
+	// A 404 is an object-level "gone" — the cached entry is stale, so signal it for
+	// invalidation. A 403 is principal-level and must not invalidate shared metadata.
+	if resp.StatusCode == http.StatusNotFound {
+		abort(errBlockUpstreamGone)
+		return
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		abort(fmt.Errorf("block %d fetch: unexpected status %d (want 206)", blockIdx, resp.StatusCode))
+		return
+	}
+	// ETag validation precedes shape validation so an overwrite is reported as stale
+	// even when it also changed the touched block's length.
+	respETag := resp.Header.Get("ETag")
+	if respETag == "" {
+		abort(fmt.Errorf("block %d fetch: response missing ETag, cannot verify version", blockIdx))
+		return
+	}
+	if respETag != meta.ETag {
+		abort(errBlockETagMismatch)
+		return
+	}
+	if resp.ContentLength != blockLen {
+		abort(fmt.Errorf("block %d fetch: content-length %d, want %d", blockIdx, resp.ContentLength, blockLen))
+		return
+	}
+	if rs, re, _, ok := parseContentRange(resp.Header.Get("Content-Range")); !ok || rs != bStart || re != bEnd {
+		abort(fmt.Errorf("block %d fetch: content-range bounds %d-%d (ok=%t), want %d-%d", blockIdx, rs, re, ok, bStart, bEnd))
+		return
+	}
+
+	// A block becomes usable only after its body is exact. The same immutable slice
+	// is then safe for concurrent read-only assembly and remote gRPC marshaling.
+	bufp := getBlockBuf(blockLen)
+	blockBuf := (*bufp)[:blockLen]
+	if _, rerr := io.ReadFull(resp.Body, blockBuf); rerr != nil {
+		putBlockBuf(bufp)
+		abort(fmt.Errorf("block %d fetch: short body (%w), want %d bytes", blockIdx, rerr, blockLen))
+		return
+	}
+	ttl := int(s.config.Cache.TTL.Seconds())
+
+	// Only a client that positively reports a remote owner takes the detached path.
+	// Unknown clients retain the old synchronous semantics, as do local embedded owners.
+	local, known := s.cache.IsBlockLocal(bucket, key, meta.ETag, meta.BlockSize, blockIdx)
+	if !known || local {
+		perr := s.cache.PutBlock(fetchCtx, bucket, key, meta.ETag, meta.BlockSize, blockIdx, blockBuf, ttl)
+		s.releaseCacheSlot(reserveWeight)
+		cancel()
+		if perr != nil {
+			putBlockBuf(bufp)
 			metrics.CacheBlockPopulateFailed.Inc()
-			return nil, perr
+			state.completeServe(nil, nil, perr)
+			s.finishBlockFetch(blockKey, state, perr)
+			return
 		}
 		metrics.CacheBlockPopulated.Inc()
 		metrics.CacheBlockBytesPopulated.Add(float64(blockLen))
-		return nil, nil
-	})
-	select {
-	case res := <-ch:
-		return res.Err
-	case <-ctx.Done():
-		// The caller gave up (e.g. client disconnected). Stop waiting and return promptly; the
-		// detached fetch above keeps running to populate the cache for any remaining waiters.
-		return ctx.Err()
+		state.completeServe(bufp, blockBuf, nil)
+		s.finishBlockFetch(blockKey, state, nil)
+		return
 	}
+
+	// Remote persistence is intentionally detached from the assembled response.
+	// The state retains both the slot and buffer until PutBlock has consumed the
+	// bytes, so this cannot create unbounded writers or recycle a live pool buffer.
+	state.completeServe(bufp, blockBuf, nil)
+	go func() {
+		perr := s.cache.PutBlock(fetchCtx, bucket, key, meta.ETag, meta.BlockSize, blockIdx, blockBuf, ttl)
+		if perr != nil {
+			metrics.CacheBlockPopulateFailed.Inc()
+			log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Int64("block", blockIdx).Msg("Detached remote block cache write failed")
+		} else {
+			metrics.CacheBlockPopulated.Inc()
+			metrics.CacheBlockBytesPopulated.Add(float64(blockLen))
+		}
+		s.releaseCacheSlot(reserveWeight)
+		cancel()
+		s.finishBlockFetch(blockKey, state, perr)
+	}()
 }
 
 // invalidateStaleBlockMeta deletes the object's cache entry only if the stored meta still carries

--- a/proxy/block_cache_remote_write_test.go
+++ b/proxy/block_cache_remote_write_test.go
@@ -1,0 +1,397 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// remoteMissTrace records the cross-node waterfall without timing-based
+// synchronization. Tests use its ordering as a regression guard and log the
+// completed trace for a readable miss-path timeline.
+type remoteMissTrace struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (t *remoteMissTrace) add(event string) {
+	t.mu.Lock()
+	t.events = append(t.events, event)
+	t.mu.Unlock()
+}
+
+func (t *remoteMissTrace) snapshot() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.events...)
+}
+
+func (t *remoteMissTrace) requireOrder(tb testing.TB, want ...string) {
+	tb.Helper()
+	events := t.snapshot()
+	next := 0
+	for _, event := range events {
+		if next < len(want) && event == want[next] {
+			next++
+		}
+	}
+	if next != len(want) {
+		tb.Fatalf("waterfall = %s, missing ordered sequence %s", strings.Join(events, " -> "), strings.Join(want, " -> "))
+	}
+}
+
+// gatedOwnerBlockClient models either a local or a remote embedded owner. It
+// holds PutBlockBytes until the test releases it, retaining the caller's slice
+// meanwhile so buffer ownership and write detachment can be observed directly.
+type gatedOwnerBlockClient struct {
+	cacheclient.CacheClient
+	local bool
+	trace *remoteMissTrace
+
+	getCalls atomic.Int64
+
+	putStarted  chan struct{}
+	allowPut    chan struct{}
+	putFinished chan struct{}
+
+	mu       sync.Mutex
+	received []byte
+}
+
+func newGatedOwnerBlockClient(base cacheclient.CacheClient, local bool, trace *remoteMissTrace) *gatedOwnerBlockClient {
+	return &gatedOwnerBlockClient{
+		CacheClient: base,
+		local:       local,
+		trace:       trace,
+		putStarted:  make(chan struct{}, 1),
+		allowPut:    make(chan struct{}),
+		putFinished: make(chan struct{}, 1),
+	}
+}
+
+func (c *gatedOwnerBlockClient) IsLocal(string) bool { return c.local }
+
+func (c *gatedOwnerBlockClient) GetRangeStream(ctx context.Context, key string, start, end int64, w io.Writer) error {
+	if c.getCalls.Add(1) == 1 {
+		c.trace.add("cache-miss-probe")
+	} else {
+		c.trace.add("cache-read")
+	}
+	return c.CacheClient.GetRangeStream(ctx, key, start, end, w)
+}
+
+func (c *gatedOwnerBlockClient) PutBlockBytes(ctx context.Context, key string, data []byte, ttlSeconds int64) (bool, error) {
+	c.trace.add("remote-cache-put-start")
+	select {
+	case c.putStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case <-c.allowPut:
+	case <-ctx.Done():
+		return true, ctx.Err()
+	}
+
+	c.mu.Lock()
+	c.received = append(c.received[:0], data...)
+	c.mu.Unlock()
+	err := c.CacheClient.Put(ctx, key, data, ttlSeconds)
+	c.trace.add("remote-cache-put-finish")
+	select {
+	case c.putFinished <- struct{}{}:
+	default:
+	}
+	return true, err
+}
+
+func (c *gatedOwnerBlockClient) receivedBlock() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.received...)
+}
+
+// tracedBlockForwarder adds the upstream range fetch to the test waterfall
+// while reusing the normal block-cache response validation fixture.
+type tracedBlockForwarder struct {
+	*blockMockForwarder
+	trace *remoteMissTrace
+}
+
+func (f *tracedBlockForwarder) DoConditionalGetRequest(ctx context.Context, bucket, key, accessKey, secretKey, etag string, modifiedSince int64, rangeHeader string) (*http.Response, error) {
+	f.trace.add("upstream-fetch")
+	return f.blockMockForwarder.DoConditionalGetRequest(ctx, bucket, key, accessKey, secretKey, etag, modifiedSince, rangeHeader)
+}
+
+func newGatedAssembledRangeService(t *testing.T, local bool) (*Service, *cache.Cache, *gatedOwnerBlockClient, *blockMockForwarder, *cache.CachedObjectMeta, *remoteMissTrace) {
+	t.Helper()
+	const (
+		bucket = "remote-bucket"
+		key    = "remote-key"
+	)
+
+	trace := &remoteMissTrace{}
+	mock := newBlockMock([]byte("ABCDEFGH"), `"v1"`)
+	forwarder := &tracedBlockForwarder{blockMockForwarder: mock, trace: trace}
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	cfg.Cache.MaxConcurrentWrites = 1
+	cfg.Cache.MaxPopulateMemoryBytes = -1 // isolate the count-bound detached writer in this fixture
+	client := newGatedOwnerBlockClient(cacheclient.NewMemoryCache(), local, trace)
+	store := cache.NewCacheWithClient(client, &cfg.Cache)
+	svc := NewService(forwarder, store, cfg)
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"v1"`,
+		ContentLength: 8,
+		StatusCode:    http.StatusOK,
+		BlockSize:     4,
+	}
+	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+		t.Fatalf("seed block meta = (wrote=%t, err=%v)", wrote, err)
+	}
+	return svc, store, client, mock, meta, trace
+}
+
+type assembledRangeResult struct {
+	w      *httptest.ResponseRecorder
+	served bool
+	err    error
+}
+
+func startGatedAssembledRange(svc *Service, meta *cache.CachedObjectMeta, trace *remoteMissTrace) <-chan assembledRangeResult {
+	results := make(chan assembledRangeResult, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		served, err := svc.serveAssembledRange(context.Background(), w, meta.Bucket, meta.Key, "access", "secret", meta, byteRange{start: 0, end: 3}, time.Now())
+		trace.add("response-committed")
+		results <- assembledRangeResult{w: w, served: served, err: err}
+	}()
+	return results
+}
+
+func waitBlockSignal(t *testing.T, signal <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+func waitAssembledRange(t *testing.T, results <-chan assembledRangeResult) assembledRangeResult {
+	t.Helper()
+	select {
+	case result := <-results:
+		return result
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for assembled range response")
+		return assembledRangeResult{}
+	}
+}
+
+func activeBlockFetch(svc *Service, blockKey string) *blockFetchState {
+	svc.blockFetchMu.Lock()
+	defer svc.blockFetchMu.Unlock()
+	return svc.blockFetches[blockKey]
+}
+
+// A remote-owner miss must return as soon as the aligned upstream block has
+// been validated. The trace proves that no post-put cache reread sits between
+// the upstream fetch and the committed 206, while the blocked writer proves the
+// client does not wait for remote persistence.
+func TestServeAssembledRange_RemoteMissServesValidatedBytesBeforeCacheWrite(t *testing.T) {
+	svc, store, client, mock, meta, trace := newGatedAssembledRangeService(t, false)
+	results := startGatedAssembledRange(svc, meta, trace)
+
+	// Do not wait for the writer to be scheduled first: it is intentionally a
+	// separate goroutine and may start before or after this response completes.
+	// The blocked PutBlockBytes call is the durability boundary the response must
+	// not wait on.
+	result := waitAssembledRange(t, results)
+	if result.err != nil || !result.served {
+		t.Fatalf("serveAssembledRange = (served=%t, err=%v)", result.served, result.err)
+	}
+	if result.w.Code != http.StatusPartialContent || result.w.Body.String() != "ABCD" {
+		t.Fatalf("response = (%d, %q), want (206, ABCD)", result.w.Code, result.w.Body.String())
+	}
+	if got := client.getCalls.Load(); got != 1 {
+		t.Fatalf("remote cache reads before response = %d, want 1 (the initial miss probe only)", got)
+	}
+	if got := mock.blockGets.Load(); got != 1 {
+		t.Fatalf("upstream block fetches = %d, want 1", got)
+	}
+	waitBlockSignal(t, client.putStarted, "remote cache put start")
+
+	blockKey := cache.MakeBlockKey(meta.Bucket, meta.Key, meta.ETag, meta.BlockSize, 0)
+	state := activeBlockFetch(svc, blockKey)
+	if state == nil {
+		t.Fatal("detached remote write was removed before it completed")
+	}
+	state.mu.Lock()
+	bufferRetained := state.bufp != nil && !state.cacheFinished && state.consumers == 0
+	state.mu.Unlock()
+	if !bufferRetained {
+		t.Fatal("validated block buffer was not retained by the detached writer after the response")
+	}
+
+	close(client.allowPut)
+	waitBlockSignal(t, client.putFinished, "remote cache put finish")
+	select {
+	case <-state.cacheDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached remote write did not release its fetch state")
+	}
+	state.mu.Lock()
+	bufferReleased := state.bufp == nil
+	state.mu.Unlock()
+	if !bufferReleased {
+		t.Fatal("pooled block buffer remained owned after both writer and assembler completed")
+	}
+	trace.requireOrder(t, "cache-miss-probe", "upstream-fetch", "response-committed", "remote-cache-put-finish")
+	t.Logf("remote range-miss waterfall: %s", strings.Join(trace.snapshot(), " -> "))
+
+	if !store.BlockExists(context.Background(), meta.Bucket, meta.Key, meta.ETag, meta.BlockSize, 0) {
+		t.Fatal("remote owner was not populated after the detached write completed")
+	}
+	if got := client.receivedBlock(); !bytes.Equal(got, []byte("ABCD")) {
+		t.Fatalf("remote writer received %q, want ABCD", got)
+	}
+}
+
+// Overlapping assembled requests keep joining the validated state while its
+// remote write is pending, rather than refetching bytes the first request has
+// already validated but not yet made durable at the owner.
+func TestServeAssembledRange_RemoteMissCoalescesUntilWriteFinishes(t *testing.T) {
+	svc, _, client, mock, meta, _ := newGatedAssembledRangeService(t, false)
+	first := startGatedAssembledRange(svc, meta, client.trace)
+
+	waitBlockSignal(t, client.putStarted, "first remote cache put start")
+	if result := waitAssembledRange(t, first); result.err != nil || !result.served {
+		t.Fatalf("first serveAssembledRange = (served=%t, err=%v)", result.served, result.err)
+	}
+	second := startGatedAssembledRange(svc, meta, client.trace)
+	if result := waitAssembledRange(t, second); result.err != nil || !result.served {
+		t.Fatalf("second serveAssembledRange = (served=%t, err=%v)", result.served, result.err)
+	}
+	if got := mock.blockGets.Load(); got != 1 {
+		t.Fatalf("upstream block fetches for overlapping remote misses = %d, want 1", got)
+	}
+	if got := client.getCalls.Load(); got != 2 {
+		t.Fatalf("remote cache reads for overlapping misses = %d, want 2 (one initial probe per request)", got)
+	}
+	select {
+	case <-client.putStarted:
+		t.Fatal("overlapping request started a second remote cache write")
+	default:
+	}
+
+	close(client.allowPut)
+	waitBlockSignal(t, client.putFinished, "remote cache put finish")
+}
+
+// A detached writer owns the cache-populate slot until its remote put completes,
+// so a stalled peer cannot turn a burst of assembled misses into unbounded work.
+func TestServeAssembledRange_RemoteWriterHoldsPopulateSlot(t *testing.T) {
+	svc, _, client, mock, meta, _ := newGatedAssembledRangeService(t, false)
+	results := startGatedAssembledRange(svc, meta, client.trace)
+
+	waitBlockSignal(t, client.putStarted, "remote cache put start")
+	if err := svc.fetchOneBlock(context.Background(), meta.Bucket, meta.Key, "access", "secret", meta, 1); !errors.Is(err, errCachePopulateDeclined) {
+		t.Fatalf("second block fetch while remote writer is stalled = %v, want %v", err, errCachePopulateDeclined)
+	}
+	if got := mock.blockGets.Load(); got != 1 {
+		t.Fatalf("bounded writer allowed a second upstream fetch: got %d, want 1", got)
+	}
+
+	close(client.allowPut)
+	waitBlockSignal(t, client.putFinished, "remote cache put finish")
+	result := waitAssembledRange(t, results)
+	if result.err != nil || !result.served {
+		t.Fatalf("serveAssembledRange = (served=%t, err=%v)", result.served, result.err)
+	}
+}
+
+// Local ownership intentionally retains the old durability boundary: the 206
+// cannot commit until the local cache write finishes, even though it uses the
+// staged bytes rather than doing a post-write reread.
+func TestServeAssembledRange_LocalOwnerWaitsForCacheWrite(t *testing.T) {
+	svc, store, client, _, meta, _ := newGatedAssembledRangeService(t, true)
+	results := startGatedAssembledRange(svc, meta, client.trace)
+
+	waitBlockSignal(t, client.putStarted, "local cache put start")
+	select {
+	case result := <-results:
+		t.Fatalf("local response completed before its cache write: served=%t err=%v", result.served, result.err)
+	default:
+	}
+
+	close(client.allowPut)
+	result := waitAssembledRange(t, results)
+	if result.err != nil || !result.served || result.w.Body.String() != "ABCD" {
+		t.Fatalf("local assembled response = (served=%t, err=%v, body=%q), want successful ABCD", result.served, result.err, result.w.Body.String())
+	}
+	if !store.BlockExists(context.Background(), meta.Bucket, meta.Key, meta.ETag, meta.BlockSize, 0) {
+		t.Fatal("local block was not durable before the response completed")
+	}
+}
+
+// A delete that lands while a remote writer is detached may leave an unreachable
+// versioned block, but it must never restore metadata past the tombstone.
+func TestServeAssembledRange_RemoteWriteRespectsTombstoneVisibility(t *testing.T) {
+	svc, store, client, _, meta, _ := newGatedAssembledRangeService(t, false)
+	results := startGatedAssembledRange(svc, meta, client.trace)
+
+	waitBlockSignal(t, client.putStarted, "remote cache put start")
+	result := waitAssembledRange(t, results)
+	if result.err != nil || !result.served {
+		t.Fatalf("serveAssembledRange = (served=%t, err=%v)", result.served, result.err)
+	}
+	if err := store.Delete(context.Background(), meta.Bucket, meta.Key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	close(client.allowPut)
+	waitBlockSignal(t, client.putFinished, "remote cache put finish")
+
+	if _, found, err := store.GetMeta(context.Background(), meta.Bucket, meta.Key); err != nil || found {
+		t.Fatalf("metadata after tombstoned detached write = (found=%t, err=%v), want absent", found, err)
+	}
+	if tombstone := store.GetTombstoneTimestamp(context.Background(), meta.Bucket, meta.Key); tombstone == 0 {
+		t.Fatal("delete tombstone disappeared while detached block write completed")
+	}
+}
+
+// Validation remains before both handoff and persistence: a short 206 body
+// cannot be served from memory or left behind as a block after a remote miss.
+func TestServeAssembledRange_RemoteMissRejectsShortValidatedBlock(t *testing.T) {
+	svc, store, client, mock, meta, _ := newGatedAssembledRangeService(t, false)
+	mock.blockGetShortBody = true
+
+	w := httptest.NewRecorder()
+	served, err := svc.serveAssembledRange(context.Background(), w, meta.Bucket, meta.Key, "access", "secret", meta, byteRange{start: 0, end: 3}, time.Now())
+	if served || err == nil {
+		t.Fatalf("short body serve = (served=%t, err=%v), want pre-commit failure", served, err)
+	}
+	select {
+	case <-client.putStarted:
+		t.Fatal("short upstream body reached the remote cache writer")
+	default:
+	}
+	if store.BlockExists(context.Background(), meta.Bucket, meta.Key, meta.ETag, meta.BlockSize, 0) {
+		t.Fatal("short upstream body was persisted as a complete block")
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tigrisdata/tag/config"
 	"github.com/tigrisdata/tag/metrics"
 	"github.com/tigrisdata/tag/proxy/broadcast"
-	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -66,12 +65,13 @@ type Service struct {
 	forwarder               RequestForwarder
 	cache                   *cache.Cache
 	config                  *config.Config
-	cacheSemaphore          chan struct{}      // Count ceiling on concurrent cache-populate ops (nil = unlimited)
-	populateBudget          *byteBudget        // Byte budget bounding all cache buffering — populate + block-serve staging (nil = unlimited)
-	perPopulateCap          int64              // Max bytes a single populate can buffer (reservation ceiling)
-	broadcastManager        *broadcast.Manager // For streaming request coalescing
-	activeBackgroundFetches sync.Map           // Dedup for background full-object fetches (range caching)
-	blockFetch              singleflight.Group // Coalesce concurrent fetches of the same block (RFC 0001)
+	cacheSemaphore          chan struct{}               // Count ceiling on concurrent cache-populate ops (nil = unlimited)
+	populateBudget          *byteBudget                 // Byte budget bounding all cache buffering — populate + block-serve staging (nil = unlimited)
+	perPopulateCap          int64                       // Max bytes a single populate can buffer (reservation ceiling)
+	broadcastManager        *broadcast.Manager          // For streaming request coalescing
+	activeBackgroundFetches sync.Map                    // Dedup for background full-object fetches (range caching)
+	blockFetchMu            sync.Mutex                  // Guards blockFetches
+	blockFetches            map[string]*blockFetchState // Coalesce block fetches while a detached remote write is pending
 }
 
 // NewService creates a new proxy service.
@@ -146,6 +146,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		populateBudget:   populateBudget,
 		perPopulateCap:   perPopulateCap,
 		broadcastManager: broadcast.NewManager(channelBuf),
+		blockFetches:     make(map[string]*blockFetchState),
 	}
 }
 


### PR DESCRIPTION
## Problem

On a block-mode range miss, `serveAssembledRange` waits for every missing block to be fetched **and persisted** via `PutBlock` before assembling the response, then **re-reads those same blocks** via `GetBlockRangeStream`. For remote-owned keys (~2/3 of keys in a 3-node cluster under consistent hashing) that means **three transfers of the same block before the client sees a byte**:

```
before: miss probe → presence recheck → upstream fetch → sync remote put → sync remote re-read → response
after:  miss probe → upstream fetch → response   (remote put detached, after the client)
```

A production goroutine capture on the ORD parseable-tag cluster (v1.17.1, 2,600 req/s, inflight=225) showed 69 goroutines parked in the remote put and 179 in the remote read-back, with **total p95 1.43 s vs upstream p95 0.28 s** — ~1.1 s of TAG-side miss latency from the two synchronous cross-node hops plus peer queueing (CPU 5/16 cores, zero sheds, zero populate skips ruled out other causes).

## Change

- `fetchBlocksToCache`/`fetchOneBlock` keep each validated block in its pooled buffer and **hand it to the assembler** — the response is served from memory. The post-fetch cache re-read runs only for blocks this request did not itself fetch.
- The **remote-owner cache write detaches** and completes after the response, **holding its populate slot** for the write's duration — a stalled peer back-pressures new fetches instead of spawning unbounded work.
- The redundant remote **presence recheck is coalesced away**: a `blockFetches` map (replacing the `singleflight` group) lets overlapping requests **join the in-flight validated bytes** while a detached write is pending — two overlapping misses cost one upstream fetch and one remote write.
- **Local-owner semantics unchanged**: the 206 still waits for the local durable write (using staged bytes, no re-read). Short bodies are rejected before both handoff and persistence. Tombstone visibility preserved: a delete landing during a detached write never resurrects metadata (tested).

## Measured (perfloop case `case_1sgxydbzz3`, sealed verdict VALIDATED)

End-to-end through the real HTTP handler, paired runs in **both orders**:

| Metric (1 MiB remote-owned miss) | Before | After |
|---|---|---|
| Latency | 5.41 ms/op | **2.00 ms/op (2.7×)** |
| Throughput | 194 MB/s | **524 MB/s** |
| User CPU | 9.54 M ns/op | **6.18 M ns/op (−35%)** |
| Remote cache RPCs | 4 | **2** |
| Remote cache GETs | 3 | **1** |
| Post-fetch re-reads | 1 | **0** |

A composed synchronous-write alternative (3.98 ms/op, more CPU) and a simpler singleflight variant (4.19 ms/op) were benchmarked against the same guards and both lost. Partial-range shape (4 KiB) verified with exact bytes and the same RPC reduction.

## Validation

- Full build incl. `cmd/tag` (RocksDB toolchain — the perfloop sandbox could not build this; validated locally)
- `go test -race` green: `proxy`, `proxy/broadcast`, `cache`, `handlers`
- New concurrency tests pass at `-count=5` under race: overlap coalescing, populate-slot backpressure, local-owner durability boundary, tombstone visibility during detached write, short-body rejection
- Local benchmark reproduces the sealed counters: 0 re-reads, 1 remote GET, 2 remote RPCs per miss

**Semantic note:** for remote-owned blocks the response now commits before the block is durable at the owner. Worst case is a later re-fetch, never wrong data; local-owner durability is unchanged.

## Provenance

Diagnosed from a live prod load test (goroutine capture + Grafana after tigris-infra#14974 made ORD observable); hypothesis `hyp_j3gq459x5j` admitted and case-sessioned in perfloop — 4 self-improving candidates, sealed `VALIDATED` on `cand_z067hhxfdz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3c5fd03b9bf4db0a94f4e49ae7a40bd75b829960. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->