### PR TITLE
feat(cache): parquet footer prefetch and prefetch precision metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -199,6 +199,17 @@ type CacheConfig struct {
 	// "lru" (default) or "fifo" (oldest-written first). Only takes effect when
 	// MaxDiskUsageBytes > 0 — with no disk cap nothing is evicted regardless.
 	EvictionPolicy string `yaml:"eviction_policy"`
+	// ParquetOptimization enables format-aware prefetching for objects whose key
+	// ends in ".parquet". A parquet reader always reads the file footer before any
+	// data, and the footer is at the end of the object, so a read that touches the
+	// object's tail is a reliable signal that the whole metadata region is about to
+	// be read. When the metadata spans more than the tail block, TAG fetches the
+	// remaining metadata blocks in the background instead of letting the reader
+	// discover them as serial misses. Off by default: it reads 8 bytes of object
+	// content to size the footer, which is format-specific behavior an operator
+	// should opt into.
+	ParquetOptimization bool `yaml:"parquet_optimization"`
+
 	// CompactionBytesPerSecond bounds the shared source-read budget for ocache's
 	// background file compaction and segment recompaction (bytes/second). It
 	// protects serving reads on throughput-capped volumes: unthrottled
@@ -573,6 +584,10 @@ func applyEnvOverrides(cfg *Config) {
 		// Override startup recovery worker count from environment
 		if workers, ok := envInt("TAG_CACHE_RECOVERY_WORKERS"); ok && workers > 0 {
 			cfg.Cache.RecoveryWorkers = workers
+		}
+		// Enable parquet-aware footer prefetching from environment.
+		if val := strings.ToLower(strings.TrimSpace(os.Getenv("TAG_CACHE_PARQUET_OPTIMIZATION"))); val != "" {
+			cfg.Cache.ParquetOptimization = val == "true" || val == "1"
 		}
 		// Override the compaction source-read budget from environment
 		// (bytes/second). An explicit 0 disables the throttle even when YAML

--- a/config/config.go
+++ b/config/config.go
@@ -203,11 +203,13 @@ type CacheConfig struct {
 	// ends in ".parquet". A parquet reader always reads the file footer before any
 	// data, and the footer is at the end of the object, so a read that touches the
 	// object's tail is a reliable signal that the whole metadata region is about to
-	// be read. When the metadata spans more than the tail block, TAG fetches the
-	// remaining metadata blocks in the background instead of letting the reader
-	// discover them as serial misses. Off by default: it reads 8 bytes of object
-	// content to size the footer, which is format-specific behavior an operator
-	// should opt into.
+	// be read. When the metadata spans more than the (partial) tail block, TAG
+	// fetches the remaining metadata blocks in the background instead of letting the
+	// reader discover them as misses. Measured on production parseable data, footers
+	// run ~1.25% of object size, so a 300 MB object carries ~3.5 MB of metadata --
+	// several blocks at a 1 MiB block_size. Off by default: it reads 8 bytes of
+	// object content to size the footer, which is format-specific behavior an
+	// operator should opt into.
 	ParquetOptimization bool `yaml:"parquet_optimization"`
 
 	// CompactionBytesPerSecond bounds the shared source-read budget for ocache's

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1240,3 +1240,34 @@ func TestCompactionBPS_OverrideByEnv(t *testing.T) {
 		})
 	}
 }
+
+// TestParquetOptimization_OverrideByEnv verifies TAG_CACHE_PARQUET_OPTIMIZATION
+// plumbs the parquet footer prefetch into the cache config. The optimization is
+// speculative work, so an unrecognized value must leave it off rather than
+// guessing the operator meant to enable it.
+func TestParquetOptimization_OverrideByEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml bool // value already set (as if from YAML) before the env override
+		env  string
+		want bool
+	}{
+		{"true enables", false, "true", true},
+		{"one enables", false, "1", true},
+		{"mixed case accepted", false, "True", true},
+		{"whitespace-padded value accepted", false, " true ", true},
+		{"false disables a yaml enable", true, "false", false},
+		{"garbage disables rather than guessing", true, "yes-please", false},
+		{"unset leaves yaml alone", true, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TAG_CACHE_PARQUET_OPTIMIZATION", tc.env)
+			cfg := NewDefault()
+			cfg.Cache.ParquetOptimization = tc.yaml
+			applyEnvOverrides(cfg)
+			if cfg.Cache.ParquetOptimization != tc.want {
+				t.Errorf("Cache.ParquetOptimization = %v, want %v", cfg.Cache.ParquetOptimization, tc.want)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,9 @@ cache:
   # covers metadata that fits in the tail block; this fetches the earlier blocks when it does
   # not, using the length the file itself declares rather than a guess. Costs one speculative
   # fetch per spanned block, shed under populate pressure like any other prefetch. Watch
-  # tag_cache_parquet_footer_bytes to see whether your files need it at all.
+  # tag_cache_parquet_footer_bytes to confirm it still applies to your data:
+  # measured on production parseable data, footers run ~1.25% of object size, so a
+  # 300 MB object carries ~3.5 MB of metadata -- several blocks at a 1 MiB block_size.
   # Override with TAG_CACHE_PARQUET_OPTIMIZATION env var.
   parquet_optimization: false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
 | `TAG_CACHE_BLOCK_SIZE`             | Block granularity **and** the read-side whole-vs-block boundary (bytes): a read miss below this is whole-cached, at/above it is block-cached; must stay below ocache's 64 MB compaction threshold | `1048576` (1 MiB)        |
+| `TAG_CACHE_PARQUET_OPTIMIZATION`   | Prefetch a parquet object's metadata blocks when a read reaches its tail, so a reader opening the file does not discover the rest of the metadata as serial misses. Only fires when the metadata spans more than the tail block (`true`/`1`; any other value leaves it off) | `false`                  |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -179,6 +180,15 @@ cache:
   # below ocache's 64 MB compaction threshold so blocks pack into shared segments. 0/unset =
   # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
   block_size: 1048576
+
+  # Parquet-aware footer prefetching (opt-in). A parquet reader must read the file's metadata
+  # before any data, and that metadata sits at the end of the object. Block caching already
+  # covers metadata that fits in the tail block; this fetches the earlier blocks when it does
+  # not, using the length the file itself declares rather than a guess. Costs one speculative
+  # fetch per spanned block, shed under populate pressure like any other prefetch. Watch
+  # tag_cache_parquet_footer_bytes to see whether your files need it at all.
+  # Override with TAG_CACHE_PARQUET_OPTIMIZATION env var.
+  parquet_optimization: false
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -353,6 +363,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
 | `block_caching_enabled` | bool     | `true`           | Enable block-aligned caching for large objects (RFC 0001)                           |
 | `block_size`            | int64    | `1048576`        | Block granularity **and** the read-side whole-vs-block boundary (must stay below ocache's 64 MB compaction threshold) |
+| `parquet_optimization`  | bool     | `false`          | Prefetch a parquet object's metadata blocks on a tail read (only when the metadata spans more than the tail block) |
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -368,25 +368,26 @@ The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
 **Type:** Histogram
 
 Size of the parquet metadata region, read from the trailer of objects served while
-`cache.parquet_optimization` is on. It is recorded for **every** parquet object whose trailer
-is read, including the ones whose metadata fits the tail block and are therefore not
-prefetched — so the distribution describes the whole population, not just the prefetched tail
-of it.
+`cache.parquet_optimization` is on. Recorded for **every** parquet object whose trailer is
+read, including ones that are not prefetched, so the distribution describes the whole
+population rather than just the prefetched tail of it.
 
-This is the measurement that decides whether the optimization has anything to do: metadata
-smaller than `cache.block_size` is already covered by the tail block that the triggering read
-cached, and prefetching it would fetch nothing. Note the ordering — the metric is only
-recorded while the flag is on, so the flow is to canary-enable on one node, read the
-distribution, and then decide for the fleet. Prefetching during that canary is bounded (capped
-block count, shed under populate pressure), which is what makes enabling-to-measure safe.
+The prefetch does work whenever `footer + 8` exceeds the **remainder** block
+(`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds
+`block_size`.
+
+Measured baseline on production parseable data (26 objects): footers run **~1.25% of object
+size** — 3.0 MB at 244 MB, 4.7 MB at 394 MB — so at a 1 MiB `block_size` the metadata spans
+3–5 blocks and the prefetch fires on ~69% of objects. Only small (<2 MB) files, with 20–50 KB
+footers, fit inside the remainder.
+
+Use the histogram to confirm that ratio still holds for your data: a schema change alters
+footer size, and a distribution that collapses below the remainder-block size means the
+optimization has stopped earning its keep.
 
 ```promql
-# Share of parquet objects whose metadata spans more than one 1 MiB block —
-# the only population the prefetch can help. Near zero means turn it off.
-1 - (
-  sum(rate(tag_cache_parquet_footer_bytes_bucket{le="1.048576e+06"}[1h])) /
-  sum(rate(tag_cache_parquet_footer_bytes_count[1h]))
-)
+# Median footer size — compare against cache.block_size.
+histogram_quantile(0.5, sum(rate(tag_cache_parquet_footer_bytes_bucket[1h])) by (le))
 ```
 
 #### tag_cache_block_hits_total / tag_cache_block_misses_total

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -342,6 +342,45 @@ sum(rate(tag_cache_block_prefetch_windows_total{outcome!="full"}[5m])) /
 sum(rate(tag_cache_block_prefetch_windows_total[5m]))
 ```
 
+#### tag_cache_block_prefetched_total / tag_cache_block_prefetch_used_total
+
+**Type:** Counter (`prefetched` labeled by `trigger`)
+
+Speculative block fetches, and how many of them were later served from cache. Together they
+give prefetch precision — the fraction of speculative work that paid for itself:
+
+```promql
+# Prefetch precision. A low ratio means the speculation is evicting more than it
+# earns: turn the trigger off rather than tuning it.
+sum(rate(tag_cache_block_prefetch_used_total[30m])) /
+sum(rate(tag_cache_block_prefetched_total[30m]))
+```
+
+Attribution counts blocks, not reads: a prefetched block served many times counts once, so
+precision cannot exceed 1. It is also deliberately an undercount — attribution is tracked in a
+bounded, TTL-expiring set, so a block served long after it was prefetched goes unattributed.
+Read the ratio as a floor.
+
+The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
+
+#### tag_cache_parquet_footer_bytes
+
+**Type:** Histogram
+
+Size of the parquet metadata region, read from the trailer of objects served while
+`cache.parquet_optimization` is on. This is the measurement that decides whether the
+optimization is worth running at all: metadata smaller than `cache.block_size` is already
+covered by the tail block that the triggering read cached, and prefetching does nothing.
+
+```promql
+# Share of parquet objects whose metadata spans more than one 1 MiB block —
+# the only population the prefetch can help. Near zero means turn it off.
+1 - (
+  sum(rate(tag_cache_parquet_footer_bytes_bucket{le="1.048576e+06"}[1h])) /
+  sum(rate(tag_cache_parquet_footer_bytes_count[1h]))
+)
+```
+
 #### tag_cache_block_hits_total / tag_cache_block_misses_total
 
 **Type:** Counter

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -368,9 +368,17 @@ The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
 **Type:** Histogram
 
 Size of the parquet metadata region, read from the trailer of objects served while
-`cache.parquet_optimization` is on. This is the measurement that decides whether the
-optimization is worth running at all: metadata smaller than `cache.block_size` is already
-covered by the tail block that the triggering read cached, and prefetching does nothing.
+`cache.parquet_optimization` is on. It is recorded for **every** parquet object whose trailer
+is read, including the ones whose metadata fits the tail block and are therefore not
+prefetched — so the distribution describes the whole population, not just the prefetched tail
+of it.
+
+This is the measurement that decides whether the optimization has anything to do: metadata
+smaller than `cache.block_size` is already covered by the tail block that the triggering read
+cached, and prefetching it would fetch nothing. Note the ordering — the metric is only
+recorded while the flag is on, so the flow is to canary-enable on one node, read the
+distribution, and then decide for the fleet. Prefetching during that canary is bounded (capped
+block count, shed under populate pressure), which is what makes enabling-to-measure safe.
 
 ```promql
 # Share of parquet objects whose metadata spans more than one 1 MiB block —

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -292,6 +292,39 @@ var (
 		[]string{"outcome"},
 	)
 
+	// CacheBlockPrefetched counts blocks fetched speculatively rather than to
+	// satisfy a request in flight. CacheBlockPrefetchUsed counts those that were
+	// later served before eviction. Their ratio is prefetch precision, which is
+	// what decides whether speculation pays for itself: an imprecise prefetcher
+	// spends upstream bandwidth and, under FIFO eviction, displaces blocks that
+	// would have been hit.
+	CacheBlockPrefetched = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tag_cache_block_prefetched_total",
+			Help: "Blocks fetched speculatively, by trigger",
+		},
+		[]string{"trigger"},
+	)
+
+	CacheBlockPrefetchUsed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_cache_block_prefetch_used_total",
+			Help: "Speculatively fetched blocks that were later served from cache",
+		},
+	)
+
+	// CacheParquetFooterBytes records observed parquet metadata sizes. The
+	// distribution answers whether footer prefetching can help at all: metadata
+	// that fits inside the object's tail block is already cached by the read that
+	// triggered this measurement, so only the tail of this distribution matters.
+	CacheParquetFooterBytes = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "tag_cache_parquet_footer_bytes",
+			Help:    "Size of the parquet metadata region, in bytes",
+			Buckets: prometheus.ExponentialBuckets(64*1024, 2, 10),
+		},
+	)
+
 	// CacheBlockHits counts covering blocks already present in cache when serving a request
 	// from block mode; CacheBlockMisses counts covering blocks that had to be fetched.
 	CacheBlockHits = promauto.NewCounter(

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -350,6 +350,7 @@ func (s *Service) serveAssembledRange(
 	// Committed serve: record hit/miss + serve metrics (only here, never on a fall-through),
 	// then write the response.
 	recordBlockServeMetrics(bK-b0+1, int64(len(missing)))
+	s.noteAssembledPrefetchHits(bucket, key, meta, b0, bK, missing)
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
@@ -362,6 +363,10 @@ func (s *Service) serveAssembledRange(
 	}
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	// A parquet reader's trailer probe is a few bytes, so it is served here rather
+	// than by streamBlockRange — this, not the streaming path, is where the footer
+	// signal actually arrives for a reader opening a file.
+	s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, rng.start, rng.end)
 	return true, nil
 }
 

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -366,7 +366,7 @@ func (s *Service) serveAssembledRange(
 	// A parquet reader's trailer probe is a few bytes, so it is served here rather
 	// than by streamBlockRange — this, not the streaming path, is where the footer
 	// signal actually arrives for a reader opening a file.
-	s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, rng.start, rng.end)
+	s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, rng.start, rng.end, buf)
 	return true, nil
 }
 
@@ -437,7 +437,9 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 	if err == nil {
 		// A completed range that reached the object's tail is a parquet reader
 		// opening the file (when the optimization is on and the key says so).
-		s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, start, end)
+		// The streaming path has already handed its bytes to the client, so the
+		// trailer has to come from cache here.
+		s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, start, end, nil)
 		return out, nil
 	}
 	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil && start+cw.written <= end {

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -430,6 +430,9 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 		}
 	}
 	if err == nil {
+		// A completed range that reached the object's tail is a parquet reader
+		// opening the file (when the optimization is on and the key says so).
+		s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, start, end)
 		return out, nil
 	}
 	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil && start+cw.written <= end {
@@ -527,6 +530,7 @@ func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWri
 		}
 		if !br.fetchedIt {
 			out.fromCache++
+			s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 		}
 		_, werr := cw.Write((*br.bufp)[:br.n])
 		putBlockBuf(br.bufp)
@@ -676,6 +680,7 @@ func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWr
 		}
 		if !wasFetched {
 			out.fromCache++
+			s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 		}
 	}
 	return out, nil
@@ -873,6 +878,7 @@ func (s *Service) serveCompleteFromBlocks(
 		out.fetched++
 	} else {
 		out.fromCache++
+		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, 0)
 	}
 	n, werr := w.Write(buf)
 	if n > 0 {

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/binary"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -189,9 +190,26 @@ func (s *Service) notePrefetchHit(bucket, key, etag string, blockSize, idx int64
 	if s.prefetchedBlocks == nil {
 		return
 	}
-	k := cache.MakeBlockKey(bucket, key, etag, blockSize, idx)
-	if _, ok := s.prefetchedBlocks.Get(k); ok {
-		s.prefetchedBlocks.Remove(k)
+	// Remove reports whether the key was present and clears it under one lock, so
+	// two serves racing on the same block cannot both attribute it. A Get-then-
+	// Remove pair would let precision exceed 1.
+	if s.prefetchedBlocks.Remove(cache.MakeBlockKey(bucket, key, etag, blockSize, idx)) {
 		metrics.CacheBlockPrefetchUsed.Inc()
+	}
+}
+
+// noteAssembledPrefetchHits attributes the covering blocks that an assembled serve
+// read straight from cache. missing lists the blocks it had to fetch, which by
+// definition were not prefetch hits. The slice holds at most two entries, so the
+// linear scan is cheaper than building a set.
+func (s *Service) noteAssembledPrefetchHits(bucket, key string, meta *cache.CachedObjectMeta, b0, bK int64, missing []int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	for i := b0; i <= bK; i++ {
+		if slices.Contains(missing, i) {
+			continue
+		}
+		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 	}
 }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -1,0 +1,197 @@
+package proxy
+
+import (
+	"context"
+	"encoding/binary"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// Parquet-aware footer prefetch (opt-in via cache.parquet_optimization).
+//
+// A parquet reader cannot read any data before it reads the file's metadata,
+// and that metadata lives at the END of the object: the last 8 bytes are a
+// 4-byte little-endian metadata length followed by the "PAR1" magic, and the
+// metadata occupies the length bytes immediately before them. So a read that
+// touches an object's tail block is a reliable signal that the reader is
+// opening the file and is about to read the whole metadata region.
+//
+// Block caching already covers the common case: the tail read caches the tail
+// block, so metadata that fits inside it is served from cache. Metadata larger
+// than one block is not — a file with many row groups and columns can carry
+// several MiB of it — and the reader discovers those blocks as serial misses,
+// each costing an upstream round trip before the first row is read.
+//
+// This prefetch closes that gap and nothing else. It fetches only blocks the
+// metadata provably spans, computed from the length the file itself declares,
+// so speculation is bounded by the object rather than by a guess.
+const (
+	parquetMagic = "PAR1"
+
+	// parquetTrailerSize is the 4-byte metadata length plus the 4-byte magic.
+	parquetTrailerSize = 8
+
+	// maxParquetFooterPrefetchBlocks bounds one prefetch. A metadata region
+	// larger than this is pathological (or a corrupt length that passed the
+	// sanity checks), and prefetching it would evict more than it can repay.
+	maxParquetFooterPrefetchBlocks = 32
+)
+
+// isParquetKey reports whether the key names a parquet object. Matching on the
+// suffix keeps the format coupling to exactly one place.
+func isParquetKey(key string) bool {
+	return strings.HasSuffix(strings.ToLower(key), ".parquet")
+}
+
+// maybePrefetchParquetFooter starts a background prefetch of the metadata
+// blocks preceding the object's tail block, when the just-served range touched
+// that tail block. It returns immediately; the fetch runs detached.
+//
+// Callers pass the range that was served, not the range that was requested: a
+// serve that failed before reaching the tail proves nothing about what the
+// reader will do next.
+func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64) {
+	if !s.parquetFooterPrefetchWanted(key, meta, servedStart, servedEnd) {
+		return
+	}
+
+	// Every tail read of a hot object hits this path, so coalesce: one prefetch
+	// per object version at a time. Without this a repeatedly-read object would
+	// spawn a goroutine and a cache read per request to reach the same
+	// already-satisfied conclusion.
+	dedupKey := "pq:" + bucket + "/" + key + "/" + meta.ETag
+	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer s.activeBackgroundFetches.Delete(dedupKey)
+		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta)
+	}()
+}
+
+// parquetFooterPrefetchWanted reports whether a completed serve is the signal
+// this prefetch keys on: the optimization enabled, a parquet key, and a read
+// that covered the object's trailer.
+func (s *Service) parquetFooterPrefetchWanted(key string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64) bool {
+	if s.config == nil || !s.config.Cache.ParquetOptimization {
+		return false
+	}
+	if meta == nil || meta.BlockSize <= 0 || meta.ContentLength <= parquetTrailerSize {
+		return false
+	}
+	if !isParquetKey(key) {
+		return false
+	}
+	// The read must have covered the trailer the metadata length lives in.
+	return servedStart <= meta.ContentLength-parquetTrailerSize && servedEnd >= meta.ContentLength-1
+}
+
+// prefetchParquetFooterBlocks reads the metadata length the object declares,
+// then fetches the metadata blocks that are not already cached.
+func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta) {
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
+
+	footerLen, ok := s.readParquetFooterLength(ctx, bucket, key, meta)
+	if !ok {
+		return
+	}
+	metrics.CacheParquetFooterBytes.Observe(float64(footerLen))
+
+	// The metadata region is the declared length plus the trailer that
+	// describes it; the reader fetches both.
+	metaStart := meta.ContentLength - parquetTrailerSize - footerLen
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	firstBlock := metaStart / meta.BlockSize
+	if firstBlock >= tailBlock {
+		// Metadata fits in the tail block, which the triggering read already
+		// cached. This is the common case and the reason the histogram above
+		// is worth more than the prefetch itself.
+		return
+	}
+	if tailBlock-firstBlock > maxParquetFooterPrefetchBlocks {
+		firstBlock = tailBlock - maxParquetFooterPrefetchBlocks
+		log.Debug().Str("bucket", bucket).Str("key", key).Int64("footer_bytes", footerLen).
+			Msg("Parquet metadata larger than the prefetch bound - prefetching the tail of it")
+	}
+
+	for i := firstBlock; i < tailBlock; i++ {
+		if ctx.Err() != nil {
+			return
+		}
+		if s.cache.BlockExists(ctx, bucket, key, meta.ETag, meta.BlockSize, i) {
+			continue
+		}
+		// fetchOneBlock coalesces against any in-flight fetch of the same block
+		// and acquires the populate budget non-blocking, so a prefetch is shed
+		// rather than queued when the budget is contended by real reads.
+		if err := s.fetchOneBlock(ctx, bucket, key, accessKey, secretKey, meta, i); err != nil {
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Int64("block", i).
+				Msg("Parquet footer prefetch failed")
+			return
+		}
+		metrics.CacheBlockPrefetched.WithLabelValues("parquet_footer").Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, i)
+	}
+}
+
+// readParquetFooterLength reads the object's 8-byte trailer from cache and
+// returns the declared metadata length. It reports false when the trailer is
+// unreadable or does not describe a parquet file, which also covers a key that
+// merely ends in ".parquet".
+func (s *Service) readParquetFooterLength(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta) (int64, bool) {
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	blockStart := tailBlock * meta.BlockSize
+	trailerStart := meta.ContentLength - parquetTrailerSize
+	if trailerStart < blockStart {
+		// A trailer straddling two blocks would need a second read; the object
+		// is degenerate enough that skipping it costs nothing.
+		return 0, false
+	}
+
+	buf := make([]byte, parquetTrailerSize)
+	localStart := trailerStart - blockStart
+	if err := s.readCachedBlockSlice(ctx, bucket, key, meta, tailBlock, localStart, localStart+parquetTrailerSize-1, buf); err != nil {
+		// The triggering read cached this block, so a failure here means it was
+		// evicted or the node lost it: no reason to speculate further.
+		return 0, false
+	}
+	if string(buf[4:]) != parquetMagic {
+		return 0, false
+	}
+
+	footerLen := int64(binary.LittleEndian.Uint32(buf[:4]))
+	if footerLen <= 0 || footerLen > meta.ContentLength-parquetTrailerSize {
+		return 0, false
+	}
+	return footerLen, true
+}
+
+// notePrefetchedBlock records a speculatively fetched block so that a later
+// serve of it can be attributed. The set is bounded and TTL-expiring: an entry
+// that ages out simply stops being attributable, which understates precision
+// rather than overstating it.
+func (s *Service) notePrefetchedBlock(bucket, key, etag string, blockSize, idx int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	s.prefetchedBlocks.Add(cache.MakeBlockKey(bucket, key, etag, blockSize, idx), struct{}{})
+}
+
+// notePrefetchHit attributes a cache hit to an earlier prefetch, once. Removing
+// the entry keeps the ratio a count of blocks rather than of reads, so a block
+// read many times cannot inflate precision.
+func (s *Service) notePrefetchHit(bucket, key, etag string, blockSize, idx int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	k := cache.MakeBlockKey(bucket, key, etag, blockSize, idx)
+	if _, ok := s.prefetchedBlocks.Get(k); ok {
+		s.prefetchedBlocks.Remove(k)
+		metrics.CacheBlockPrefetchUsed.Inc()
+	}
+}

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -21,15 +21,17 @@ import (
 // touches an object's tail block is a reliable signal that the reader is
 // opening the file and is about to read the whole metadata region.
 //
-// Block caching already covers the common case: the tail read caches the tail
-// block, so metadata that fits inside it is served from cache. Metadata larger
-// than one block is not — a file with many row groups and columns can carry
-// several MiB of it — and the reader discovers those blocks as serial misses,
-// each costing an upstream round trip before the first row is read.
+// The triggering read caches only the TAIL block, and that is a partial block:
+// ContentLength mod block_size, averaging half a block. So the prefetch is needed
+// whenever footer+8 exceeds that remainder, not merely when it exceeds block_size.
 //
-// This prefetch closes that gap and nothing else. It fetches only blocks the
-// metadata provably spans, computed from the length the file itself declares,
-// so speculation is bounded by the object rather than by a guess.
+// Measured on the ORD parseable bucket (26 objects, two days): footers run ~1.25%
+// of object size -- 3.0 MB at 244 MB, 4.7 MB at 394 MB -- so against 1 MiB blocks
+// the metadata spans 3-5 blocks and this fires on ~69% of objects. Only the small
+// (<2 MB) files, whose footers are 20-50 KB, fit in the remainder.
+//
+// It fetches only blocks the metadata provably spans, computed from the length the
+// file itself declares, so speculation is bounded by the object, not by a guess.
 const (
 	parquetMagic = "PAR1"
 
@@ -122,9 +124,8 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
 	firstBlock := metaStart / meta.BlockSize
 	if firstBlock >= tailBlock {
-		// Metadata fits in the tail block, which the triggering read already
-		// cached. This is the common case and the reason the histogram above
-		// is worth more than the prefetch itself.
+		// Metadata fits the remainder block the triggering read already cached.
+		// Measured: only the small (<2 MB) objects land here.
 		return
 	}
 	if tailBlock-firstBlock > maxParquetFooterPrefetchBlocks {

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -52,12 +52,25 @@ func isParquetKey(key string) bool {
 // blocks preceding the object's tail block, when the just-served range touched
 // that tail block. It returns immediately; the fetch runs detached.
 //
-// Callers pass the range that was served, not the range that was requested: a
-// serve that failed before reaching the tail proves nothing about what the
-// reader will do next.
-func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64) {
+// Callers pass the range that was SERVED, not the range requested: a serve that
+// failed before reaching the tail proves nothing about what the reader does next.
+//
+// served, when non-nil, is exactly those bytes. It matters on a cold open: the
+// assembled path serves a freshly fetched tail from an in-memory lease while its
+// cache write is still detached, so reading the trailer back from cache would
+// miss and silently skip the prefetch on a reader's FIRST open -- the case this
+// exists for. Callers that no longer hold the bytes pass nil.
+func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64, served []byte) {
 	if !s.parquetFooterPrefetchWanted(key, meta, servedStart, servedEnd) {
 		return
+	}
+
+	// Copy the trailer out before returning: served is a pooled buffer the caller
+	// releases as soon as we return, and the fetch below runs detached.
+	var trailer []byte
+	if int64(len(served)) == servedEnd-servedStart+1 {
+		off := meta.ContentLength - parquetTrailerSize - servedStart
+		trailer = append([]byte(nil), served[off:off+parquetTrailerSize]...)
 	}
 
 	// Every tail read of a hot object hits this path, so coalesce: one prefetch
@@ -70,7 +83,7 @@ func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey s
 	}
 	go func() {
 		defer s.activeBackgroundFetches.Delete(dedupKey)
-		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta)
+		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta, trailer)
 	}()
 }
 
@@ -93,11 +106,11 @@ func (s *Service) parquetFooterPrefetchWanted(key string, meta *cache.CachedObje
 
 // prefetchParquetFooterBlocks reads the metadata length the object declares,
 // then fetches the metadata blocks that are not already cached.
-func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta) {
+func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, trailer []byte) {
 	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
 	defer cancel()
 
-	footerLen, ok := s.readParquetFooterLength(ctx, bucket, key, meta)
+	footerLen, ok := s.parquetFooterLength(ctx, bucket, key, meta, trailer)
 	if !ok {
 		return
 	}
@@ -140,10 +153,31 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 	}
 }
 
-// readParquetFooterLength reads the object's 8-byte trailer from cache and
-// returns the declared metadata length. It reports false when the trailer is
-// unreadable or does not describe a parquet file, which also covers a key that
-// merely ends in ".parquet".
+// parquetFooterLength returns the declared metadata length, preferring a trailer
+// the caller already holds over a cache read that can race a detached write.
+func (s *Service) parquetFooterLength(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, trailer []byte) (int64, bool) {
+	if len(trailer) == parquetTrailerSize {
+		return parseParquetTrailer(trailer, meta.ContentLength)
+	}
+	return s.readParquetFooterLength(ctx, bucket, key, meta)
+}
+
+// parseParquetTrailer validates the 8-byte trailer and returns the metadata
+// length it declares, rejecting anything that cannot describe this object.
+func parseParquetTrailer(buf []byte, contentLength int64) (int64, bool) {
+	if string(buf[4:]) != parquetMagic {
+		return 0, false
+	}
+	footerLen := int64(binary.LittleEndian.Uint32(buf[:4]))
+	if footerLen <= 0 || footerLen > contentLength-parquetTrailerSize {
+		return 0, false
+	}
+	return footerLen, true
+}
+
+// readParquetFooterLength reads the object's 8-byte trailer from cache. It
+// reports false when the trailer is unreadable or does not describe a parquet
+// file, which also covers a key that merely ends in ".parquet".
 func (s *Service) readParquetFooterLength(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta) (int64, bool) {
 	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
 	blockStart := tailBlock * meta.BlockSize
@@ -161,15 +195,7 @@ func (s *Service) readParquetFooterLength(ctx context.Context, bucket, key strin
 		// evicted or the node lost it: no reason to speculate further.
 		return 0, false
 	}
-	if string(buf[4:]) != parquetMagic {
-		return 0, false
-	}
-
-	footerLen := int64(binary.LittleEndian.Uint32(buf[:4]))
-	if footerLen <= 0 || footerLen > meta.ContentLength-parquetTrailerSize {
-		return 0, false
-	}
-	return footerLen, true
+	return parseParquetTrailer(buf, meta.ContentLength)
 }
 
 // notePrefetchedBlock records a speculatively fetched block so that a later

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	cacheclient "github.com/tigrisdata/ocache/client"
 	"github.com/tigrisdata/tag/cache"
@@ -158,6 +160,7 @@ type parquetFooterForwarder struct {
 
 	mu     sync.Mutex
 	ranges []string
+	served chan struct{}
 }
 
 func (f *parquetFooterForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
@@ -168,6 +171,9 @@ func (f *parquetFooterForwarder) DoConditionalGetRequest(_ context.Context, _, _
 	f.mu.Lock()
 	f.ranges = append(f.ranges, rangeHeader)
 	f.mu.Unlock()
+	if f.served != nil {
+		f.served <- struct{}{}
+	}
 
 	header := make(http.Header)
 	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(f.body)))
@@ -276,6 +282,70 @@ func TestMaybePrefetchParquetFooter_CoalescesConcurrentTriggers(t *testing.T) {
 	// A coalesced trigger must leave the in-flight marker for its owner to clear.
 	if _, ok := s.activeBackgroundFetches.Load(dedupKey); !ok {
 		t.Fatal("coalesced trigger deleted the in-flight marker owned by another prefetch")
+	}
+}
+
+// Regression test for the wiring, not the mechanism. A parquet reader's trailer
+// probe is a few bytes, so it is served by the assembled-range path and never
+// reaches streamBlockRange. Triggering the prefetch only from the streaming path
+// meant the signal that matters most never fired in production shapes.
+func TestServeRangeFromBlockCache_TrailerProbeTriggersFooterPrefetch(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	metaStart := int64(3500) // inside block 3, so blocks 3 and 4 must be prefetched
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	served := make(chan struct{}, blocks)
+	fwd := &parquetFooterForwarder{body: body, etag: etag, served: served}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+	tail := int64(blocks - 1)
+	if err := store.PutBlock(context.Background(), bucket, key, etag, blockSize, tail, body[tail*blockSize:], 3600); err != nil {
+		t.Fatalf("seeding tail block: %v", err)
+	}
+
+	// The read a parquet reader actually issues first: the 8-byte trailer.
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", contentLength-parquetTrailerSize, contentLength-1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
+	req.Header.Set("Range", rangeHeader)
+
+	ok, err := s.serveRangeFromBlockCache(context.Background(), rec, req, bucket, key, "access", "secret", meta, rangeHeader, time.Now())
+	if err != nil || !ok {
+		t.Fatalf("serveRangeFromBlockCache(trailer) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+
+	// The prefetch is detached; wait for the two blocks it must fetch.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-served:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("trailer probe did not trigger the footer prefetch (ranges so far: %v)", fwd.requestedRanges())
+		}
+	}
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("prefetched ranges = %v, want %v", got, want)
 	}
 }
 

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -232,7 +232,7 @@ func TestPrefetchParquetFooterBlocks_FetchesTheSpannedBlocks(t *testing.T) {
 		t.Fatalf("seeding tail block: %v", err)
 	}
 
-	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta)
+	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta, nil)
 
 	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
 	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
@@ -258,7 +258,7 @@ func TestPrefetchParquetFooterBlocks_NoFetchWhenFooterFitsTailBlock(t *testing.T
 	s.forwarder = fwd
 
 	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
-	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta)
+	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta, nil)
 
 	if got := fwd.requestedRanges(); len(got) != 0 {
 		t.Fatalf("prefetched %v for metadata that fits the tail block", got)
@@ -277,7 +277,7 @@ func TestMaybePrefetchParquetFooter_CoalescesConcurrentTriggers(t *testing.T) {
 	dedupKey := "pq:b/a.parquet/" + meta.ETag
 	s.activeBackgroundFetches.Store(dedupKey, struct{}{})
 
-	s.maybePrefetchParquetFooter("b", "a.parquet", "access", "secret", meta, contentLength-parquetTrailerSize, contentLength-1)
+	s.maybePrefetchParquetFooter("b", "a.parquet", "access", "secret", meta, contentLength-parquetTrailerSize, contentLength-1, nil)
 
 	// A coalesced trigger must leave the in-flight marker for its owner to clear.
 	if _, ok := s.activeBackgroundFetches.Load(dedupKey); !ok {
@@ -346,6 +346,70 @@ func TestServeRangeFromBlockCache_TrailerProbeTriggersFooterPrefetch(t *testing.
 	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
 	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
 		t.Fatalf("prefetched ranges = %v, want %v", got, want)
+	}
+}
+
+// Regression test for the cold-open race. The assembled serve path returns a
+// freshly fetched tail block from an in-memory lease while its cache write is
+// still detached, so the trailer is NOT yet readable from cache when the
+// prefetch fires. Reading it back from cache would skip the prefetch on a
+// reader's first open, which is precisely what this feature targets -- and it
+// would also bias tag_cache_parquet_footer_bytes toward warm re-opens only.
+func TestPrefetchParquetFooterBlocks_UsesServedTrailerWhenTailNotYetCached(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	metaStart := int64(3500)
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: body, etag: etag}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+
+	// Deliberately seed NOTHING: this is the cold open, with the tail block's
+	// cache write still in flight.
+	trailer := body[contentLength-parquetTrailerSize:]
+	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta, trailer)
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("prefetched ranges = %v, want %v (served trailer was ignored)", got, want)
+	}
+}
+
+// Without the served bytes and without a cached tail, there is nothing to read
+// the length from, so the prefetch must skip rather than guess.
+func TestPrefetchParquetFooterBlocks_SkipsWhenTrailerUnavailable(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: content, etag: `"v1"`}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta, nil)
+
+	if got := fwd.requestedRanges(); len(got) != 0 {
+		t.Fatalf("prefetched %v with no readable trailer", got)
 	}
 }
 

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -1,0 +1,301 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"sync"
+	"testing"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// parquetTailBlock builds an object tail that a parquet reader would recognise:
+// footerLen bytes of metadata, then the 4-byte length, then the magic.
+func parquetTailBlock(t *testing.T, blockSize, footerLen int64) (content []byte, contentLength int64) {
+	t.Helper()
+	// One full block of padding before the metadata region keeps the trailer
+	// inside the tail block while forcing the metadata to start earlier.
+	contentLength = blockSize + footerLen + parquetTrailerSize
+	content = make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(content[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(content[contentLength-4:], parquetMagic)
+	return content, contentLength
+}
+
+func TestIsParquetKey(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want bool
+	}{
+		{"metrics/date=2026-08-19/hour=01/minute=40/ingestor.data.01M0.parquet", true},
+		{"UPPER.PARQUET", true},
+		{"manifest.json", false},
+		{"parquet", false},
+		{"a.parquet.tmp", false},
+	} {
+		if got := isParquetKey(tc.key); got != tc.want {
+			t.Errorf("isParquetKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// The trigger must fire only for a completed read that reached the object's
+// trailer, and only when the optimization is enabled. Everything else is a
+// read that tells us nothing about a reader opening the file.
+func TestMaybePrefetchParquetFooter_TriggerConditions(t *testing.T) {
+	const blockSize = 1024
+	meta := &cache.CachedObjectMeta{
+		ETag:          `"v1"`,
+		BlockSize:     blockSize,
+		ContentLength: 4096,
+	}
+	tail := meta.ContentLength - 1
+	trailer := meta.ContentLength - parquetTrailerSize
+
+	for _, tc := range []struct {
+		name        string
+		enabled     bool
+		key         string
+		start, end  int64
+		wantTrigger bool
+	}{
+		{"tail read on parquet fires", true, "a.parquet", trailer, tail, true},
+		{"whole object read fires", true, "a.parquet", 0, tail, true},
+		{"disabled does not fire", false, "a.parquet", trailer, tail, false},
+		{"non-parquet key does not fire", true, "a.json", trailer, tail, false},
+		{"read short of the trailer does not fire", true, "a.parquet", 0, trailer - 1, false},
+		{"read stopping before the last byte does not fire", true, "a.parquet", trailer, tail - 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewDefault()
+			cfg.Cache.ParquetOptimization = tc.enabled
+			s := &Service{config: cfg}
+
+			// With no cache wired, a fired trigger panics in the goroutine it
+			// starts, so assert on the decision itself rather than the effect.
+			got := s.parquetFooterPrefetchWanted(tc.key, meta, tc.start, tc.end)
+			if got != tc.wantTrigger {
+				t.Errorf("trigger = %v, want %v", got, tc.wantTrigger)
+			}
+		})
+	}
+}
+
+// The declared metadata length is read from the object's own trailer. A value
+// that is not a parquet trailer, or that cannot describe this object, must be
+// rejected rather than turned into a prefetch range.
+func TestReadParquetFooterLength(t *testing.T) {
+	const blockSize = 1024
+
+	t.Run("reads the declared length", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		got, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta)
+		if !ok || got != 300 {
+			t.Fatalf("footer length = %d (ok=%v), want 300", got, ok)
+		}
+	})
+
+	t.Run("rejects a missing magic", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		copy(content[contentLength-4:], "XXXX")
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		if _, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta); ok {
+			t.Fatal("accepted an object whose trailer is not a parquet trailer")
+		}
+	})
+
+	t.Run("rejects a length larger than the object", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		binary.LittleEndian.PutUint32(content[contentLength-parquetTrailerSize:], uint32(contentLength))
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		if _, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta); ok {
+			t.Fatal("accepted a metadata length that cannot fit in the object")
+		}
+	})
+}
+
+// Precision accounting must count blocks, not reads: a prefetched block served
+// repeatedly is one useful prefetch, not many.
+func TestPrefetchAttribution_CountsEachBlockOnce(t *testing.T) {
+	s := NewService(nil, nil, config.NewDefault())
+	const blockSize = 1024
+
+	s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, 7)
+	key := cache.MakeBlockKey("b", "a.parquet", `"v1"`, blockSize, 7)
+	if _, ok := s.prefetchedBlocks.Get(key); !ok {
+		t.Fatal("prefetched block was not recorded")
+	}
+
+	s.notePrefetchHit("b", "a.parquet", `"v1"`, blockSize, 7)
+	if _, ok := s.prefetchedBlocks.Get(key); ok {
+		t.Fatal("attribution left the block recorded, so a re-read would count twice")
+	}
+	// A second hit on the same block must be a no-op rather than a panic or a
+	// second attribution.
+	s.notePrefetchHit("b", "a.parquet", `"v1"`, blockSize, 7)
+}
+
+// parquetFooterForwarder serves ranged reads out of a full object body and
+// records what was asked for, which is what the prefetch is judged on.
+type parquetFooterForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+
+	mu     sync.Mutex
+	ranges []string
+}
+
+func (f *parquetFooterForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
+	var start, end int64
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+		return nil, fmt.Errorf("unparsable range %q: %w", rangeHeader, err)
+	}
+	f.mu.Lock()
+	f.ranges = append(f.ranges, rangeHeader)
+	f.mu.Unlock()
+
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(f.body)))
+	header.Set("ETag", f.etag)
+	chunk := f.body[start : end+1]
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: int64(len(chunk)),
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(chunk)),
+	}, nil
+}
+
+func (f *parquetFooterForwarder) requestedRanges() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.ranges)
+}
+
+// The whole point of the optimization: metadata that spans more blocks than the
+// tail must pull exactly the blocks it spans — no more, and not the tail block
+// the triggering read already cached.
+func TestPrefetchParquetFooterBlocks_FetchesTheSpannedBlocks(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	// Place the metadata start inside block 3, so blocks 3 and 4 must be
+	// prefetched and block 5 (the tail) must not.
+	metaStart := int64(3500)
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: body, etag: etag}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+	// Seed only the tail block, as the triggering read would have.
+	tail := int64(blocks - 1)
+	if err := store.PutBlock(context.Background(), bucket, key, etag, blockSize, tail, body[tail*blockSize:], 3600); err != nil {
+		t.Fatalf("seeding tail block: %v", err)
+	}
+
+	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta)
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("upstream ranges = %v, want %v", got, want)
+	}
+	for _, idx := range []int64{3, 4} {
+		if !store.BlockExists(context.Background(), bucket, key, etag, blockSize, idx) {
+			t.Errorf("block %d was not cached by the prefetch", idx)
+		}
+		if _, ok := s.prefetchedBlocks.Get(cache.MakeBlockKey(bucket, key, etag, blockSize, idx)); !ok {
+			t.Errorf("block %d was not recorded for attribution", idx)
+		}
+	}
+}
+
+// Metadata that fits inside the tail block is already cached by the read that
+// triggered the prefetch, so speculating further would be pure waste.
+func TestPrefetchParquetFooterBlocks_NoFetchWhenFooterFitsTailBlock(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	s := newParquetTestService(t, content, blockSize)
+	fwd := &parquetFooterForwarder{body: content, etag: `"v1"`}
+	s.forwarder = fwd
+
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta)
+
+	if got := fwd.requestedRanges(); len(got) != 0 {
+		t.Fatalf("prefetched %v for metadata that fits the tail block", got)
+	}
+}
+
+// A hot object is tail-read repeatedly. Each such read must not start its own
+// prefetch goroutine while one is already running for that object version.
+func TestMaybePrefetchParquetFooter_CoalescesConcurrentTriggers(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	s := newParquetTestService(t, content, blockSize)
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+	// Stand in for a prefetch already running for this object version.
+	dedupKey := "pq:b/a.parquet/" + meta.ETag
+	s.activeBackgroundFetches.Store(dedupKey, struct{}{})
+
+	s.maybePrefetchParquetFooter("b", "a.parquet", "access", "secret", meta, contentLength-parquetTrailerSize, contentLength-1)
+
+	// A coalesced trigger must leave the in-flight marker for its owner to clear.
+	if _, ok := s.activeBackgroundFetches.Load(dedupKey); !ok {
+		t.Fatal("coalesced trigger deleted the in-flight marker owned by another prefetch")
+	}
+}
+
+// newParquetTestService wires a Service whose cache serves the given object
+// content at block granularity, which is all the footer reader needs.
+func newParquetTestService(t *testing.T, content []byte, blockSize int64) *Service {
+	t.Helper()
+	cfg := config.NewDefault()
+	c := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	s := NewService(nil, c, cfg)
+	s.config.Cache.ParquetOptimization = true
+
+	contentLength := int64(len(content))
+	blocks := (contentLength + blockSize - 1) / blockSize
+	for i := int64(0); i < blocks; i++ {
+		start := i * blockSize
+		end := min(start+blockSize, contentLength)
+		if err := c.PutBlock(context.Background(), "b", "a.parquet", `"v1"`, blockSize, i, content[start:end], 3600); err != nil {
+			t.Fatalf("seeding block %d: %v", i, err)
+		}
+	}
+	return s
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/config"
@@ -72,6 +73,10 @@ type Service struct {
 	activeBackgroundFetches sync.Map                    // Dedup for background full-object fetches (range caching)
 	blockFetchMu            sync.Mutex                  // Guards blockFetches
 	blockFetches            map[string]*blockFetchState // Coalesce block fetches while a detached remote write is pending
+	// prefetchedBlocks remembers recently prefetched block keys so a later serve
+	// of one can be attributed, giving prefetch precision. Bounded and
+	// TTL-expiring: this is measurement, and must not become a memory term.
+	prefetchedBlocks *expirable.LRU[string, struct{}]
 }
 
 // NewService creates a new proxy service.
@@ -147,6 +152,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		perPopulateCap:   perPopulateCap,
 		broadcastManager: broadcast.NewManager(channelBuf),
 		blockFetches:     make(map[string]*blockFetchState),
+		prefetchedBlocks: expirable.NewLRU[string, struct{}](maxPrefetchedBlockTracking, nil, prefetchTrackingTTL),
 	}
 }
 
@@ -192,6 +198,18 @@ func (s *Service) populateWeight(contentLength int64) int64 {
 	return w
 }
 
+const (
+	// maxPrefetchedBlockTracking bounds the prefetch attribution set. Sized well
+	// above the blocks one node prefetches within the TTL, so precision is not
+	// understated by eviction from this set.
+	maxPrefetchedBlockTracking = 65536
+
+	// prefetchTrackingTTL is how long a prefetched block stays attributable. A
+	// prefetch that is not used within this window was not useful in the sense
+	// that motivates prefetching — hiding latency from the read that follows it.
+	prefetchTrackingTTL = 30 * time.Minute
+)
+
 // stagingWeight is the byte weight a block-serve staging buffer reserves against the
 // serve-staging budget: the buffer's ACTUAL size, clamped only by the total budget (so a
 // buffer larger than the whole budget still serves one-at-a-time, mirroring populateWeight).
@@ -214,6 +232,7 @@ func (s *Service) stagingWeight(n int64) int64 {
 // budget. warmWrite populates (cache-warm-on-write, which pre-cache data about to
 // be read) get a reserved, prioritized slice of the budget so the read-miss
 // full-object warm flood can't starve them; readMiss populates use the rest.
+
 type populatePriority int
 
 const (


### PR DESCRIPTION
Tier 1 of the block-prefetching work: when a read reaches a parquet object's tail, fetch the metadata blocks the reader is about to need.

A parquet reader can't read data before it reads the file's metadata, and that metadata sits at the **end** of the object (4-byte LE length + `PAR1` magic in the last 8 bytes). So a read that reaches the trailer is a reliable signal the reader is opening the file.

## This is not a marginal case — measured on production

The triggering read caches only the **tail block**, and that's a *partial* block: `ContentLength mod block_size`, averaging half a block. So the prefetch does work whenever `footer + 8` exceeds that remainder — a lower bar than "footer exceeds `block_size`".

I sampled 26 objects from a production bucket across two days, reading each trailer directly:

| Object size | Footer | Blocks metadata spans (1 MiB) |
| --- | --- | --- |
| 394 MB | **4.69 MB** | ~5 |
| 342 MB | **4.31 MB** | ~5 |
| 269 MB | **3.53 MB** | ~4 |
| 244 MB | **3.01 MB** | ~3 |
| 133 MB | 1.62 MB | ~2 |
| 0.2–1.9 MB | 19–52 KB | 0 (fits) |

Footers are a consistent **~1.25% of object size** — the schema is 76 KB wide, with per-row-group column statistics on top. **The prefetch fires on 18 of 26 objects.** The exceptions are the small sub-2 MB files.

So on a large object today, a reader's first open finds 3–5 metadata blocks absent.

## How it's bounded

- Fires only on a **completed** serve that covered the trailer.
- Triggered from **both** serve paths. A trailer probe is a few bytes, so it lands in `serveAssembledRange`, not `streamBlockRange` — wiring only the latter meant it never fired (caught in review, 99d9b2a).
- The footer length comes from the **bytes just served**, not a cache read: the assembled path returns a freshly fetched tail from an in-memory lease while its cache write is still detached, so re-reading it would miss on exactly the cold open this targets (caught in review, 9632b4a).
- Range computed from the length the file declares, validated against object size. Bad magic or an impossible length → no prefetch.
- Capped at 32 blocks; skips blocks already cached.
- Coalesced per `bucket/key/etag`, so a hot object spawns one goroutine, not one per request.
- Uses `fetchOneBlock`, so it takes the populate budget **non-blocking** and is shed rather than queued under contention.

Off by default (`cache.parquet_optimization` / `TAG_CACHE_PARQUET_OPTIMIZATION`): it reads 8 bytes of object content, which is format-specific behaviour an operator should opt into.

## Metrics

| Metric | Purpose |
| --- | --- |
| `tag_cache_parquet_footer_bytes` | Footer-size distribution, recorded for every parquet object whose trailer is read — including non-prefetched ones, so it's unbiased. Now has a known baseline (~1.25% of object size) to detect **drift** against if the schema changes. |
| `tag_cache_block_prefetched_total` / `_prefetch_used_total` | Prefetch precision. Reusable by future triggers via the `trigger` label. |

Attribution counts **blocks, not reads**, clears atomically (concurrent serves can't double-count), and expires — so the ratio is a **floor**, never an inflated claim.

## Scope

The workload's objects are minute-sharded, so widening a query time range crosses into *different* objects rather than reading further within one. Same-object readahead (Tier 2) and cross-object prefetch (Tier 3) are deliberately out; Tier 3 would need LIST plumbing that doesn't exist. Block hit ratio is already 98.4%, so the footer is where a same-object optimization has a provable mechanism.

## Testing

`proxy/block_cache_parquet_test.go`: trigger conditions, trailer parsing (valid / bad magic / impossible length), coalescing, single-count attribution, plus three end-to-end tests — correct block range prefetched; a real trailer probe through `serveRangeFromBlockCache`; and a **cold open with nothing seeded**, asserting the served trailer is used when the tail isn't cached yet.

Both regression tests were verified to **fail without their fix** rather than assumed to pass — the first reported no upstream ranges at all, the second an empty range list.

`TestParquetOptimization_OverrideByEnv` per the repo's env-override convention, including that an unrecognized value leaves this speculative feature **off**.

`make test` green across all packages; `make lint` clean; `-race` clean.

## Rollout

Ship disabled, enable on one ORD node, and watch `prefetch_used / prefetched` alongside block-miss rate on first opens. The footer-size question that would normally gate this is already answered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

