### PR TITLE
perf(metrics): prefetch-window outcome counter + finer latency buckets

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -22,9 +22,12 @@ var (
 	// RequestDuration tracks request latency by operation.
 	RequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "tag_request_duration_seconds",
-			Help:    "Request duration in seconds",
-			Buckets: prometheus.DefBuckets,
+			Name: "tag_request_duration_seconds",
+			Help: "Request duration in seconds",
+			// DefBuckets plus extra resolution in the 1-10s tail (1.5, 2, 3, 4, 7.5):
+			// the default 1 -> 2.5 -> 5 -> 10 jumps are too coarse to localize p99 during
+			// tail investigations — quantiles interpolate across whole seconds.
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10},
 		},
 		[]string{"operation"},
 	)
@@ -273,6 +276,20 @@ var (
 			Name: "tag_cache_block_populate_failed_total",
 			Help: "Number of validated object blocks whose cache write failed (block-aligned caching)",
 		},
+	)
+
+	// CacheBlockPrefetchWindows counts multi-block serves by the prefetch window they were
+	// granted from the shared staging budget: "full" (requested window granted), "shrunk"
+	// (a smaller window than requested), or "sequential" (budget declined every window size —
+	// the serve degraded to the unbuffered sequential path). A rising shrunk/sequential share
+	// under load means the staging budget (half of max_populate_memory_bytes) is saturating
+	// and tail latency is being served by the slow path.
+	CacheBlockPrefetchWindows = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tag_cache_block_prefetch_windows_total",
+			Help: "Multi-block serves by granted prefetch window outcome: full, shrunk, or sequential (block-aligned caching)",
+		},
+		[]string{"outcome"},
 	)
 
 	// CacheBlockHits counts covering blocks already present in cache when serving a request

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -404,12 +404,17 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 	if b0 == bK {
 		out, err = s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 	} else {
-		window := min(bK-b0+1, int64(maxBlockServePrefetch))
+		requested := min(bK-b0+1, int64(maxBlockServePrefetch))
 		pipelined := false
-		for ; window >= 2; window-- {
+		for window := requested; window >= 2; window-- {
 			weight := s.stagingWeight(window * meta.BlockSize)
 			if s.populateBudget != nil && !s.populateBudget.tryAcquireStaging(weight) {
 				continue
+			}
+			if window == requested {
+				metrics.CacheBlockPrefetchWindows.WithLabelValues("full").Inc()
+			} else {
+				metrics.CacheBlockPrefetchWindows.WithLabelValues("shrunk").Inc()
 			}
 			out, err = s.streamBlockRangePipelined(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end, int(window))
 			if s.populateBudget != nil {
@@ -419,6 +424,7 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 			break
 		}
 		if !pipelined {
+			metrics.CacheBlockPrefetchWindows.WithLabelValues("sequential").Inc()
 			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Pipeline buffer budget declined - streaming blocks sequentially")
 			out, err = s.streamBlockRangeSequential(ctx, cw, bucket, key, accessKey, secretKey, meta, start, end)
 		}

--- a/proxy/block_cache_prefetch_test.go
+++ b/proxy/block_cache_prefetch_test.go
@@ -13,10 +13,12 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	cacheclient "github.com/tigrisdata/ocache/client"
 	pb "github.com/tigrisdata/ocache/proto"
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/metrics"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -752,5 +754,53 @@ func TestBlockCache_PipelineClientWriteFailureCancelsPrefetches(t *testing.T) {
 	service.populateBudget.mu.Unlock()
 	if remaining != total || inUse != 0 {
 		t.Fatalf("staging budget after cancelled prefetch = (remaining=%d, in_use=%d), want (%d, 0)", remaining, inUse, total)
+	}
+}
+
+// prefetchWindowOutcome reads the current value of the prefetch-window outcome counter.
+func prefetchWindowOutcome(t *testing.T, outcome string) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := metrics.CacheBlockPrefetchWindows.WithLabelValues(outcome).Write(&m); err != nil {
+		t.Fatalf("read counter %q: %v", outcome, err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// Every multi-block serve classifies the prefetch window it was granted: a budget
+// covering the full request counts "full", a budget granting a smaller window counts
+// "shrunk", and a budget that declines every window size counts "sequential". The
+// counter is the operator-facing signal that tail latency is coming from staging
+// saturation rather than the fast pipelined path.
+func TestBlockCache_PrefetchWindowOutcomeCounter(t *testing.T) {
+	blockSize := int64(prefetchTestBlockSize)
+	cases := []struct {
+		name    string
+		blocks  int
+		total   int64 // MaxPopulateMemoryBytes; staging cap is half
+		outcome string
+	}{
+		// 4 blocks requested, staging cap 4 blocks -> full window granted.
+		{"full", 4, 8 * blockSize, "full"},
+		// 4 blocks requested, staging cap 2 blocks -> window shrinks to 2.
+		{"shrunk", 4, 4 * blockSize, "shrunk"},
+		// 4 blocks requested, staging cap under 2 blocks -> sequential fallback.
+		{"sequential", 4, 3 * blockSize, "sequential"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newBlockPrefetchFixture(t, false, tc.blocks)
+			fixture.service.config.Cache.MaxPopulateMemoryBytes = tc.total
+			fixture.service.populateBudget = newByteBudget(tc.total, 0, fixture.service.perPopulateCap)
+			fixture.service.populateBudget.stagingCap = tc.total / 2
+
+			before := prefetchWindowOutcome(t, tc.outcome)
+			if _, err := fixture.serve(fixture.newWriter()); err != nil {
+				t.Fatalf("serve: %v", err)
+			}
+			if got := prefetchWindowOutcome(t, tc.outcome) - before; got != 1 {
+				t.Fatalf("outcome %q counted %v times, want 1", tc.outcome, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

Chasing the residual p99 tail on the block-serve path hit two observability walls:

1. **Bucket resolution**: `tag_request_duration_seconds` uses `DefBuckets` (… 1 → 2.5 → 5 → 10). Every tail reading in the recent investigation was an interpolation across whole seconds — "p99 ≈ 2.3 s" actually meant "somewhere in the 1–2.5 bucket", "≈9 s" meant "somewhere in 5–10". Impossible to localize the tail or see movement below the bucket span.
2. **Invisible degradation**: when the shared staging budget declines a prefetch window, the serve silently shrinks the window or falls back to sequential streaming (old-path latency), with only a Debug log. The 4→12 GiB ORD budget experiment had to *infer* this mechanism from the shape of the p99 plateau; there was no direct signal.

## What

- `tag_request_duration_seconds` buckets: DefBuckets + **1.5, 2, 3, 4, 7.5**. Additive — existing dashboards/queries keep working with better resolution; cost is 5 extra buckets per operation label.
- New `tag_cache_block_prefetch_windows_total{outcome="full"|"shrunk"|"sequential"}` — one increment per multi-block serve, classifying the granted window. A rising `shrunk`/`sequential` share under load = staging saturation serving the tail from the slow path → alertable, and directly answers whether a budget bump is needed (or working).

Per the flood-safety convention (#150 review): signal via metric, keep the per-request log at Debug.

## Validation

- New `TestBlockCache_PrefetchWindowOutcomeCounter` drives all three outcomes by sizing the staging budget (full grant / forced shrink / full decline), asserting exactly one increment each — passes at `-count=3` under race.
- Full `-race` suites green: proxy, broadcast, metrics. gofmt clean.

## Next

Once deployed, the next warm load run tells us directly what the residual 1–2.5 s p99 is made of (sequential-fallback share vs genuine worst-case work) — turning the adaptive-window / peer-side follow-up decision into an evidence-based one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9ddcac6192f30e9039345316bd1a30b16a2e97e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->