### PR TITLE
Release

### DIFF
--- a/auth/signer.go
+++ b/auth/signer.go
@@ -233,29 +233,48 @@ func (s *RequestSigner) buildCanonicalRequest(req *http.Request, bodyHash string
 }
 
 // buildCanonicalQueryString builds the canonical query string from URL parameters.
-func (s *RequestSigner) buildCanonicalQueryString(query url.Values) string {
+func (*RequestSigner) buildCanonicalQueryString(query url.Values) string {
+	return canonicalQueryString(query)
+}
+
+// canonicalQueryString builds sorted key=value pairs using AWS SigV4 encoding.
+func canonicalQueryString(query url.Values) string {
 	if len(query) == 0 {
 		return ""
 	}
 
-	// Get sorted keys
 	keys := make([]string, 0, len(query))
-	for k := range query {
-		keys = append(keys, k)
+	for key := range query {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
-	// Build sorted key=value pairs using AWS SigV4 encoding
-	pairs := make([]string, 0, len(query))
-	for _, k := range keys {
-		values := query[k]
+	// Every byte can become a three-byte escape, plus the pair separators.
+	size := 0
+	for _, key := range keys {
+		values := query[key]
 		sort.Strings(values)
-		for _, v := range values {
-			pairs = append(pairs, awsURIEncode(k, true)+"="+awsURIEncode(v, true))
+		for _, value := range values {
+			size += 3*len(key) + 3*len(value) + 2
 		}
 	}
 
-	return strings.Join(pairs, "&")
+	var result strings.Builder
+	result.Grow(size)
+	pairs := 0
+	for _, key := range keys {
+		for _, value := range query[key] {
+			if pairs > 0 {
+				result.WriteByte('&')
+			}
+			writeAWSURIEncoded(&result, key, true)
+			result.WriteByte('=')
+			writeAWSURIEncoded(&result, value, true)
+			pairs++
+		}
+	}
+
+	return result.String()
 }
 
 // buildCanonicalHeaders builds canonical headers and signed headers string.
@@ -373,15 +392,24 @@ func hashSHA256(data []byte) string {
 func awsURIEncode(s string, encodeSlash bool) string {
 	var result strings.Builder
 	result.Grow(len(s) * 3) // Worst case: all chars need encoding
-	for _, c := range []byte(s) {
-		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-			(c >= '0' && c <= '9') || c == '_' || c == '-' || c == '~' || c == '.' {
-			result.WriteByte(c)
-		} else if c == '/' && !encodeSlash {
-			result.WriteByte(c)
-		} else {
-			result.WriteString(fmt.Sprintf("%%%02X", c))
-		}
-	}
+	writeAWSURIEncoded(&result, s, encodeSlash)
 	return result.String()
+}
+
+const awsURIHex = "0123456789ABCDEF"
+
+func writeAWSURIEncoded(result *strings.Builder, s string, encodeSlash bool) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || c == '_' || c == '-' || c == '~' || c == '.' ||
+			(c == '/' && !encodeSlash) {
+			result.WriteByte(c)
+			continue
+		}
+
+		result.WriteByte('%')
+		result.WriteByte(awsURIHex[c>>4])
+		result.WriteByte(awsURIHex[c&0x0F])
+	}
 }

--- a/auth/signer_benchmark_test.go
+++ b/auth/signer_benchmark_test.go
@@ -17,6 +17,19 @@ func newSignerBenchmark() *RequestSigner {
 	return NewRequestSigner("https://upstream.example.com", "us-east-1")
 }
 
+func BenchmarkRequestValidatorBuildCanonicalQueryStringReservedBytes(b *testing.B) {
+	validator := NewRequestValidator(NewCredentialStore())
+	query := newReservedCanonicalQueryValues()
+	if got := validator.buildCanonicalQueryString(newReservedCanonicalQueryValues()); got != reservedCanonicalQueryString {
+		b.Fatalf("buildCanonicalQueryString() = %q, want %q", got, reservedCanonicalQueryString)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		validator.buildCanonicalQueryString(query)
+	}
+}
+
 func BenchmarkRequestSignerSignRequest(b *testing.B) {
 	signer := newSignerBenchmark()
 	ctx := context.Background()

--- a/auth/signer_test.go
+++ b/auth/signer_test.go
@@ -6,9 +6,19 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 )
+
+func newReservedCanonicalQueryValues() url.Values {
+	return url.Values{
+		"prefix/with space": {"one/two", "a b", "100%"},
+		"x+y":               {"日本", ""},
+	}
+}
+
+const reservedCanonicalQueryString = "prefix%2Fwith%20space=100%25&prefix%2Fwith%20space=a%20b&prefix%2Fwith%20space=one%2Ftwo&x%2By=&x%2By=%E6%97%A5%E6%9C%AC"
 
 func TestRequestSigner_SignRequest(t *testing.T) {
 	signer := NewRequestSigner("https://s3.amazonaws.com", "us-east-1")
@@ -174,6 +184,27 @@ func TestBuildCanonicalQueryString(t *testing.T) {
 
 			if result != tt.expected {
 				t.Errorf("buildCanonicalQueryString() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCanonicalQueryStringReservedBytes(t *testing.T) {
+	signer := NewRequestSigner("https://s3.amazonaws.com", "us-east-1")
+	validator := NewRequestValidator(NewCredentialStore())
+
+	tests := []struct {
+		name  string
+		build func(url.Values) string
+	}{
+		{name: "signer", build: signer.buildCanonicalQueryString},
+		{name: "validator", build: validator.buildCanonicalQueryString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.build(newReservedCanonicalQueryValues()); got != reservedCanonicalQueryString {
+				t.Errorf("buildCanonicalQueryString() = %q, want %q", got, reservedCanonicalQueryString)
 			}
 		})
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -266,29 +265,8 @@ func (v *RequestValidator) buildCanonicalRequestPresigned(r *http.Request, signe
 }
 
 // buildCanonicalQueryString builds the canonical query string.
-func (v *RequestValidator) buildCanonicalQueryString(query url.Values) string {
-	if len(query) == 0 {
-		return ""
-	}
-
-	// Get sorted keys
-	keys := make([]string, 0, len(query))
-	for k := range query {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	// Build sorted key=value pairs using AWS SigV4 encoding
-	pairs := make([]string, 0, len(query))
-	for _, k := range keys {
-		values := query[k]
-		sort.Strings(values)
-		for _, val := range values {
-			pairs = append(pairs, awsURIEncode(k, true)+"="+awsURIEncode(val, true))
-		}
-	}
-
-	return strings.Join(pairs, "&")
+func (*RequestValidator) buildCanonicalQueryString(query url.Values) string {
+	return canonicalQueryString(query)
 }
 
 // buildCanonicalHeadersFromList builds canonical headers from a list of header names.

--- a/config/config.go
+++ b/config/config.go
@@ -199,6 +199,19 @@ type CacheConfig struct {
 	// "lru" (default) or "fifo" (oldest-written first). Only takes effect when
 	// MaxDiskUsageBytes > 0 — with no disk cap nothing is evicted regardless.
 	EvictionPolicy string `yaml:"eviction_policy"`
+	// ParquetOptimization enables format-aware prefetching for objects whose key
+	// ends in ".parquet". A parquet reader always reads the file footer before any
+	// data, and the footer is at the end of the object, so a read that touches the
+	// object's tail is a reliable signal that the whole metadata region is about to
+	// be read. When the metadata spans more than the (partial) tail block, TAG
+	// fetches the remaining metadata blocks in the background instead of letting the
+	// reader discover them as misses. Measured on production parseable data, footers
+	// run ~1.25% of object size, so a 300 MB object carries ~3.5 MB of metadata --
+	// several blocks at a 1 MiB block_size. Off by default: it reads 8 bytes of
+	// object content to size the footer, which is format-specific behavior an
+	// operator should opt into.
+	ParquetOptimization bool `yaml:"parquet_optimization"`
+
 	// CompactionBytesPerSecond bounds the shared source-read budget for ocache's
 	// background file compaction and segment recompaction (bytes/second). It
 	// protects serving reads on throughput-capped volumes: unthrottled
@@ -573,6 +586,10 @@ func applyEnvOverrides(cfg *Config) {
 		// Override startup recovery worker count from environment
 		if workers, ok := envInt("TAG_CACHE_RECOVERY_WORKERS"); ok && workers > 0 {
 			cfg.Cache.RecoveryWorkers = workers
+		}
+		// Enable parquet-aware footer prefetching from environment.
+		if val := strings.ToLower(strings.TrimSpace(os.Getenv("TAG_CACHE_PARQUET_OPTIMIZATION"))); val != "" {
+			cfg.Cache.ParquetOptimization = val == "true" || val == "1"
 		}
 		// Override the compaction source-read budget from environment
 		// (bytes/second). An explicit 0 disables the throttle even when YAML

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1240,3 +1240,34 @@ func TestCompactionBPS_OverrideByEnv(t *testing.T) {
 		})
 	}
 }
+
+// TestParquetOptimization_OverrideByEnv verifies TAG_CACHE_PARQUET_OPTIMIZATION
+// plumbs the parquet footer prefetch into the cache config. The optimization is
+// speculative work, so an unrecognized value must leave it off rather than
+// guessing the operator meant to enable it.
+func TestParquetOptimization_OverrideByEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml bool // value already set (as if from YAML) before the env override
+		env  string
+		want bool
+	}{
+		{"true enables", false, "true", true},
+		{"one enables", false, "1", true},
+		{"mixed case accepted", false, "True", true},
+		{"whitespace-padded value accepted", false, " true ", true},
+		{"false disables a yaml enable", true, "false", false},
+		{"garbage disables rather than guessing", true, "yes-please", false},
+		{"unset leaves yaml alone", true, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TAG_CACHE_PARQUET_OPTIMIZATION", tc.env)
+			cfg := NewDefault()
+			cfg.Cache.ParquetOptimization = tc.yaml
+			applyEnvOverrides(cfg)
+			if cfg.Cache.ParquetOptimization != tc.want {
+				t.Errorf("Cache.ParquetOptimization = %v, want %v", cfg.Cache.ParquetOptimization, tc.want)
+			}
+		})
+	}
+}

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -14,4 +14,4 @@ labels:
 
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.6
+    newTag: v1.17.7

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: tag
-          image: tigrisdata/tag:v1.17.6
+          image: tigrisdata/tag:v1.17.7
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                    | `/var/cache/tag`         |
 | `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
 | `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)  | `lru`                    |
-| `TAG_CACHE_COMPACTION_BPS`        | Shared source-read budget (bytes/second) for ocache background compaction + recompaction; protects serving reads on throughput-capped volumes. `0` disables (also via env override); unset keeps YAML/default; set to a small fraction of the volume cap (e.g. `16777216` = 16 MiB/s on a 240 MB/s volume) | unthrottled              |
+| `TAG_CACHE_COMPACTION_BPS`        | Shared read budget (bytes/second) for ocache background compaction, recompaction, and the liveness walks that gate reclaim; protects serving reads on throughput-capped volumes. `0` disables (also via env override); unset keeps YAML/default; set to a small fraction of the volume cap (e.g. `33554432` = 32 MiB/s on a 240 MB/s volume) | unthrottled              |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)  | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
@@ -134,10 +134,10 @@ cache:
   # Override with TAG_CACHE_EVICTION_POLICY env var
   eviction_policy: lru
 
-  # Shared source-read budget (bytes/second) for ocache's background file
-  # compaction and segment recompaction. Protects serving reads on
-  # throughput-capped volumes: unthrottled compaction bursts can saturate the
-  # disk and stall foreground GETs. 0/unset = unthrottled (the ocache library
+  # Shared read budget (bytes/second) for ocache's background file compaction,
+  # segment recompaction, and the liveness walks that gate reclaim. Protects
+  # serving reads on throughput-capped volumes: unthrottled compaction bursts
+  # can saturate the disk and stall foreground GETs. 0/unset = unthrottled (the ocache library
   # default); size it to a small fraction of the volume's throughput cap
   # (e.g. 33554432 = 32 MiB/s on a 240 MB/s volume). Populate writes are
   # never throttled — only compaction's own reads (writes follow implicitly).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
 | `TAG_CACHE_BLOCK_SIZE`             | Block granularity **and** the read-side whole-vs-block boundary (bytes): a read miss below this is whole-cached, at/above it is block-cached; must stay below ocache's 64 MB compaction threshold | `1048576` (1 MiB)        |
+| `TAG_CACHE_PARQUET_OPTIMIZATION`   | Prefetch a parquet object's metadata blocks when a read reaches its tail, so a reader opening the file does not discover the rest of the metadata as serial misses. Only fires when the metadata spans more than the tail block (`true`/`1`; any other value leaves it off) | `false`                  |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
 | `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
@@ -179,6 +180,17 @@ cache:
   # below ocache's 64 MB compaction threshold so blocks pack into shared segments. 0/unset =
   # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
   block_size: 1048576
+
+  # Parquet-aware footer prefetching (opt-in). A parquet reader must read the file's metadata
+  # before any data, and that metadata sits at the end of the object. Block caching already
+  # covers metadata that fits in the tail block; this fetches the earlier blocks when it does
+  # not, using the length the file itself declares rather than a guess. Costs one speculative
+  # fetch per spanned block, shed under populate pressure like any other prefetch. Watch
+  # tag_cache_parquet_footer_bytes to confirm it still applies to your data:
+  # measured on production parseable data, footers run ~1.25% of object size, so a
+  # 300 MB object carries ~3.5 MB of metadata -- several blocks at a 1 MiB block_size.
+  # Override with TAG_CACHE_PARQUET_OPTIMIZATION env var.
+  parquet_optimization: false
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments
@@ -353,6 +365,7 @@ Controls the embedded cache behavior. TAG uses an embedded OCache instance with 
 | `size_threshold`        | int64    | `1073741824`     | Max object size to cache (bytes)                                                    |
 | `block_caching_enabled` | bool     | `true`           | Enable block-aligned caching for large objects (RFC 0001)                           |
 | `block_size`            | int64    | `1048576`        | Block granularity **and** the read-side whole-vs-block boundary (must stay below ocache's 64 MB compaction threshold) |
+| `parquet_optimization`  | bool     | `false`          | Prefetch a parquet object's metadata blocks on a tail read (only when the metadata spans more than the tail block) |
 | `disk_path`             | string   | `/var/cache/tag` | Path to cache data directory                                                        |
 | `max_disk_usage_bytes`  | int64    | `0`              | Max disk usage (0 = unlimited)                                                      |
 | `eviction_policy`       | string   | `lru`            | Eviction order when the disk cap is hit: `lru` or `fifo` (only applies when `max_disk_usage_bytes` > 0) |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,7 +69,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.17.6
+    newTag: v1.17.7
 ```
 
 ## Production Considerations
@@ -132,7 +132,22 @@ Sizing guidance:
 - **Ceiling:** total compaction I/O ≈ 2× the budget (each byte is read then written); keep that well under half the volume cap so serving always has headroom. `32 MiB/s` on a 240 MB/s volume consumes ~27%.
 - **Floor:** the budget must outpace sustained cache churn or raw-file backlog accumulates. One pod at 32 MiB/s drains ~2.7 TB/day.
 - Populate writes (the serving path filling the cache) are **never** throttled — only compaction's own source reads (its writes follow implicitly).
+- The budget also covers the **liveness walks that gate recompaction** (one ~4 KiB page charged per entry examined), so enabling it bounds reclaim's read load too rather than leaving it unaccounted.
 - The throttle deliberately trades slower backlog drain for stable serving latency; watch `rate(ocache_compaction_bytes_compacted_total[5m])` (should plateau near the budget during drain — use a multi-minute window, as the counter advances at batch-commit granularity and short windows read spiky) and serving p95 during post-load consolidation.
+
+### Reclaiming dead space
+
+Objects that are overwritten, deleted, or expired leave dead bytes inside segment files. Those bytes have no metadata pointing at them, so TTL, eviction, and the deletion queue cannot reach them — only segment recompaction frees them, by copying the live entries out and deleting the old segment.
+
+Recompaction decides what to reclaim by **deriving** each cold segment's dead bytes from the segment's own entries checked against metadata ([ocache RFC-009](https://github.com/tigrisdata/ocache/blob/main/docs/rfcs/RFC-009-walk-gated-recompaction.md)), so reclaim does not depend on bookkeeping counters staying perfect. There is nothing to configure; the relevant knobs are ocache defaults (2 h minimum segment age, 0.5 fragmentation threshold).
+
+What to watch:
+
+- `rate(ocache_segment_walks_total[10m])` — segments examined. Should be non-zero on any node with cold segments; flat zero means recompaction is disabled or every segment is younger than the age gate.
+- `increase(ocache_recompaction_segments_total[1h])` and `increase(ocache_recompaction_bytes_freed_total[1h])` — reclaim actually happening.
+- **Physical vs logical divergence is the real health signal**: compare `kubelet_volume_stats_used_bytes` for the cache PVC against `ocache_disk_usage_bytes` (live bytes). A gap that grows and never shrinks means dead space is accumulating faster than it is reclaimed; a gap that stays small means reclaim is keeping up. Expect the gap to spike during heavy population and while a recompaction holds both the old and new segment on disk.
+
+Because segments must pass the age gate first, reclaim begins roughly two hours after a pod restart, not immediately.
 
 ### Health Checks
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -342,6 +342,54 @@ sum(rate(tag_cache_block_prefetch_windows_total{outcome!="full"}[5m])) /
 sum(rate(tag_cache_block_prefetch_windows_total[5m]))
 ```
 
+#### tag_cache_block_prefetched_total / tag_cache_block_prefetch_used_total
+
+**Type:** Counter (`prefetched` labeled by `trigger`)
+
+Speculative block fetches, and how many of them were later served from cache. Together they
+give prefetch precision — the fraction of speculative work that paid for itself:
+
+```promql
+# Prefetch precision. A low ratio means the speculation is evicting more than it
+# earns: turn the trigger off rather than tuning it.
+sum(rate(tag_cache_block_prefetch_used_total[30m])) /
+sum(rate(tag_cache_block_prefetched_total[30m]))
+```
+
+Attribution counts blocks, not reads: a prefetched block served many times counts once, so
+precision cannot exceed 1. It is also deliberately an undercount — attribution is tracked in a
+bounded, TTL-expiring set, so a block served long after it was prefetched goes unattributed.
+Read the ratio as a floor.
+
+The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
+
+#### tag_cache_parquet_footer_bytes
+
+**Type:** Histogram
+
+Size of the parquet metadata region, read from the trailer of objects served while
+`cache.parquet_optimization` is on. Recorded for **every** parquet object whose trailer is
+read, including ones that are not prefetched, so the distribution describes the whole
+population rather than just the prefetched tail of it.
+
+The prefetch does work whenever `footer + 8` exceeds the **remainder** block
+(`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds
+`block_size`.
+
+Measured baseline on production parseable data (26 objects): footers run **~1.25% of object
+size** — 3.0 MB at 244 MB, 4.7 MB at 394 MB — so at a 1 MiB `block_size` the metadata spans
+3–5 blocks and the prefetch fires on ~69% of objects. Only small (<2 MB) files, with 20–50 KB
+footers, fit inside the remainder.
+
+Use the histogram to confirm that ratio still holds for your data: a schema change alters
+footer size, and a distribution that collapses below the remainder-block size means the
+optimization has stopped earning its keep.
+
+```promql
+# Median footer size — compare against cache.block_size.
+histogram_quantile(0.5, sum(rate(tag_cache_parquet_footer_bytes_bucket[1h])) by (le))
+```
+
 #### tag_cache_block_hits_total / tag_cache_block_misses_total
 
 **Type:** Counter

--- a/handlers/transparent_put_benchmark_test.go
+++ b/handlers/transparent_put_benchmark_test.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/auth"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/proxy"
+)
+
+const (
+	transparentPutBenchmarkBucket = "benchmark-bucket"
+	transparentPutBenchmarkKey    = "transparent-put-object"
+	transparentPutBenchmarkETag   = `"transparent-put-etag"`
+)
+
+var (
+	transparentPutBenchmarkBody     = bytes.Repeat([]byte("transparent-put-body-"), 256)
+	transparentPutBenchmarkResponse = []byte("transparent-put-response")
+)
+
+// transparentPutBenchmarkFixture sends authenticated PUTs through the public
+// handler route and transparent forwarder to a real HTTP upstream. The upstream
+// checks the forwarded body and returns ordinary response metadata, so each
+// benchmark operation consumes the same response a client would receive.
+type transparentPutBenchmarkFixture struct {
+	gateway          *httptest.Server
+	client           *http.Client
+	upstreamRequests atomic.Int64
+}
+
+func newTransparentPutBenchmarkFixture(tb testing.TB) *transparentPutBenchmarkFixture {
+	tb.Helper()
+
+	fixture := &transparentPutBenchmarkFixture{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fixture.upstreamRequests.Add(1)
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "missing client authorization", http.StatusUnauthorized)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil || !bytes.Equal(body, transparentPutBenchmarkBody) {
+			http.Error(w, "unexpected request body", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("ETag", transparentPutBenchmarkETag)
+		w.Header().Set("X-Amz-Request-Id", "benchmark-request")
+		w.Header().Set("X-Upstream-Metadata", "benchmark-metadata")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(transparentPutBenchmarkResponse)
+	}))
+	tb.Cleanup(upstream.Close)
+
+	cfg := config.NewDefault()
+	cfg.Upstream.Endpoint = upstream.URL
+	cacheStore := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	forwarder := proxy.NewForwarder(
+		nil,
+		cfg.Upstream.Endpoint,
+		cfg.Upstream.Region,
+		cfg.Upstream.MaxIdleConnsPerHost,
+		auth.NewProxySigner("benchmark-proxy-access", "benchmark-proxy-secret"),
+		nil,
+	)
+	service := proxy.NewService(forwarder, cacheStore, cfg)
+	fixture.gateway = httptest.NewServer(NewServer(service, "127.0.0.1", 0, false, cfg.Server.MaxInflightRequests).Router())
+	tb.Cleanup(fixture.gateway.Close)
+
+	fixture.client = &http.Client{Transport: &http.Transport{
+		MaxIdleConns:        16,
+		MaxIdleConnsPerHost: 16,
+	}}
+	tb.Cleanup(fixture.client.CloseIdleConnections)
+	return fixture
+}
+
+func (f *transparentPutBenchmarkFixture) put() error {
+	req, err := http.NewRequest(
+		http.MethodPut,
+		f.gateway.URL+"/"+transparentPutBenchmarkBucket+"/"+transparentPutBenchmarkKey,
+		bytes.NewReader(transparentPutBenchmarkBody),
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=benchmark/20260101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=deadbeef")
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return err
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return readErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("ETag") != transparentPutBenchmarkETag || !bytes.Equal(body, transparentPutBenchmarkResponse) {
+		return &transparentPutBenchmarkResponseError{status: resp.StatusCode, etag: resp.Header.Get("ETag"), body: body}
+	}
+	return nil
+}
+
+type transparentPutBenchmarkResponseError struct {
+	status int
+	etag   string
+	body   []byte
+}
+
+func (e *transparentPutBenchmarkResponseError) Error() string {
+	return fmt.Sprintf("transparent PUT response = (status=%d, etag=%q, body=%q)", e.status, e.etag, e.body)
+}
+
+// BenchmarkTransparentPutObject measures concurrent authenticated PUTs through
+// handlers.Server, proxy.Service.HandlePutObject, and the transparent forwarder
+// with the default enabled-cache configuration. The warm request establishes both
+// HTTP connection pools before the timed normal PUT load.
+func BenchmarkTransparentPutObject(b *testing.B) {
+	oldLogger := log.Logger
+	log.Logger = log.Logger.Level(zerolog.WarnLevel)
+	b.Cleanup(func() { log.Logger = oldLogger })
+
+	fixture := newTransparentPutBenchmarkFixture(b)
+	if err := fixture.put(); err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetParallelism(1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := fixture.put(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.StopTimer()
+
+	if got, want := fixture.upstreamRequests.Load(), int64(b.N+1); got != want {
+		b.Fatalf("upstream PUTs = %d, want %d", got, want)
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -292,6 +292,39 @@ var (
 		[]string{"outcome"},
 	)
 
+	// CacheBlockPrefetched counts blocks fetched speculatively rather than to
+	// satisfy a request in flight. CacheBlockPrefetchUsed counts those that were
+	// later served before eviction. Their ratio is prefetch precision, which is
+	// what decides whether speculation pays for itself: an imprecise prefetcher
+	// spends upstream bandwidth and, under FIFO eviction, displaces blocks that
+	// would have been hit.
+	CacheBlockPrefetched = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tag_cache_block_prefetched_total",
+			Help: "Blocks fetched speculatively, by trigger",
+		},
+		[]string{"trigger"},
+	)
+
+	CacheBlockPrefetchUsed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tag_cache_block_prefetch_used_total",
+			Help: "Speculatively fetched blocks that were later served from cache",
+		},
+	)
+
+	// CacheParquetFooterBytes records observed parquet metadata sizes. The
+	// distribution answers whether footer prefetching can help at all: metadata
+	// that fits inside the object's tail block is already cached by the read that
+	// triggered this measurement, so only the tail of this distribution matters.
+	CacheParquetFooterBytes = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "tag_cache_parquet_footer_bytes",
+			Help:    "Size of the parquet metadata region, in bytes",
+			Buckets: prometheus.ExponentialBuckets(64*1024, 2, 10),
+		},
+	)
+
 	// CacheBlockHits counts covering blocks already present in cache when serving a request
 	// from block mode; CacheBlockMisses counts covering blocks that had to be fetched.
 	CacheBlockHits = promauto.NewCounter(

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -350,6 +350,7 @@ func (s *Service) serveAssembledRange(
 	// Committed serve: record hit/miss + serve metrics (only here, never on a fall-through),
 	// then write the response.
 	recordBlockServeMetrics(bK-b0+1, int64(len(missing)))
+	s.noteAssembledPrefetchHits(bucket, key, meta, b0, bK, missing)
 	meta.WriteHeaders(w, cache.WithRangeHeaders(rng.start, rng.end, meta.ContentLength))
 	writeCacheStatus(w, XCacheHit)
 	w.WriteHeader(http.StatusPartialContent)
@@ -362,6 +363,10 @@ func (s *Service) serveAssembledRange(
 	}
 	metrics.RecordRangeFromCacheHit()
 	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	// A parquet reader's trailer probe is a few bytes, so it is served here rather
+	// than by streamBlockRange — this, not the streaming path, is where the footer
+	// signal actually arrives for a reader opening a file.
+	s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, rng.start, rng.end, buf)
 	return true, nil
 }
 
@@ -430,6 +435,11 @@ func (s *Service) streamBlockRange(ctx context.Context, w http.ResponseWriter, b
 		}
 	}
 	if err == nil {
+		// A completed range that reached the object's tail is a parquet reader
+		// opening the file (when the optimization is on and the key says so).
+		// The streaming path has already handed its bytes to the client, so the
+		// trailer has to come from cache here.
+		s.maybePrefetchParquetFooter(bucket, key, accessKey, secretKey, meta, start, end, nil)
 		return out, nil
 	}
 	if errors.Is(err, errBlockStreamDegraded) && ctx.Err() == nil && start+cw.written <= end {
@@ -527,6 +537,7 @@ func (s *Service) streamBlockRangePipelined(ctx context.Context, cw *countingWri
 		}
 		if !br.fetchedIt {
 			out.fromCache++
+			s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 		}
 		_, werr := cw.Write((*br.bufp)[:br.n])
 		putBlockBuf(br.bufp)
@@ -676,6 +687,7 @@ func (s *Service) streamBlockRangeSequential(ctx context.Context, cw *countingWr
 		}
 		if !wasFetched {
 			out.fromCache++
+			s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 		}
 	}
 	return out, nil
@@ -873,6 +885,7 @@ func (s *Service) serveCompleteFromBlocks(
 		out.fetched++
 	} else {
 		out.fromCache++
+		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, 0)
 	}
 	n, werr := w.Write(buf)
 	if n > 0 {

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -1,0 +1,242 @@
+package proxy
+
+import (
+	"context"
+	"encoding/binary"
+	"slices"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// Parquet-aware footer prefetch (opt-in via cache.parquet_optimization).
+//
+// A parquet reader cannot read any data before it reads the file's metadata,
+// and that metadata lives at the END of the object: the last 8 bytes are a
+// 4-byte little-endian metadata length followed by the "PAR1" magic, and the
+// metadata occupies the length bytes immediately before them. So a read that
+// touches an object's tail block is a reliable signal that the reader is
+// opening the file and is about to read the whole metadata region.
+//
+// The triggering read caches only the TAIL block, and that is a partial block:
+// ContentLength mod block_size, averaging half a block. So the prefetch is needed
+// whenever footer+8 exceeds that remainder, not merely when it exceeds block_size.
+//
+// Measured on the ORD parseable bucket (26 objects, two days): footers run ~1.25%
+// of object size -- 3.0 MB at 244 MB, 4.7 MB at 394 MB -- so against 1 MiB blocks
+// the metadata spans 3-5 blocks and this fires on ~69% of objects. Only the small
+// (<2 MB) files, whose footers are 20-50 KB, fit in the remainder.
+//
+// It fetches only blocks the metadata provably spans, computed from the length the
+// file itself declares, so speculation is bounded by the object, not by a guess.
+const (
+	parquetMagic = "PAR1"
+
+	// parquetTrailerSize is the 4-byte metadata length plus the 4-byte magic.
+	parquetTrailerSize = 8
+
+	// maxParquetFooterPrefetchBlocks bounds one prefetch. A metadata region
+	// larger than this is pathological (or a corrupt length that passed the
+	// sanity checks), and prefetching it would evict more than it can repay.
+	maxParquetFooterPrefetchBlocks = 32
+)
+
+// isParquetKey reports whether the key names a parquet object. Matching on the
+// suffix keeps the format coupling to exactly one place.
+func isParquetKey(key string) bool {
+	return strings.HasSuffix(strings.ToLower(key), ".parquet")
+}
+
+// maybePrefetchParquetFooter starts a background prefetch of the metadata
+// blocks preceding the object's tail block, when the just-served range touched
+// that tail block. It returns immediately; the fetch runs detached.
+//
+// Callers pass the range that was SERVED, not the range requested: a serve that
+// failed before reaching the tail proves nothing about what the reader does next.
+//
+// served, when non-nil, is exactly those bytes. It matters on a cold open: the
+// assembled path serves a freshly fetched tail from an in-memory lease while its
+// cache write is still detached, so reading the trailer back from cache would
+// miss and silently skip the prefetch on a reader's FIRST open -- the case this
+// exists for. Callers that no longer hold the bytes pass nil.
+func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64, served []byte) {
+	if !s.parquetFooterPrefetchWanted(key, meta, servedStart, servedEnd) {
+		return
+	}
+
+	// Copy the trailer out before returning: served is a pooled buffer the caller
+	// releases as soon as we return, and the fetch below runs detached.
+	var trailer []byte
+	if int64(len(served)) == servedEnd-servedStart+1 {
+		off := meta.ContentLength - parquetTrailerSize - servedStart
+		trailer = append([]byte(nil), served[off:off+parquetTrailerSize]...)
+	}
+
+	// Every tail read of a hot object hits this path, so coalesce: one prefetch
+	// per object version at a time. Without this a repeatedly-read object would
+	// spawn a goroutine and a cache read per request to reach the same
+	// already-satisfied conclusion.
+	dedupKey := "pq:" + bucket + "/" + key + "/" + meta.ETag
+	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer s.activeBackgroundFetches.Delete(dedupKey)
+		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta, trailer)
+	}()
+}
+
+// parquetFooterPrefetchWanted reports whether a completed serve is the signal
+// this prefetch keys on: the optimization enabled, a parquet key, and a read
+// that covered the object's trailer.
+func (s *Service) parquetFooterPrefetchWanted(key string, meta *cache.CachedObjectMeta, servedStart, servedEnd int64) bool {
+	if s.config == nil || !s.config.Cache.ParquetOptimization {
+		return false
+	}
+	if meta == nil || meta.BlockSize <= 0 || meta.ContentLength <= parquetTrailerSize {
+		return false
+	}
+	if !isParquetKey(key) {
+		return false
+	}
+	// The read must have covered the trailer the metadata length lives in.
+	return servedStart <= meta.ContentLength-parquetTrailerSize && servedEnd >= meta.ContentLength-1
+}
+
+// prefetchParquetFooterBlocks reads the metadata length the object declares,
+// then fetches the metadata blocks that are not already cached.
+func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, trailer []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
+
+	footerLen, ok := s.parquetFooterLength(ctx, bucket, key, meta, trailer)
+	if !ok {
+		return
+	}
+	metrics.CacheParquetFooterBytes.Observe(float64(footerLen))
+
+	// The metadata region is the declared length plus the trailer that
+	// describes it; the reader fetches both.
+	metaStart := meta.ContentLength - parquetTrailerSize - footerLen
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	firstBlock := metaStart / meta.BlockSize
+	if firstBlock >= tailBlock {
+		// Metadata fits the remainder block the triggering read already cached.
+		// Measured: only the small (<2 MB) objects land here.
+		return
+	}
+	if tailBlock-firstBlock > maxParquetFooterPrefetchBlocks {
+		firstBlock = tailBlock - maxParquetFooterPrefetchBlocks
+		log.Debug().Str("bucket", bucket).Str("key", key).Int64("footer_bytes", footerLen).
+			Msg("Parquet metadata larger than the prefetch bound - prefetching the tail of it")
+	}
+
+	for i := firstBlock; i < tailBlock; i++ {
+		if ctx.Err() != nil {
+			return
+		}
+		if s.cache.BlockExists(ctx, bucket, key, meta.ETag, meta.BlockSize, i) {
+			continue
+		}
+		// fetchOneBlock coalesces against any in-flight fetch of the same block
+		// and acquires the populate budget non-blocking, so a prefetch is shed
+		// rather than queued when the budget is contended by real reads.
+		if err := s.fetchOneBlock(ctx, bucket, key, accessKey, secretKey, meta, i); err != nil {
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Int64("block", i).
+				Msg("Parquet footer prefetch failed")
+			return
+		}
+		metrics.CacheBlockPrefetched.WithLabelValues("parquet_footer").Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, i)
+	}
+}
+
+// parquetFooterLength returns the declared metadata length, preferring a trailer
+// the caller already holds over a cache read that can race a detached write.
+func (s *Service) parquetFooterLength(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, trailer []byte) (int64, bool) {
+	if len(trailer) == parquetTrailerSize {
+		return parseParquetTrailer(trailer, meta.ContentLength)
+	}
+	return s.readParquetFooterLength(ctx, bucket, key, meta)
+}
+
+// parseParquetTrailer validates the 8-byte trailer and returns the metadata
+// length it declares, rejecting anything that cannot describe this object.
+func parseParquetTrailer(buf []byte, contentLength int64) (int64, bool) {
+	if string(buf[4:]) != parquetMagic {
+		return 0, false
+	}
+	footerLen := int64(binary.LittleEndian.Uint32(buf[:4]))
+	if footerLen <= 0 || footerLen > contentLength-parquetTrailerSize {
+		return 0, false
+	}
+	return footerLen, true
+}
+
+// readParquetFooterLength reads the object's 8-byte trailer from cache. It
+// reports false when the trailer is unreadable or does not describe a parquet
+// file, which also covers a key that merely ends in ".parquet".
+func (s *Service) readParquetFooterLength(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta) (int64, bool) {
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	blockStart := tailBlock * meta.BlockSize
+	trailerStart := meta.ContentLength - parquetTrailerSize
+	if trailerStart < blockStart {
+		// A trailer straddling two blocks would need a second read; the object
+		// is degenerate enough that skipping it costs nothing.
+		return 0, false
+	}
+
+	buf := make([]byte, parquetTrailerSize)
+	localStart := trailerStart - blockStart
+	if err := s.readCachedBlockSlice(ctx, bucket, key, meta, tailBlock, localStart, localStart+parquetTrailerSize-1, buf); err != nil {
+		// The triggering read cached this block, so a failure here means it was
+		// evicted or the node lost it: no reason to speculate further.
+		return 0, false
+	}
+	return parseParquetTrailer(buf, meta.ContentLength)
+}
+
+// notePrefetchedBlock records a speculatively fetched block so that a later
+// serve of it can be attributed. The set is bounded and TTL-expiring: an entry
+// that ages out simply stops being attributable, which understates precision
+// rather than overstating it.
+func (s *Service) notePrefetchedBlock(bucket, key, etag string, blockSize, idx int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	s.prefetchedBlocks.Add(cache.MakeBlockKey(bucket, key, etag, blockSize, idx), struct{}{})
+}
+
+// notePrefetchHit attributes a cache hit to an earlier prefetch, once. Removing
+// the entry keeps the ratio a count of blocks rather than of reads, so a block
+// read many times cannot inflate precision.
+func (s *Service) notePrefetchHit(bucket, key, etag string, blockSize, idx int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	// Remove reports whether the key was present and clears it under one lock, so
+	// two serves racing on the same block cannot both attribute it. A Get-then-
+	// Remove pair would let precision exceed 1.
+	if s.prefetchedBlocks.Remove(cache.MakeBlockKey(bucket, key, etag, blockSize, idx)) {
+		metrics.CacheBlockPrefetchUsed.Inc()
+	}
+}
+
+// noteAssembledPrefetchHits attributes the covering blocks that an assembled serve
+// read straight from cache. missing lists the blocks it had to fetch, which by
+// definition were not prefetch hits. The slice holds at most two entries, so the
+// linear scan is cheaper than building a set.
+func (s *Service) noteAssembledPrefetchHits(bucket, key string, meta *cache.CachedObjectMeta, b0, bK int64, missing []int64) {
+	if s.prefetchedBlocks == nil {
+		return
+	}
+	for i := b0; i <= bK; i++ {
+		if slices.Contains(missing, i) {
+			continue
+		}
+		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
+	}
+}

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -1,0 +1,435 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// parquetTailBlock builds an object tail that a parquet reader would recognise:
+// footerLen bytes of metadata, then the 4-byte length, then the magic.
+func parquetTailBlock(t *testing.T, blockSize, footerLen int64) (content []byte, contentLength int64) {
+	t.Helper()
+	// One full block of padding before the metadata region keeps the trailer
+	// inside the tail block while forcing the metadata to start earlier.
+	contentLength = blockSize + footerLen + parquetTrailerSize
+	content = make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(content[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(content[contentLength-4:], parquetMagic)
+	return content, contentLength
+}
+
+func TestIsParquetKey(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want bool
+	}{
+		{"metrics/date=2026-08-19/hour=01/minute=40/ingestor.data.01M0.parquet", true},
+		{"UPPER.PARQUET", true},
+		{"manifest.json", false},
+		{"parquet", false},
+		{"a.parquet.tmp", false},
+	} {
+		if got := isParquetKey(tc.key); got != tc.want {
+			t.Errorf("isParquetKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// The trigger must fire only for a completed read that reached the object's
+// trailer, and only when the optimization is enabled. Everything else is a
+// read that tells us nothing about a reader opening the file.
+func TestMaybePrefetchParquetFooter_TriggerConditions(t *testing.T) {
+	const blockSize = 1024
+	meta := &cache.CachedObjectMeta{
+		ETag:          `"v1"`,
+		BlockSize:     blockSize,
+		ContentLength: 4096,
+	}
+	tail := meta.ContentLength - 1
+	trailer := meta.ContentLength - parquetTrailerSize
+
+	for _, tc := range []struct {
+		name        string
+		enabled     bool
+		key         string
+		start, end  int64
+		wantTrigger bool
+	}{
+		{"tail read on parquet fires", true, "a.parquet", trailer, tail, true},
+		{"whole object read fires", true, "a.parquet", 0, tail, true},
+		{"disabled does not fire", false, "a.parquet", trailer, tail, false},
+		{"non-parquet key does not fire", true, "a.json", trailer, tail, false},
+		{"read short of the trailer does not fire", true, "a.parquet", 0, trailer - 1, false},
+		{"read stopping before the last byte does not fire", true, "a.parquet", trailer, tail - 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewDefault()
+			cfg.Cache.ParquetOptimization = tc.enabled
+			s := &Service{config: cfg}
+
+			// With no cache wired, a fired trigger panics in the goroutine it
+			// starts, so assert on the decision itself rather than the effect.
+			got := s.parquetFooterPrefetchWanted(tc.key, meta, tc.start, tc.end)
+			if got != tc.wantTrigger {
+				t.Errorf("trigger = %v, want %v", got, tc.wantTrigger)
+			}
+		})
+	}
+}
+
+// The declared metadata length is read from the object's own trailer. A value
+// that is not a parquet trailer, or that cannot describe this object, must be
+// rejected rather than turned into a prefetch range.
+func TestReadParquetFooterLength(t *testing.T) {
+	const blockSize = 1024
+
+	t.Run("reads the declared length", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		got, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta)
+		if !ok || got != 300 {
+			t.Fatalf("footer length = %d (ok=%v), want 300", got, ok)
+		}
+	})
+
+	t.Run("rejects a missing magic", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		copy(content[contentLength-4:], "XXXX")
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		if _, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta); ok {
+			t.Fatal("accepted an object whose trailer is not a parquet trailer")
+		}
+	})
+
+	t.Run("rejects a length larger than the object", func(t *testing.T) {
+		content, contentLength := parquetTailBlock(t, blockSize, 300)
+		binary.LittleEndian.PutUint32(content[contentLength-parquetTrailerSize:], uint32(contentLength))
+		s := newParquetTestService(t, content, blockSize)
+		meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+		if _, ok := s.readParquetFooterLength(context.Background(), "b", "a.parquet", meta); ok {
+			t.Fatal("accepted a metadata length that cannot fit in the object")
+		}
+	})
+}
+
+// Precision accounting must count blocks, not reads: a prefetched block served
+// repeatedly is one useful prefetch, not many.
+func TestPrefetchAttribution_CountsEachBlockOnce(t *testing.T) {
+	s := NewService(nil, nil, config.NewDefault())
+	const blockSize = 1024
+
+	s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, 7)
+	key := cache.MakeBlockKey("b", "a.parquet", `"v1"`, blockSize, 7)
+	if _, ok := s.prefetchedBlocks.Get(key); !ok {
+		t.Fatal("prefetched block was not recorded")
+	}
+
+	s.notePrefetchHit("b", "a.parquet", `"v1"`, blockSize, 7)
+	if _, ok := s.prefetchedBlocks.Get(key); ok {
+		t.Fatal("attribution left the block recorded, so a re-read would count twice")
+	}
+	// A second hit on the same block must be a no-op rather than a panic or a
+	// second attribution.
+	s.notePrefetchHit("b", "a.parquet", `"v1"`, blockSize, 7)
+}
+
+// parquetFooterForwarder serves ranged reads out of a full object body and
+// records what was asked for, which is what the prefetch is judged on.
+type parquetFooterForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+
+	mu     sync.Mutex
+	ranges []string
+	served chan struct{}
+}
+
+func (f *parquetFooterForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
+	var start, end int64
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+		return nil, fmt.Errorf("unparsable range %q: %w", rangeHeader, err)
+	}
+	f.mu.Lock()
+	f.ranges = append(f.ranges, rangeHeader)
+	f.mu.Unlock()
+	if f.served != nil {
+		f.served <- struct{}{}
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(f.body)))
+	header.Set("ETag", f.etag)
+	chunk := f.body[start : end+1]
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: int64(len(chunk)),
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(chunk)),
+	}, nil
+}
+
+func (f *parquetFooterForwarder) requestedRanges() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.ranges)
+}
+
+// The whole point of the optimization: metadata that spans more blocks than the
+// tail must pull exactly the blocks it spans — no more, and not the tail block
+// the triggering read already cached.
+func TestPrefetchParquetFooterBlocks_FetchesTheSpannedBlocks(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	// Place the metadata start inside block 3, so blocks 3 and 4 must be
+	// prefetched and block 5 (the tail) must not.
+	metaStart := int64(3500)
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: body, etag: etag}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+	// Seed only the tail block, as the triggering read would have.
+	tail := int64(blocks - 1)
+	if err := store.PutBlock(context.Background(), bucket, key, etag, blockSize, tail, body[tail*blockSize:], 3600); err != nil {
+		t.Fatalf("seeding tail block: %v", err)
+	}
+
+	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta, nil)
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("upstream ranges = %v, want %v", got, want)
+	}
+	for _, idx := range []int64{3, 4} {
+		if !store.BlockExists(context.Background(), bucket, key, etag, blockSize, idx) {
+			t.Errorf("block %d was not cached by the prefetch", idx)
+		}
+		if _, ok := s.prefetchedBlocks.Get(cache.MakeBlockKey(bucket, key, etag, blockSize, idx)); !ok {
+			t.Errorf("block %d was not recorded for attribution", idx)
+		}
+	}
+}
+
+// Metadata that fits inside the tail block is already cached by the read that
+// triggered the prefetch, so speculating further would be pure waste.
+func TestPrefetchParquetFooterBlocks_NoFetchWhenFooterFitsTailBlock(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	s := newParquetTestService(t, content, blockSize)
+	fwd := &parquetFooterForwarder{body: content, etag: `"v1"`}
+	s.forwarder = fwd
+
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta, nil)
+
+	if got := fwd.requestedRanges(); len(got) != 0 {
+		t.Fatalf("prefetched %v for metadata that fits the tail block", got)
+	}
+}
+
+// A hot object is tail-read repeatedly. Each such read must not start its own
+// prefetch goroutine while one is already running for that object version.
+func TestMaybePrefetchParquetFooter_CoalescesConcurrentTriggers(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	s := newParquetTestService(t, content, blockSize)
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+
+	// Stand in for a prefetch already running for this object version.
+	dedupKey := "pq:b/a.parquet/" + meta.ETag
+	s.activeBackgroundFetches.Store(dedupKey, struct{}{})
+
+	s.maybePrefetchParquetFooter("b", "a.parquet", "access", "secret", meta, contentLength-parquetTrailerSize, contentLength-1, nil)
+
+	// A coalesced trigger must leave the in-flight marker for its owner to clear.
+	if _, ok := s.activeBackgroundFetches.Load(dedupKey); !ok {
+		t.Fatal("coalesced trigger deleted the in-flight marker owned by another prefetch")
+	}
+}
+
+// Regression test for the wiring, not the mechanism. A parquet reader's trailer
+// probe is a few bytes, so it is served by the assembled-range path and never
+// reaches streamBlockRange. Triggering the prefetch only from the streaming path
+// meant the signal that matters most never fired in production shapes.
+func TestServeRangeFromBlockCache_TrailerProbeTriggersFooterPrefetch(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	metaStart := int64(3500) // inside block 3, so blocks 3 and 4 must be prefetched
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	served := make(chan struct{}, blocks)
+	fwd := &parquetFooterForwarder{body: body, etag: etag, served: served}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+	tail := int64(blocks - 1)
+	if err := store.PutBlock(context.Background(), bucket, key, etag, blockSize, tail, body[tail*blockSize:], 3600); err != nil {
+		t.Fatalf("seeding tail block: %v", err)
+	}
+
+	// The read a parquet reader actually issues first: the 8-byte trailer.
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", contentLength-parquetTrailerSize, contentLength-1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key, nil)
+	req.Header.Set("Range", rangeHeader)
+
+	ok, err := s.serveRangeFromBlockCache(context.Background(), rec, req, bucket, key, "access", "secret", meta, rangeHeader, time.Now())
+	if err != nil || !ok {
+		t.Fatalf("serveRangeFromBlockCache(trailer) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+
+	// The prefetch is detached; wait for the two blocks it must fetch.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-served:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("trailer probe did not trigger the footer prefetch (ranges so far: %v)", fwd.requestedRanges())
+		}
+	}
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("prefetched ranges = %v, want %v", got, want)
+	}
+}
+
+// Regression test for the cold-open race. The assembled serve path returns a
+// freshly fetched tail block from an in-memory lease while its cache write is
+// still detached, so the trailer is NOT yet readable from cache when the
+// prefetch fires. Reading it back from cache would skip the prefetch on a
+// reader's first open, which is precisely what this feature targets -- and it
+// would also bias tag_cache_parquet_footer_bytes toward warm re-opens only.
+func TestPrefetchParquetFooterBlocks_UsesServedTrailerWhenTailNotYetCached(t *testing.T) {
+	const (
+		blockSize = 1024
+		blocks    = 6
+		bucket    = "bucket"
+		key       = "a.parquet"
+		etag      = `"v1"`
+	)
+	contentLength := int64(blockSize * blocks)
+	metaStart := int64(3500)
+	footerLen := contentLength - parquetTrailerSize - metaStart
+
+	body := make([]byte, contentLength)
+	binary.LittleEndian.PutUint32(body[contentLength-parquetTrailerSize:], uint32(footerLen))
+	copy(body[contentLength-4:], parquetMagic)
+
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: body, etag: etag}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: etag, BlockSize: blockSize, ContentLength: contentLength}
+
+	// Deliberately seed NOTHING: this is the cold open, with the tail block's
+	// cache write still in flight.
+	trailer := body[contentLength-parquetTrailerSize:]
+	s.prefetchParquetFooterBlocks(bucket, key, "access", "secret", meta, trailer)
+
+	want := []string{"bytes=3072-4095", "bytes=4096-5119"}
+	if got := fwd.requestedRanges(); !slices.Equal(got, want) {
+		t.Fatalf("prefetched ranges = %v, want %v (served trailer was ignored)", got, want)
+	}
+}
+
+// Without the served bytes and without a cached tail, there is nothing to read
+// the length from, so the prefetch must skip rather than guess.
+func TestPrefetchParquetFooterBlocks_SkipsWhenTrailerUnavailable(t *testing.T) {
+	const blockSize = 1024
+	content, contentLength := parquetTailBlock(t, blockSize, 300)
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = blockSize
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &parquetFooterForwarder{body: content, etag: `"v1"`}
+	s := NewService(fwd, store, cfg)
+
+	meta := &cache.CachedObjectMeta{ETag: `"v1"`, BlockSize: blockSize, ContentLength: contentLength}
+	s.prefetchParquetFooterBlocks("b", "a.parquet", "access", "secret", meta, nil)
+
+	if got := fwd.requestedRanges(); len(got) != 0 {
+		t.Fatalf("prefetched %v with no readable trailer", got)
+	}
+}
+
+// newParquetTestService wires a Service whose cache serves the given object
+// content at block granularity, which is all the footer reader needs.
+func newParquetTestService(t *testing.T, content []byte, blockSize int64) *Service {
+	t.Helper()
+	cfg := config.NewDefault()
+	c := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	s := NewService(nil, c, cfg)
+	s.config.Cache.ParquetOptimization = true
+
+	contentLength := int64(len(content))
+	blocks := (contentLength + blockSize - 1) / blockSize
+	for i := int64(0); i < blocks; i++ {
+		start := i * blockSize
+		end := min(start+blockSize, contentLength)
+		if err := c.PutBlock(context.Background(), "b", "a.parquet", `"v1"`, blockSize, i, content[start:end], 3600); err != nil {
+			t.Fatalf("seeding block %d: %v", i, err)
+		}
+	}
+	return s
+}

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -562,6 +562,55 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 	}()
 }
 
+// hasNoCacheDirectives reports whether any Cache-Control field has a directive that
+// forbids shared caching. It matches directive names rather than substrings, so extension
+// directives and parameter values such as no-storex or foo="no-store" retain normal caching.
+func hasNoCacheDirectives(cacheControls []string) bool {
+	for _, cacheControl := range cacheControls {
+		for i := 0; i < len(cacheControl); {
+			// A field can contain a comma-separated list of directives. Skip optional
+			// whitespace and any empty directives before reading the next name.
+			for i < len(cacheControl) && (cacheControl[i] == ',' || cacheControl[i] == ' ' || cacheControl[i] == '\t') {
+				i++
+			}
+			start := i
+			for i < len(cacheControl) && cacheControl[i] != '=' && cacheControl[i] != ',' && cacheControl[i] != ' ' && cacheControl[i] != '\t' {
+				i++
+			}
+			if strings.EqualFold(cacheControl[start:i], "no-store") || strings.EqualFold(cacheControl[start:i], "private") {
+				return true
+			}
+
+			// Consume the rest of this directive. Commas in quoted extension values do
+			// not start another directive, and an escaped quote stays in that value.
+			quoted, escaped := false, false
+		scanDirective:
+			for i < len(cacheControl) {
+				switch cacheControl[i] {
+				case '\\':
+					if quoted {
+						escaped = !escaped
+					}
+				case '"':
+					if !escaped {
+						quoted = !quoted
+					}
+					escaped = false
+				case ',':
+					if !quoted {
+						i++
+						break scanDirective
+					}
+				default:
+					escaped = false
+				}
+				i++
+			}
+		}
+	}
+	return false
+}
+
 // hasNoCacheHeaders checks if response has no-cache directives.
 func (s *Service) hasNoCacheHeaders(headers http.Header) bool {
 	cc := headers.Get("Cache-Control")

--- a/proxy/caching_test.go
+++ b/proxy/caching_test.go
@@ -5,6 +5,30 @@ import (
 	"time"
 )
 
+func TestHasNoCacheDirectives(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		cacheControls []string
+		want          bool
+	}{
+		{name: "no directives", want: false},
+		{name: "no-store", cacheControls: []string{"no-store"}, want: true},
+		{name: "private with field list", cacheControls: []string{`private="Set-Cookie"`}, want: true},
+		{name: "later repeated directive", cacheControls: []string{"max-age=60", "No-Store"}, want: true},
+		{name: "after quoted extension", cacheControls: []string{`foo="value, still", private`}, want: true},
+		{name: "extension names", cacheControls: []string{"no-storex, privatex"}, want: false},
+		{name: "extension value", cacheControls: []string{"foo=no-store"}, want: false},
+		{name: "quoted extension value", cacheControls: []string{`foo="no-store, private"`}, want: false},
+		{name: "escaped quote in extension value", cacheControls: []string{`foo="a\", no-store", max-age=60`}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasNoCacheDirectives(tc.cacheControls); got != tc.want {
+				t.Errorf("hasNoCacheDirectives(%q) = %t, want %t", tc.cacheControls, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCacheWriteTimeoutForSize(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -190,7 +190,7 @@ func newBaseForwarder(tigrisEndpoint, region string, maxIdleConnsPerHost int) ba
 // originalReq is the original client request, passed to the response interceptor
 // for parsing auth info. It can be nil if no interceptor is set.
 func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64, originalReq *http.Request) error {
-	_, _, err := b.executeAndStreamReturningMeta(w, fwdReq, inContentLength, originalReq)
+	_, _, err := b.executeAndStreamWithMeta(w, fwdReq, inContentLength, originalReq, false)
 	return err
 }
 
@@ -199,6 +199,12 @@ func (b *baseForwarder) executeAndStream(w http.ResponseWriter, fwdReq *http.Req
 // tee path, which needs the response ETag to build cache metadata for the just-written
 // object without a read-back GET. On a transport error it returns (0, nil, err).
 func (b *baseForwarder) executeAndStreamReturningMeta(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64, originalReq *http.Request) (int, http.Header, error) {
+	return b.executeAndStreamWithMeta(w, fwdReq, inContentLength, originalReq, true)
+}
+
+// executeAndStreamWithMeta streams an upstream response and optionally retains an
+// owned copy of its headers for a caller that needs metadata after streaming.
+func (b *baseForwarder) executeAndStreamWithMeta(w http.ResponseWriter, fwdReq *http.Request, inContentLength int64, originalReq *http.Request, captureMeta bool) (int, http.Header, error) {
 	if inContentLength > 0 {
 		metrics.BytesTransferred.WithLabelValues("in").Add(float64(inContentLength))
 	}
@@ -217,9 +223,12 @@ func (b *baseForwarder) executeAndStreamReturningMeta(w http.ResponseWriter, fwd
 		b.responseInterceptor(resp, originalReq)
 	}
 
-	// Clone response headers before streaming so callers can read the upstream ETag
-	// after the body is consumed.
-	respHeaders := resp.Header.Clone()
+	var respHeaders http.Header
+	if captureMeta {
+		// The write-through tee reads the ETag after the body is consumed, so it
+		// needs independent header ownership.
+		respHeaders = resp.Header.Clone()
+	}
 
 	// Stream response back to client
 	copyHeaders(w.Header(), resp.Header)

--- a/proxy/forwarder_signing_benchmark_test.go
+++ b/proxy/forwarder_signing_benchmark_test.go
@@ -31,6 +31,13 @@ const (
 		"?tagging&versionId=one%2Ftwo%20with%25marker-" +
 		"000000000000000000000000000000000000000000000000000000000000"
 
+	// This is a GetObjectTagging request with query keys and values that need
+	// SigV4 percent encoding. It exercises validation and re-signing through
+	// Service.HandlePassthrough without an upstream network round trip.
+	signingForwarderBenchmarkEscapedQueryPath = "/benchmark-bucket/object%2Fwith space+and%25" +
+		"?tagging&prefix%2Fwith%20space=one%2Ftwo&prefix%2Fwith%20space=a%20b" +
+		"&prefix%2Fwith%20space=100%25&x%2By=&x%2By=%E6%97%A5%E6%9C%AC"
+
 	// This is an UploadPart request, which is also routed to
 	// Service.HandlePassthrough through handleObjectWithQuery. Its escaped key
 	// and opaque upload ID are deliberately longer than the tagging request.
@@ -204,6 +211,27 @@ func BenchmarkServiceHandlePassthroughSigning(b *testing.B) {
 		b,
 		http.MethodGet,
 		signingForwarderBenchmarkGetPath,
+		"",
+		http.Header{"X-Amz-Expected-Bucket-Owner": {"123456789012"}},
+	)
+	req := incomingRequest.Clone(context.Background())
+	writer := signingForwarderBenchmarkResponseWriter{header: make(http.Header)}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if err := service.HandlePassthrough(&writer, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkServiceHandlePassthroughSigningEscapedQuery measures a signed
+// passthrough request whose canonical query has reserved keys and values.
+func BenchmarkServiceHandlePassthroughSigningEscapedQuery(b *testing.B) {
+	service, incomingRequest := newSigningPassthroughBenchmark(
+		b,
+		http.MethodGet,
+		signingForwarderBenchmarkEscapedQueryPath,
 		"",
 		http.Header{"X-Amz-Expected-Bucket-Owner": {"123456789012"}},
 	)

--- a/proxy/forwarder_test.go
+++ b/proxy/forwarder_test.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type forwarderTestTransport func(*http.Request) (*http.Response, error)
+
+func (f forwarderTestTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestExecuteAndStreamReturningMetaOwnsHeaders(t *testing.T) {
+	upstreamHeaders := make(http.Header)
+	upstreamHeaders.Set("ETag", `"upstream-etag"`)
+	upstreamHeaders["X-Upstream-Metadata"] = []string{"first", "second"}
+
+	forwarder := newBaseForwarder("https://upstream.example.com", "us-east-1", 1)
+	forwarder.httpClient = &http.Client{Transport: forwarderTestTransport(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     upstreamHeaders,
+			Body:       io.NopCloser(strings.NewReader("response body")),
+		}, nil
+	})}
+
+	writer := httptest.NewRecorder()
+	request, err := http.NewRequest(http.MethodPut, "https://upstream.example.com/bucket/object", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, headers, err := forwarder.executeAndStreamReturningMeta(writer, request, 0, nil)
+	if err != nil {
+		t.Fatalf("executeAndStreamReturningMeta: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+	if writer.Body.String() != "response body" {
+		t.Errorf("client body = %q, want response body", writer.Body.String())
+	}
+	if writer.Header().Get("ETag") != `"upstream-etag"` {
+		t.Errorf("client ETag = %q, want upstream ETag", writer.Header().Get("ETag"))
+	}
+	if headers.Get("ETag") != `"upstream-etag"` {
+		t.Fatalf("captured ETag = %q, want upstream ETag", headers.Get("ETag"))
+	}
+	if got := headers.Values("X-Upstream-Metadata"); len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Fatalf("captured metadata = %q, want [first second]", got)
+	}
+
+	upstreamHeaders.Set("ETag", `"changed-upstream-etag"`)
+	upstreamHeaders["X-Upstream-Metadata"][0] = "changed"
+	if headers.Get("ETag") != `"upstream-etag"` {
+		t.Errorf("captured ETag changed with upstream map: %q", headers.Get("ETag"))
+	}
+	if got := headers.Values("X-Upstream-Metadata"); len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Errorf("captured metadata changed with upstream slice: %q", got)
+	}
+
+	headers.Set("ETag", `"changed-captured-etag"`)
+	if upstreamHeaders.Get("ETag") != `"changed-upstream-etag"` {
+		t.Errorf("upstream ETag changed with captured map: %q", upstreamHeaders.Get("ETag"))
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -490,8 +490,10 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// Forward to Tigris, recording the upstream status. When eligible, forwardPutMaybeTee
 	// tees the decoded body so we can populate the cache directly (write-through) instead of
 	// a read-back warm-on-write GET; teed is non-nil only when a tee was attempted.
+	// requestRejectsCache marks a no-store/private PUT that was plain-forwarded before tee
+	// admission and must not start a read-back warm after a successful write.
 	rec := &statusRecorder{ResponseWriter: w}
-	teed, err := s.forwardPutMaybeTee(r.Context(), rec, r, bucket, key)
+	teed, requestRejectsCache, err := s.forwardPutMaybeTee(r.Context(), rec, r, bucket, key)
 
 	// Re-invalidate AFTER upstream confirms the write. A GET that raced the
 	// in-flight PUT may have fetched the pre-PUT object and begun re-caching it;
@@ -504,13 +506,13 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
 		s.invalidateObject(context.Background(), bucket, key)
-		cached := false
+		teeHandled := requestRejectsCache
 		if teed != nil {
 			// writeThroughCache takes ownership of the reserved populate budget.
-			cached = s.writeThroughCache(bucket, key, teed)
+			teeHandled = s.writeThroughCache(bucket, key, teed)
 			teed = nil
 		}
-		if !cached {
+		if !teeHandled {
 			s.warmOnWrite(r, bucket, key)
 		}
 	}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/config"
@@ -72,6 +73,10 @@ type Service struct {
 	activeBackgroundFetches sync.Map                    // Dedup for background full-object fetches (range caching)
 	blockFetchMu            sync.Mutex                  // Guards blockFetches
 	blockFetches            map[string]*blockFetchState // Coalesce block fetches while a detached remote write is pending
+	// prefetchedBlocks remembers recently prefetched block keys so a later serve
+	// of one can be attributed, giving prefetch precision. Bounded and
+	// TTL-expiring: this is measurement, and must not become a memory term.
+	prefetchedBlocks *expirable.LRU[string, struct{}]
 }
 
 // NewService creates a new proxy service.
@@ -147,6 +152,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		perPopulateCap:   perPopulateCap,
 		broadcastManager: broadcast.NewManager(channelBuf),
 		blockFetches:     make(map[string]*blockFetchState),
+		prefetchedBlocks: expirable.NewLRU[string, struct{}](maxPrefetchedBlockTracking, nil, prefetchTrackingTTL),
 	}
 }
 
@@ -192,6 +198,18 @@ func (s *Service) populateWeight(contentLength int64) int64 {
 	return w
 }
 
+const (
+	// maxPrefetchedBlockTracking bounds the prefetch attribution set. Sized well
+	// above the blocks one node prefetches within the TTL, so precision is not
+	// understated by eviction from this set.
+	maxPrefetchedBlockTracking = 65536
+
+	// prefetchTrackingTTL is how long a prefetched block stays attributable. A
+	// prefetch that is not used within this window was not useful in the sense
+	// that motivates prefetching — hiding latency from the read that follows it.
+	prefetchTrackingTTL = 30 * time.Minute
+)
+
 // stagingWeight is the byte weight a block-serve staging buffer reserves against the
 // serve-staging budget: the buffer's ACTUAL size, clamped only by the total budget (so a
 // buffer larger than the whole budget still serves one-at-a-time, mirroring populateWeight).
@@ -214,6 +232,7 @@ func (s *Service) stagingWeight(n int64) int64 {
 // budget. warmWrite populates (cache-warm-on-write, which pre-cache data about to
 // be read) get a reserved, prioritized slice of the budget so the read-miss
 // full-object warm flood can't starve them; readMiss populates use the rest.
+
 type populatePriority int
 
 const (

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -78,9 +78,19 @@ func teeObjectSize(r *http.Request) int64 {
 // threshold, and the populate budget admits it without blocking — it tees the decoded body
 // so the caller can populate the cache without a read-back warm GET. It returns a non-nil
 // *teeState only when a tee was attempted; the caller must then route it through
-// writeThroughCache (which releases the reserved budget). Otherwise it performs a plain
-// forward and returns nil, and the caller falls back to warm-on-write.
-func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string) (*teeState, error) {
+// writeThroughCache (which releases the reserved budget). A PUT request policy that
+// conclusively rejects shared caching takes the plain-forward path before tee admission and
+// returns requestRejectsCache=true so the caller also skips the read-back warm. Other plain
+// forwards return nil, false and fall back to warm-on-write.
+func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string) (teed *teeState, requestRejectsCache bool, err error) {
+	if s.config.Cache.WarmOnWrite && s.cache.IsEnabled() {
+		// net/http canonicalizes incoming header keys. Avoid parsing a policy on the
+		// common cacheable path, which has no Cache-Control field at all.
+		if cacheControls := r.Header["Cache-Control"]; len(cacheControls) > 0 && hasNoCacheDirectives(cacheControls) {
+			return nil, true, s.forwarder.Forward(ctx, w, r)
+		}
+	}
+
 	tf, ok := s.forwarder.(bodyTeeingForwarder)
 	size := teeObjectSize(r)
 	eligible := ok &&
@@ -110,7 +120,7 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 		size <= s.config.Cache.SizeThreshold
 
 	if !eligible {
-		return nil, s.forwarder.Forward(ctx, w, r)
+		return nil, false, s.forwarder.Forward(ctx, w, r)
 	}
 
 	// Non-blocking admission: the tee runs on the client PUT path, so it must never block
@@ -118,18 +128,21 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 	// without blocking; on denial we fall back to a plain forward + (async, blocking)
 	// warm-on-write, so the object still gets cached under budget pressure.
 	if !s.acquireCacheSlot(ctx, size, priorityReadMiss) {
-		return nil, s.forwarder.Forward(ctx, w, r)
+		return nil, false, s.forwarder.Forward(ctx, w, r)
 	}
 
 	// Preallocate to the exact known size to avoid repeated append reallocations on the
 	// write hot path.
-	ts := &teeState{buf: &cappedBuffer{buf: make([]byte, 0, int(size)), cap: int(size)}, weight: size}
+	ts := &teeState{
+		buf:    &cappedBuffer{buf: make([]byte, 0, int(size)), cap: int(size)},
+		weight: size,
+	}
 	status, headers, accessKey, secretKey, err := tf.ForwardTeeingBody(ctx, w, r, ts.buf)
 	ts.statusCode = status
 	ts.respHeaders = headers
 	ts.accessKey = accessKey
 	ts.secretKey = secretKey
-	return ts, err
+	return ts, false, err
 }
 
 // writeThroughCache populates the cache from a teed PutObject body without a full-object
@@ -137,9 +150,10 @@ func (s *Service) forwardPutMaybeTee(ctx context.Context, w http.ResponseWriter,
 // headers a GET would, minus the body), so the cached entry can never diverge from an origin
 // GET, then writes that meta with the bytes already teed.
 //
-// Returns true when the write was handed off to the async path (which caches the object or,
-// if the HEAD can't confirm it, falls back to a read-back warm), false when it declined
-// synchronously (over-cap body, missing ETag, or no usable credentials) so the caller warms.
+// Returns true when the tee was handed off to the async path (which caches the object or,
+// if the HEAD can't confirm it, falls back to a read-back warm). It returns false only when
+// it declined synchronously (over-cap body, missing ETag, or no usable credentials) so the
+// caller warms.
 // The reserved populate budget is always released: synchronously on decline, or when the
 // async work completes.
 func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {

--- a/proxy/write_through_benchmark_test.go
+++ b/proxy/write_through_benchmark_test.go
@@ -1,0 +1,199 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// writeThroughBenchmarkForwarder counts metadata HEADs and signals when a HEAD
+// response closes. cacheTeedBodyFromHead closes that response only after it has
+// finished the metadata/body cache write, so the signal is a precise detached-commit
+// boundary without polling the populate limiter.
+type writeThroughBenchmarkForwarder struct {
+	*teeMockForwarder
+	heads     atomic.Int64
+	committed chan struct{}
+}
+
+type writeThroughBenchmarkCommitBody struct {
+	io.ReadCloser
+	committed chan<- struct{}
+}
+
+func (b *writeThroughBenchmarkCommitBody) Close() error {
+	err := b.ReadCloser.Close()
+	select {
+	case b.committed <- struct{}{}:
+	default: // Close is idempotent for the benchmark signal.
+	}
+	return err
+}
+
+func (f *writeThroughBenchmarkForwarder) DoConditionalHeadRequest(
+	ctx context.Context,
+	bucket, key, accessKey, secretKey, etag string,
+	lastModified int64,
+) (*http.Response, error) {
+	f.heads.Add(1)
+	resp, err := f.teeMockForwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, etag, lastModified)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+
+	// The mock's HEAD metadata is immutable, but each detached commit needs its own body
+	// close notification. A HEAD has no meaningful body, so use a fresh empty one.
+	clone := *resp
+	clone.Header = resp.Header.Clone()
+	clone.Body = &writeThroughBenchmarkCommitBody{
+		ReadCloser: io.NopCloser(strings.NewReader("")),
+		committed:  f.committed,
+	}
+	return &clone, nil
+}
+
+// waitForWriteThroughCommit waits for the detached cache commit that follows a teed PUT.
+func waitForWriteThroughCommit(b testing.TB, committed <-chan struct{}) {
+	b.Helper()
+	select {
+	case <-committed:
+	case <-time.After(time.Second):
+		b.Fatal("timed out waiting for write-through cache commit")
+	}
+}
+
+// benchmarkHandlePutObjectWriteThroughTee measures an eligible PUT through
+// HandlePutObject. When includeDetachedCommit is true, the detached tee commit is included
+// in the timed operation. Otherwise it is synchronized between requests but excluded because
+// it runs after the client receives its PUT response. The mock HEAD deliberately has no
+// Cache-Control directive, so its origin metadata is cacheable.
+func benchmarkHandlePutObjectWriteThroughTee(b *testing.B, putCacheControl string, includeDetachedCommit bool) {
+	oldLogger := log.Logger
+	log.Logger = log.Logger.Level(zerolog.WarnLevel)
+	b.Cleanup(func() { log.Logger = oldLogger })
+
+	const (
+		bucket   = "benchmark-bucket"
+		key      = "write-through-object"
+		bodySize = 64 << 10
+		etag     = `"tee-etag"`
+	)
+	body := strings.Repeat("t", bodySize)
+
+	var teedPuts, directPuts atomic.Int32
+	head := headResp(etag, "application/octet-stream", int64(len(body)))
+	forwarder := &writeThroughBenchmarkForwarder{
+		committed: make(chan struct{}, 1),
+		teeMockForwarder: &teeMockForwarder{
+			mockForwarder: &mockForwarder{
+				conditionalResp: head,
+				forwardFunc: func(_ context.Context, w http.ResponseWriter, r *http.Request) error {
+					if _, err := io.Copy(io.Discard, r.Body); err != nil {
+						return err
+					}
+					directPuts.Add(1)
+					w.WriteHeader(http.StatusOK)
+					return nil
+				},
+			},
+			teeFunc: teeUpstream(&teedPuts, etag),
+		},
+	}
+	svc, c := newTestService(forwarder, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.BlockSize = 1 << 20
+	// waitForWriteThroughCommit serializes commits, so no benchmark iteration can overlap
+	// another. Disabling the limiter avoids turning its observed state into a polling signal.
+	svc.cacheSemaphore = nil
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		teedBefore := teedPuts.Load()
+		r := authedPut(bucket, key, body)
+		if putCacheControl != "" {
+			r.Header.Set("Cache-Control", putCacheControl)
+		}
+		w := httptest.NewRecorder()
+		if err := svc.HandlePutObject(w, r); err != nil {
+			b.Fatalf("HandlePutObject: %v", err)
+		}
+		if w.Code != http.StatusOK {
+			b.Fatalf("client status = %d, want %d", w.Code, http.StatusOK)
+		}
+		if teedPuts.Load() != teedBefore {
+			if !includeDetachedCommit {
+				b.StopTimer()
+			}
+			waitForWriteThroughCommit(b, forwarder.committed)
+			if !includeDetachedCommit {
+				b.StartTimer()
+			}
+		} else if putCacheControl != "no-store" {
+			b.Fatal("cacheable PUT did not use the write-through tee")
+		}
+	}
+	b.StopTimer()
+
+	if got := teedPuts.Load() + directPuts.Load(); got != int32(b.N) {
+		b.Fatalf("upstream PUTs = %d, want %d", got, b.N)
+	}
+	heads := forwarder.heads.Load()
+	wantCached := true
+	switch putCacheControl {
+	case "":
+		if directPuts.Load() != 0 {
+			b.Fatalf("plain-forward PUTs = %d, want 0 for cacheable PUTs", directPuts.Load())
+		}
+		if heads != int64(b.N) {
+			b.Fatalf("metadata HEADs = %d, want %d for cacheable PUTs", heads, b.N)
+		}
+	case "no-store":
+		switch heads {
+		case 0:
+			if directPuts.Load() != int32(b.N) {
+				b.Fatalf("plain-forward PUTs = %d, want %d after policy rejection", directPuts.Load(), b.N)
+			}
+			wantCached = false
+		case int64(b.N):
+			if teedPuts.Load() != int32(b.N) {
+				b.Fatalf("tee upstream PUTs = %d, want %d before policy rejection", teedPuts.Load(), b.N)
+			}
+		default:
+			b.Fatalf("metadata HEADs = %d, want 0 or %d", heads, b.N)
+		}
+	default:
+		b.Fatalf("unsupported PUT Cache-Control %q", putCacheControl)
+	}
+	_, found, err := c.GetMeta(context.Background(), bucket, key)
+	if err != nil {
+		b.Fatalf("GetMeta: %v", err)
+	}
+	if found != wantCached {
+		b.Fatalf("cached = %t, want %t", found, wantCached)
+	}
+	b.ReportMetric(float64(heads)/float64(b.N), "upstream_HEADs/op")
+}
+
+// BenchmarkHandlePutObjectWriteThroughTeeNoStoreCacheableOrigin measures a completed
+// eligible 64 KiB PUT declaring Cache-Control: no-store when the origin's HEAD metadata is
+// cacheable. The baseline follows that HEAD and publishes a cache entry; the candidate
+// conservatively honors the request policy and plain-forwards without cache work.
+func BenchmarkHandlePutObjectWriteThroughTeeNoStoreCacheableOrigin(b *testing.B) {
+	benchmarkHandlePutObjectWriteThroughTee(b, "no-store", true)
+}
+
+// BenchmarkHandlePutObjectWriteThroughTeeCacheable measures the ordinary cacheable
+// PUT's client-visible path. It keeps the authoritative metadata HEAD and waits for each
+// detached tee commit outside the timed span to verify cache publication before the next PUT.
+func BenchmarkHandlePutObjectWriteThroughTeeCacheable(b *testing.B) {
+	benchmarkHandlePutObjectWriteThroughTee(b, "", false)
+}

--- a/proxy/write_through_test.go
+++ b/proxy/write_through_test.go
@@ -234,7 +234,7 @@ func TestHandlePutObject_WriteThroughTee_HeadFailureFallsBackToWarm(t *testing.T
 // the tee must NOT fall back to a read-back warm — a warm would only re-download the full
 // body to reject it again, defeating the bandwidth win.
 func TestHandlePutObject_WriteThroughTee_NotCacheableSkipsWarm(t *testing.T) {
-	var puts, warmGets atomic.Int32
+	var puts, warmGets, heads atomic.Int32
 	body := "no-store-body"
 
 	head := headResp(`"tee-etag"`, "text/plain", int64(len(body)))
@@ -245,7 +245,8 @@ func TestHandlePutObject_WriteThroughTee_NotCacheableSkipsWarm(t *testing.T) {
 			conditionalResp:  head,
 			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"), // must NOT fire
 		},
-		teeFunc: teeUpstream(&puts, `"tee-etag"`),
+		teeFunc:  teeUpstream(&puts, `"tee-etag"`),
+		headHook: func() { heads.Add(1) },
 	}
 	svc, c := newTestService(mock, true)
 	svc.config.Cache.WarmOnWrite = true
@@ -264,6 +265,140 @@ func TestHandlePutObject_WriteThroughTee_NotCacheableSkipsWarm(t *testing.T) {
 	}
 	if got := puts.Load(); got != 1 {
 		t.Errorf("tee upstream PUTs = %d, want 1", got)
+	}
+	if got := heads.Load(); got != 1 {
+		t.Errorf("metadata HEADs = %d, want 1 (no policy was available on the PUT)", got)
+	}
+}
+
+// A Cache-Control policy supplied with the PUT is already enough to reject shared caching.
+// The request must take the plain-forward path before tee admission: no metadata HEAD, tee
+// buffer, cache entry, or read-back warm is needed for no-store/private.
+func TestHandlePutObject_WriteThroughTee_RequestCacheControlPlainForwards(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		cacheControls []string
+	}{
+		{name: "no-store", cacheControls: []string{"No-Store"}},
+		{name: "private", cacheControls: []string{"max-age=60, PRIVATE"}},
+		{name: "private-with-field-list", cacheControls: []string{`private="Set-Cookie"`}},
+		{name: "repeated-no-store", cacheControls: []string{"max-age=60", "no-store"}},
+		{name: "repeated-private", cacheControls: []string{"max-age=60", "private"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var teedPuts, directPuts, warmGets, heads atomic.Int32
+			var forwardedBody bytes.Buffer
+			body := "request-cache-control-body"
+
+			mock := &teeMockForwarder{
+				mockForwarder: &mockForwarder{
+					// A cacheable response makes an accidental HEAD observable as both a
+					// second request and a wrongly published entry.
+					conditionalResp:  headResp(`"tee-etag"`, "text/plain", int64(len(body))),
+					doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+					forwardFunc: func(_ context.Context, w http.ResponseWriter, r *http.Request) error {
+						if _, err := io.Copy(&forwardedBody, r.Body); err != nil {
+							return err
+						}
+						directPuts.Add(1)
+						w.WriteHeader(http.StatusOK)
+						return nil
+					},
+				},
+				teeFunc:  teeUpstream(&teedPuts, `"tee-etag"`),
+				headHook: func() { heads.Add(1) },
+			}
+			svc, c := newTestService(mock, true)
+			svc.config.Cache.WarmOnWrite = true
+			svc.config.Cache.SizeThreshold = 1 << 20
+			svc.config.Cache.BlockSize = 1 << 20
+			svc.cacheSemaphore = make(chan struct{}, 1)
+
+			r := authedPut(wowBucket, wowKey, body)
+			for _, cacheControl := range tc.cacheControls {
+				r.Header.Add("Cache-Control", cacheControl)
+			}
+			w := httptest.NewRecorder()
+			if err := svc.HandlePutObject(w, r); err != nil {
+				t.Fatalf("HandlePutObject: %v", err)
+			}
+			if w.Code != http.StatusOK {
+				t.Fatalf("client status = %d, want 200", w.Code)
+			}
+			if metaCached(c, wowBucket, wowKey, 300*time.Millisecond) {
+				t.Error("request-declared non-cacheable object was cached")
+			}
+			if got := teedPuts.Load(); got != 0 {
+				t.Errorf("tee upstream PUTs = %d, want 0", got)
+			}
+			if got := directPuts.Load(); got != 1 {
+				t.Errorf("plain-forward upstream PUTs = %d, want 1", got)
+			}
+			if got := forwardedBody.String(); got != body {
+				t.Errorf("plain-forward body = %q, want %q", got, body)
+			}
+			if got := heads.Load(); got != 0 {
+				t.Errorf("metadata HEADs = %d, want 0", got)
+			}
+			if got := warmGets.Load(); got != 0 {
+				t.Errorf("read-back warm GETs = %d, want 0", got)
+			}
+			if !svc.acquireCacheSlot(context.Background(), int64(len(body)), priorityReadMiss) {
+				t.Fatal("request policy path held a cache slot")
+			}
+			svc.releaseCacheSlot(int64(len(body)))
+		})
+	}
+}
+
+// Only exact no-store/private directives reject shared storage. no-cache and extension
+// directives whose names or values merely contain those strings retain the normal tee path
+// and its authoritative metadata HEAD.
+func TestHandlePutObject_WriteThroughTee_RequestCacheControlExtensionsUseHead(t *testing.T) {
+	var teedPuts, directPuts, warmGets, heads atomic.Int32
+	body := "request-no-cache-body"
+
+	mock := &teeMockForwarder{
+		mockForwarder: &mockForwarder{
+			conditionalResp:  headResp(`"tee-etag"`, "text/plain", int64(len(body))),
+			doFullObjectFunc: warmObjectResponder(&warmGets, "warm-body"),
+			forwardFunc: func(_ context.Context, w http.ResponseWriter, r *http.Request) error {
+				if _, err := io.Copy(io.Discard, r.Body); err != nil {
+					return err
+				}
+				directPuts.Add(1)
+				w.WriteHeader(http.StatusOK)
+				return nil
+			},
+		},
+		teeFunc:  teeUpstream(&teedPuts, `"tee-etag"`),
+		headHook: func() { heads.Add(1) },
+	}
+	svc, c := newTestService(mock, true)
+	svc.config.Cache.WarmOnWrite = true
+	svc.config.Cache.SizeThreshold = 1 << 20
+	svc.config.Cache.BlockSize = 1 << 20
+
+	r := authedPut(wowBucket, wowKey, body)
+	r.Header.Set("Cache-Control", `no-cache, no-storex, privatex, foo="private, no-store"`)
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, r); err != nil {
+		t.Fatalf("HandlePutObject: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("cacheable request-policy PUT was not cached through the tee")
+	}
+	if got := teedPuts.Load(); got != 1 {
+		t.Errorf("tee upstream PUTs = %d, want 1", got)
+	}
+	if got := directPuts.Load(); got != 0 {
+		t.Errorf("plain-forward upstream PUTs = %d, want 0", got)
+	}
+	if got := heads.Load(); got != 1 {
+		t.Errorf("metadata HEADs = %d, want 1", got)
+	}
+	if got := warmGets.Load(); got != 0 {
+		t.Errorf("read-back warm GETs = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cache populate and block-serve paths (speculative upstream fetches, Cache-Control policy on PUTs). Opt-in and bounded, but a bug could over-fetch parquet objects or skip caching incorrectly.
> 
> **Overview**
> Adds opt-in **parquet footer prefetch** (`cache.parquet_optimization` / `TAG_CACHE_PARQUET_OPTIMIZATION`, off by default). A tail read of a `.parquet` object that covers the 8-byte trailer can background-fetch the metadata blocks the file itself declares, so a reader opening the file does not walk those blocks as serial misses. Prefetch is coalesced per object version, shed under populate pressure, capped at 32 blocks, and attributed via `tag_cache_block_prefetched_total` / `tag_cache_block_prefetch_used_total` plus `tag_cache_parquet_footer_bytes`.
> 
> PUTs that declare `Cache-Control: no-store` or `private` now skip write-through tee, metadata HEAD, and warm-on-write. Directive matching is name-based so extension names/values that merely contain those strings still cache.
> 
> Also shares SigV4 canonical query encoding between signer and validator with fewer allocations, clones upstream headers only when write-through needs them, and bumps the k8s image tag to **v1.17.7**. Docs cover reclaim/compaction liveness walks and the new metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1ffb96dfb4b966bd89e02476936fec68c774c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->