### PR TITLE
docs: compaction I/O throttling guidance + deploy pin refresh

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.0
+    newTag: v1.17.6

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.17.0
+          image: tigrisdata/tag:v1.17.6
           imagePullPolicy: Always
           env:
             - name: POD_NAME
@@ -59,6 +59,10 @@ spec:
               value: "tag-headless:7000"
             - name: TAG_CACHE_MAX_DISK_USAGE
               value: "429496729600"
+            # On throughput-capped volumes, bound background compaction I/O so it
+            # cannot starve serving reads (see docs/deploy.md). 0/unset = unthrottled.
+            # - name: TAG_CACHE_COMPACTION_BPS
+            #   value: "33554432" # 32 MiB/s
             - name: TAG_LOG_LEVEL
               value: "info"
           ports:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,17 @@ cache:
   # Override with TAG_CACHE_EVICTION_POLICY env var
   eviction_policy: lru
 
+  # Shared source-read budget (bytes/second) for ocache's background file
+  # compaction and segment recompaction. Protects serving reads on
+  # throughput-capped volumes: unthrottled compaction bursts can saturate the
+  # disk and stall foreground GETs. 0/unset = unthrottled (the ocache library
+  # default); size it to a small fraction of the volume's throughput cap
+  # (e.g. 33554432 = 32 MiB/s on a 240 MB/s volume). Populate writes are
+  # never throttled — only compaction's own reads (writes follow implicitly).
+  # Override with TAG_CACHE_COMPACTION_BPS env var (explicit 0 disables a
+  # YAML-set value).
+  compaction_bytes_per_second: 0
+
   # Warm the cache after a successful write (PutObject / CompleteMultipartUpload /
   # CopyObject) by triggering a background full-object fetch, so a read soon after a
   # write hits cache. This is cache-warm-on-write (write-around plus async warming),
@@ -345,6 +356,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |
+| `compaction_bytes_per_second` | int64 | `0`          | Shared source-read budget (bytes/s) for background compaction + recompaction; `0` = unthrottled. Size to a small fraction of the volume's throughput cap |
 | `warm_on_write`         | bool     | `false`          | Warm the cache after a successful write via a background fetch (one extra upstream GET per write) |
 | `warm_on_write_reserved_fraction` | float | `0.5`     | Elastic share of the populate budget reserved for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; `0`/unset = default, negative = disabled) |
 | `node_id`               | string   | `""`             | Unique node identifier for cluster mode                                             |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -132,7 +132,7 @@ Sizing guidance:
 - **Ceiling:** total compaction I/O ≈ 2× the budget (each byte is read then written); keep that well under half the volume cap so serving always has headroom. `32 MiB/s` on a 240 MB/s volume consumes ~27%.
 - **Floor:** the budget must outpace sustained cache churn or raw-file backlog accumulates. One pod at 32 MiB/s drains ~2.7 TB/day.
 - Populate writes (the serving path filling the cache) are **never** throttled — only compaction's own source reads (its writes follow implicitly).
-- The throttle deliberately trades slower backlog drain for stable serving latency; watch `ocache_compaction_bytes_compacted_total` (should plateau at the budget during drain) and serving p95 during post-load consolidation.
+- The throttle deliberately trades slower backlog drain for stable serving latency; watch `rate(ocache_compaction_bytes_compacted_total[5m])` (should plateau near the budget during drain — use a multi-minute window, as the counter advances at batch-commit granularity and short windows read spiky) and serving p95 during post-load consolidation.
 
 ### Health Checks
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.0
+    newTag: v1.17.6
 ```
 
 ## Production Considerations
@@ -114,6 +114,25 @@ Start near your median read size; the `1048576` (1 MiB) default suits typical an
 - **Serve latency** — `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
 
 Cache buffering memory (populate + block-serve staging) is bounded by `TAG_CACHE_MAX_POPULATE_MEMORY` — one honest total (default 2 GiB). See the [Configuration Reference](configuration.md).
+
+### Compaction I/O throttling on throughput-capped volumes
+
+Cloud block volumes are usually throughput-capped (e.g. OCI Balanced at 240 MB/s, gp3 baseline at 125 MB/s). ocache's background compaction (raw-file → segment consolidation and segment recompaction) is unthrottled by default and, after heavy cache population, can burst well past such caps — starving foreground serving reads and causing multi-second p95 stalls until the backlog drains.
+
+On capped volumes, set a shared compaction budget:
+
+```yaml
+env:
+  - name: TAG_CACHE_COMPACTION_BPS
+    value: "33554432" # 32 MiB/s
+```
+
+Sizing guidance:
+
+- **Ceiling:** total compaction I/O ≈ 2× the budget (each byte is read then written); keep that well under half the volume cap so serving always has headroom. `32 MiB/s` on a 240 MB/s volume consumes ~27%.
+- **Floor:** the budget must outpace sustained cache churn or raw-file backlog accumulates. One pod at 32 MiB/s drains ~2.7 TB/day.
+- Populate writes (the serving path filling the cache) are **never** throttled — only compaction's own source reads (its writes follow implicitly).
+- The throttle deliberately trades slower backlog drain for stable serving latency; watch `ocache_compaction_bytes_compacted_total` (should plateau at the budget during drain) and serving p95 during post-load consolidation.
 
 ### Health Checks
 


### PR DESCRIPTION
Documentation follow-up to #165 and the v1.17.6 rollout:

- **configuration.md**: `cache.compaction_bytes_per_second` added to the YAML reference (with sizing/semantics comments) and the config table — the env row landed in #165; this completes the YAML side
- **deploy.md**: new *Compaction I/O throttling on throughput-capped volumes* production consideration — why (unthrottled compaction bursts starve serving on capped volumes), sizing ceiling (~2× budget total I/O, keep under half the cap) and floor (must outpace churn; 32 MiB/s drains ~2.7 TB/day/pod), what to watch. Overlay example pin bumped to v1.17.6
- **deploy/kubernetes/base**: image pins v1.17.0 → v1.17.6 (kustomization + statefulset) and a commented `TAG_CACHE_COMPACTION_BPS` example in the env block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and commented example env vars only; image tag bumps are routine deploy metadata with no runtime logic changes in this PR.
> 
> **Overview**
> Documents **`cache.compaction_bytes_per_second`** / **`TAG_CACHE_COMPACTION_BPS`**: shared source-read budget for ocache background compaction so bursts do not saturate throughput-capped volumes and stall serving GETs. Adds YAML comments and a config-table row in **configuration.md**, plus a new **deploy.md** production section (sizing ceiling/floor, populate vs compaction behavior, metrics to watch).
> 
> Kubernetes base and deploy overlay examples bump the image tag **v1.17.0 → v1.17.6**, and the StatefulSet env block includes a **commented** `TAG_CACHE_COMPACTION_BPS` example (32 MiB/s) pointing at the deploy guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16c716c98b93f993069dd2cdba442f55bece651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->