### PR TITLE
docs: reclaim guidance and v1.17.7 pins

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.6
+    newTag: v1.17.7

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.17.6
+          image: tigrisdata/tag:v1.17.7
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                    | `/var/cache/tag`         |
 | `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
-| `TAG_CACHE_COMPACTION_BPS`        | Shared source-read budget (bytes/second) for ocache background compaction + recompaction; protects serving reads on throughput-capped volumes. `0` disables (also via env override); unset keeps YAML/default; set to a small fraction of the volume cap (e.g. `16777216` = 16 MiB/s on a 240 MB/s volume) | unthrottled              |
+| `TAG_CACHE_COMPACTION_BPS`        | Shared read budget (bytes/second) for ocache background compaction, recompaction, and the liveness walks that gate reclaim; protects serving reads on throughput-capped volumes. `0` disables (also via env override); unset keeps YAML/default; set to a small fraction of the volume cap (e.g. `33554432` = 32 MiB/s on a 240 MB/s volume) | unthrottled              |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
@@ -134,10 +134,10 @@ cache:
   # Override with TAG_CACHE_EVICTION_POLICY env var
   eviction_policy: lru
 
-  # Shared source-read budget (bytes/second) for ocache's background file
-  # compaction and segment recompaction. Protects serving reads on
-  # throughput-capped volumes: unthrottled compaction bursts can saturate the
-  # disk and stall foreground GETs. 0/unset = unthrottled (the ocache library
+  # Shared read budget (bytes/second) for ocache's background file compaction,
+  # segment recompaction, and the liveness walks that gate reclaim. Protects
+  # serving reads on throughput-capped volumes: unthrottled compaction bursts
+  # can saturate the disk and stall foreground GETs. 0/unset = unthrottled (the ocache library
   # default); size it to a small fraction of the volume's throughput cap
   # (e.g. 33554432 = 32 MiB/s on a 240 MB/s volume). Populate writes are
   # never throttled — only compaction's own reads (writes follow implicitly).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.6
+    newTag: v1.17.7
 ```
 
 ## Production Considerations
@@ -132,7 +132,22 @@ Sizing guidance:
 - **Ceiling:** total compaction I/O ≈ 2× the budget (each byte is read then written); keep that well under half the volume cap so serving always has headroom. `32 MiB/s` on a 240 MB/s volume consumes ~27%.
 - **Floor:** the budget must outpace sustained cache churn or raw-file backlog accumulates. One pod at 32 MiB/s drains ~2.7 TB/day.
 - Populate writes (the serving path filling the cache) are **never** throttled — only compaction's own source reads (its writes follow implicitly).
+- The budget also covers the **liveness walks that gate recompaction** (one ~4 KiB page charged per entry examined), so enabling it bounds reclaim's read load too rather than leaving it unaccounted.
 - The throttle deliberately trades slower backlog drain for stable serving latency; watch `rate(ocache_compaction_bytes_compacted_total[5m])` (should plateau near the budget during drain — use a multi-minute window, as the counter advances at batch-commit granularity and short windows read spiky) and serving p95 during post-load consolidation.
+
+### Reclaiming dead space
+
+Objects that are overwritten, deleted, or expired leave dead bytes inside segment files. Those bytes have no metadata pointing at them, so TTL, eviction, and the deletion queue cannot reach them — only segment recompaction frees them, by copying the live entries out and deleting the old segment.
+
+Recompaction decides what to reclaim by **deriving** each cold segment's dead bytes from the segment's own entries checked against metadata ([ocache RFC-009](https://github.com/tigrisdata/ocache/blob/main/docs/rfcs/RFC-009-walk-gated-recompaction.md)), so reclaim does not depend on bookkeeping counters staying perfect. There is nothing to configure; the relevant knobs are ocache defaults (2 h minimum segment age, 0.5 fragmentation threshold).
+
+What to watch:
+
+- `rate(ocache_segment_walks_total[10m])` — segments examined. Should be non-zero on any node with cold segments; flat zero means recompaction is disabled or every segment is younger than the age gate.
+- `increase(ocache_recompaction_segments_total[1h])` and `increase(ocache_recompaction_bytes_freed_total[1h])` — reclaim actually happening.
+- **Physical vs logical divergence is the real health signal**: compare `kubelet_volume_stats_used_bytes` for the cache PVC against `ocache_disk_usage_bytes` (live bytes). A gap that grows and never shrinks means dead space is accumulating faster than it is reclaimed; a gap that stays small means reclaim is keeping up. Expect the gap to spike during heavy population and while a recompaction holds both the old and new segment on disk.
+
+Because segments must pass the age gate first, reclaim begins roughly two hours after a pod restart, not immediately.
 
 ### Health Checks
 


### PR DESCRIPTION
Documentation follow-up to the v1.17.7 / ocache v1.11.0 rollout.

- **New `Reclaiming dead space` section in `docs/deploy.md`** — what dead bytes are, why only recompaction can free them (they have no metadata pointing at them, so TTL/eviction/deletion-queue cannot reach them), and that reclaim is now decided by derived liveness rather than bookkeeping counters. The operationally useful part: **the gap between `kubelet_volume_stats_used_bytes` and `ocache_disk_usage_bytes` is the health signal** — a gap that only grows is precisely the failure that filled the ORD volumes on Aug 17. Also notes reclaim starts ~2 h after a restart because of the segment age gate.
- **`TAG_CACHE_COMPACTION_BPS`** documented as covering liveness walks as well as payload copies (env table, YAML comment, and the deploy sizing guidance), with the example updated to the 32 MiB/s value we actually run on ORD.
- **Pins refreshed to v1.17.7** in `deploy/kubernetes/base/` and the overlay example.

Docs and manifests only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d46a14ea7f8fba1c576dfd463b0a333bd7a78fc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->