### PR TITLE
ci: repoint apt mirror in all workflows that install system deps

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -99,6 +99,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Use reachable apt mirror
+        # The runner image points apt at azure.archive.ubuntu.com, which is a
+        # single point of failure (and unreliable outside Azure). Repoint to
+        # the main Ubuntu archive before installing packages.
+        run: |
+          sudo grep -rl azure.archive.ubuntu.com /etc/apt/ | xargs -r sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g'
+
       - name: Install system dependencies
         run: make install-deps
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,9 @@ jobs:
       - name: Use reachable apt mirror
         # The runner image points apt at azure.archive.ubuntu.com, which is a
         # single point of failure (and unreliable outside Azure). Repoint to
-        # the main Ubuntu archive before installing packages.
+        # the main Ubuntu archive before installing packages. Linux-only: the
+        # darwin matrix entry has no /etc/apt and installs via Homebrew.
+        if: runner.os == 'Linux'
         run: |
           sudo grep -rl azure.archive.ubuntu.com /etc/apt/ | xargs -r sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Use reachable apt mirror
+        # The runner image points apt at azure.archive.ubuntu.com, which is a
+        # single point of failure (and unreliable outside Azure). Repoint to
+        # the main Ubuntu archive before installing packages.
+        run: |
+          sudo grep -rl azure.archive.ubuntu.com /etc/apt/ | xargs -r sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g'
+
       - name: Install system dependencies
         run: make install-deps
 

--- a/.github/workflows/s3-tests-cluster.yaml
+++ b/.github/workflows/s3-tests-cluster.yaml
@@ -51,6 +51,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Use reachable apt mirror
+        # The runner image points apt at azure.archive.ubuntu.com, which is a
+        # single point of failure (and unreliable outside Azure). Repoint to
+        # the main Ubuntu archive before installing packages.
+        run: |
+          sudo grep -rl azure.archive.ubuntu.com /etc/apt/ | xargs -r sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g'
+
       - name: Install system dependencies
         run: make install-deps
 

--- a/.github/workflows/s3-tests.yaml
+++ b/.github/workflows/s3-tests.yaml
@@ -51,6 +51,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Use reachable apt mirror
+        # The runner image points apt at azure.archive.ubuntu.com, which is a
+        # single point of failure (and unreliable outside Azure). Repoint to
+        # the main Ubuntu archive before installing packages.
+        run: |
+          sudo grep -rl azure.archive.ubuntu.com /etc/apt/ | xargs -r sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g'
+
       - name: Install system dependencies
         run: make install-deps
 


### PR DESCRIPTION
Extends the apt-mirror fix from #160 to every workflow that runs `make install-deps` — `release.yaml` (build-binaries), `benchmark.yaml`, `s3-tests.yaml`, `s3-tests-cluster.yaml`. Without this, the release binary build fails at `apt-get` during an `azure.archive.ubuntu.com` outage even though PR CI passes. Flagged by Cursor Bugbot on #161.

Same one-liner as test.yml: rewrite any azure.archive.ubuntu.com references under /etc/apt/ to archive.ubuntu.com before installing packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a8d66e1e76c4558783c1c35bb61812e29a7dc8d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->