### PR TITLE
docs: sync metrics reference with emitted metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -324,11 +324,20 @@ staging budget (half of `cache.max_populate_memory_bytes`):
 | `shrunk`     | A smaller window than requested was granted                           |
 | `sequential` | Every window size was declined — the serve degraded to the unbuffered sequential path |
 
-A rising `shrunk`/`sequential` share under load means the staging budget is saturating and
-tail latency is being served by the slow path — the signal to raise
-`cache.max_populate_memory_bytes`:
+The two non-`full` outcomes have different costs: `shrunk` serves are still pipelined,
+just with less read concurrency (a mild, roughly proportional latency impact), while
+`sequential` serves alone take the unbuffered slow path (one cache read in flight — the
+pre-pipelining latency profile). Track them separately:
 
 ```promql
+# Sequential fallback share — the true slow-path traffic. Any sustained non-zero
+# rate under load means tail latency is being served by the sequential path:
+# the signal to raise cache.max_populate_memory_bytes.
+sum(rate(tag_cache_block_prefetch_windows_total{outcome="sequential"}[5m])) /
+sum(rate(tag_cache_block_prefetch_windows_total[5m]))
+
+# Budget-pressure share — serves that could not get their full window (shrunk +
+# sequential). A leading indicator: rising pressure precedes sequential fallback.
 sum(rate(tag_cache_block_prefetch_windows_total{outcome!="full"}[5m])) /
 sum(rate(tag_cache_block_prefetch_windows_total[5m]))
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -52,7 +52,7 @@ Request duration in seconds.
 | ----------- | ------------ |
 | `operation` | S3 operation |
 
-**Buckets:** Default Prometheus buckets (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10)
+**Buckets:** 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10 (the default Prometheus buckets plus extra tail resolution at 1.5, 2, 3, 4 and 7.5 seconds)
 
 **Example queries:**
 
@@ -301,6 +301,37 @@ read (e.g. a Parquet footer) populates and serves only the blocks it touches.
 `tag_cache_block_populated_total` counts blocks fetched from upstream and written to cache;
 `tag_cache_block_bytes_populated_total` is the bytes those fetches pulled. Compare the bytes
 against `tag_bytes_transferred_total{direction="out"}` to gauge populate-vs-served amplification.
+
+#### tag_cache_block_populate_failed_total
+
+**Type:** Counter
+
+Blocks that were fetched from upstream and validated but whose cache write failed (either
+the unary byte-write fast path or the streaming fallback). Flood-safe, alertable signal for
+populate-write failures; the per-block error is logged only at Debug. Healthy value is 0 —
+alert on any sustained rate.
+
+#### tag_cache_block_prefetch_windows_total
+
+**Type:** Counter (labeled by `outcome`)
+
+Multi-block serves classified by the prefetch window they were granted from the shared
+staging budget (half of `cache.max_populate_memory_bytes`):
+
+| `outcome`    | Meaning                                                               |
+| ------------ | --------------------------------------------------------------------- |
+| `full`       | The requested window was granted — the fast pipelined path            |
+| `shrunk`     | A smaller window than requested was granted                           |
+| `sequential` | Every window size was declined — the serve degraded to the unbuffered sequential path |
+
+A rising `shrunk`/`sequential` share under load means the staging budget is saturating and
+tail latency is being served by the slow path — the signal to raise
+`cache.max_populate_memory_bytes`:
+
+```promql
+sum(rate(tag_cache_block_prefetch_windows_total{outcome!="full"}[5m])) /
+sum(rate(tag_cache_block_prefetch_windows_total[5m]))
+```
 
 #### tag_cache_block_hits_total / tag_cache_block_misses_total
 


### PR DESCRIPTION
Addresses Greptile's finding on release PR #158 (stale bucket list after #157), plus two more drift gaps found in the same pass:

- **`tag_request_duration_seconds`**: document the expanded bucket list (defaults + 1.5/2/3/4/7.5 s tail resolution).
- **`tag_cache_block_populate_failed_total`** (added in #150): was never documented — now covered with the alert guidance (healthy = 0).
- **`tag_cache_block_prefetch_windows_total`** (added in #157): documents the `full`/`shrunk`/`sequential` outcomes and the degraded-share query that signals staging-budget saturation.

Docs-only; no code changes. Does not block release #158 — the doc catches up on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 49273852a2c940a236a0e45aef994f0f99e4edfe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->