### PR TITLE
ci: allowlist perfloop[bot] in the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -45,7 +45,7 @@ jobs:
           branch: 'main'
           # Exact logins only — a "*[bot]" wildcard becomes a regex where [bot] is
           # a character class, which does not match bot accounts.
-          allowlist: 'dependabot[bot],github-actions[bot]'
+          allowlist: 'dependabot[bot],github-actions[bot],perfloop[bot]'
           custom-notsigned-prcomment: 'Thank you for your contribution! Before we can merge this, please sign our [Contributor License Agreement](https://github.com/tigrisdata/tag/blob/main/docs/CLA.md) by posting the comment below.'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'


### PR DESCRIPTION
The CLA check on release PR #166 fails because the squash commit of #164 is authored by `perfloop[bot]`, which cannot sign a CLA. The action's allowlist accepts exact logins only (a `*[bot]` wildcard is treated as a regex character class, per the existing comment), so add `perfloop[bot]` explicitly — same rationale as the ocache DCO bot exemption (tigrisdata/ocache#222): the reviewing human's merge is the attestation.

After merging, re-trigger the check on #166 by commenting `recheck` on it (the workflow runs on `pull_request_target` from the base branch, so it picks this up immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ff380cfcc6093196ab0253f09ec5ebb29905fce0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->