### PR TITLE
feat(cache): warm parquet footers at write time

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,14 +181,18 @@ cache:
   # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
   block_size: 1048576
 
-  # Parquet-aware footer prefetching (opt-in). A parquet reader must read the file's metadata
+  # Parquet-aware footer caching (opt-in). Drives two triggers: a read that reaches an
+  # object's trailer prefetches the rest of its metadata, and a parquet object written
+  # through TAG has its metadata warmed before the first read (RFC 0002).
+  # A parquet reader must read the file's metadata
   # before any data, and that metadata sits at the end of the object. Block caching already
   # covers metadata that fits in the tail block; this fetches the earlier blocks when it does
   # not, using the length the file itself declares rather than a guess. Costs one speculative
   # fetch per spanned block, shed under populate pressure like any other prefetch. Watch
-  # tag_cache_parquet_footer_bytes to confirm it still applies to your data:
-  # measured on production parseable data, footers run ~1.25% of object size, so a
-  # 300 MB object carries ~3.5 MB of metadata -- several blocks at a 1 MiB block_size.
+  # tag_cache_parquet_footer_bytes to see whether it applies to your data: footer
+  # size scales with row groups and columns, so a wide schema can put several MB of
+  # metadata on a few-hundred-MB object -- several blocks at a 1 MiB block_size --
+  # while a narrow schema keeps it inside the tail block and this does nothing.
   # Override with TAG_CACHE_PARQUET_OPTIMIZATION env var.
   parquet_optimization: false
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -375,10 +375,17 @@ means the readers are not following writes closely, and that trigger is not payi
 
 **Type:** Histogram
 
-Size of the parquet metadata region, read from the trailer of objects served while
+Size of the parquet metadata region, read from the trailer of objects while
 `cache.parquet_optimization` is on. Recorded for **every** parquet object whose trailer is
 read, including ones that are not prefetched, so the distribution describes the whole
 population rather than just the prefetched tail of it.
+
+Note the population depends on which triggers are active. The read trigger observes objects
+as they are read; the write trigger observes them as they are written. With both on, an object
+written and later read through the same node is observed twice, and write-heavy deployments
+will weight the distribution toward recently written objects. Read it as a distribution of
+*observations*, not of distinct objects — that is what makes it useful for drift detection and
+what to keep in mind before comparing across deployments.
 
 The prefetch does work whenever `footer + 8` exceeds the **remainder** block
 (`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -361,7 +361,15 @@ precision cannot exceed 1. It is also deliberately an undercount — attribution
 bounded, TTL-expiring set, so a block served long after it was prefetched goes unattributed.
 Read the ratio as a floor.
 
-The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
+Both triggers come from `cache.parquet_optimization`:
+
+| `trigger` | Fires when |
+| --- | --- |
+| `parquet_footer` | A read reached a parquet object's trailer — reactive, helps the second and later reads |
+| `write_warm` | A parquet object was written through TAG — proactive, removes the first read's miss (RFC 0002) |
+
+Compare the two directly. `write_warm` precision materially below `parquet_footer` precision
+means the readers are not following writes closely, and that trigger is not paying for itself.
 
 #### tag_cache_parquet_footer_bytes
 
@@ -376,14 +384,15 @@ The prefetch does work whenever `footer + 8` exceeds the **remainder** block
 (`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds
 `block_size`.
 
-Measured baseline on production parseable data (26 objects): footers run **~1.25% of object
-size** — 3.0 MB at 244 MB, 4.7 MB at 394 MB — so at a 1 MiB `block_size` the metadata spans
-3–5 blocks and the prefetch fires on ~69% of objects. Only small (<2 MB) files, with 20–50 KB
-footers, fit inside the remainder.
+Footer size scales with row groups and columns, since the footer carries per-column
+statistics. On a production deployment with a wide schema, footers ran **~1.25% of object
+size** — several MB on a few-hundred-MB object — so at a 1 MiB `block_size` the metadata spans
+several blocks and the prefetch does real work on most objects. A narrow schema keeps the
+footer inside the tail block, where there is nothing to prefetch.
 
-Use the histogram to confirm that ratio still holds for your data: a schema change alters
-footer size, and a distribution that collapses below the remainder-block size means the
-optimization has stopped earning its keep.
+Use the histogram to establish that ratio for your own data, and to detect drift: a schema
+change alters footer size, and a distribution that collapses below the remainder-block size
+means the optimization has stopped earning its keep.
 
 ```promql
 # Median footer size — compare against cache.block_size.

--- a/docs/rfcs/0002-parquet-footer-warming.md
+++ b/docs/rfcs/0002-parquet-footer-warming.md
@@ -1,0 +1,141 @@
+# RFC 0002: Parquet footer warming on write
+
+- **Status:** Proposed
+- **Related:** [RFC 0001](0001-block-aligned-caching.md) (block-aligned caching), [#174](https://github.com/tigrisdata/tag/pull/174) (read-triggered footer prefetch)
+
+## Summary
+
+Cache a parquet object's **metadata blocks at write time**, when TAG proxies the upload, instead of waiting for a reader to discover them as misses. For a workload where writers and readers overlap — an ingest pipeline feeding a dashboard that queries a recent time window — a newly written file is read within one refresh interval. TAG already has everything it needs at write time, so this schedules a fetch rather than speculating about one.
+
+## Motivation
+
+[#174](https://github.com/tigrisdata/tag/pull/174) added a read-triggered footer prefetch: when a read reaches a parquet object's trailer, TAG fetches the metadata blocks the reader is about to need. It is effective, but *reactive* by construction — the first read of a file is what fires it, so it can only help the second and later reads.
+
+For a **sliding-window** workload, the first read is the only one that misses.
+
+A dashboard querying `[now - W, now]` on a refresh interval `R` re-reads the same window every `R`. Two consequences:
+
+- The window's files are read `W/R` times, and every read after the first finds them cached.
+- The window **slides**: each interval, newly written files enter it and files older than `W` leave.
+
+So the only cold footer reads are files written since the last refresh. A read-triggered prefetch cannot help them, because for those files the triggering read *is* the cold read.
+
+This is a common shape for observability and analytics stacks: a columnar store where ingesters continuously write parquet and a dashboard repeatedly queries recent data. When the same TAG cluster proxies both the writes and the reads, the write is an exact predictor of the read.
+
+### Why not the alternatives
+
+Other prediction signals were considered:
+
+| Approach | Cost to predict | Precision |
+| --- | --- | --- |
+| Parse the writer's catalog/manifest files | Manifests can reach tens of MB and are rewritten continuously; parsing lands on the serve path | Bounded by query-side file pruning TAG cannot observe |
+| Prefix `LIST` of adjacent partitions | One request per partition | Requires the query's time extent, which TAG does not know |
+| Adjacent-partition heuristic on read | none | Same extent problem |
+| **Warm footer on write** | **none — TAG already has the object** | **Exact, whenever readers follow writers** |
+
+Manifest parsing initially looks attractive: a catalog entry typically carries both the object key and its size, which is what is needed to locate a trailer. But manifests describe far more than any single query reads, so TAG would have to guess which entries matter — and the file pruning that narrows them happens on the query side, using predicates TAG never sees. Write-time warming needs no prediction at all.
+
+## Goals
+
+- Eliminate cold footer reads for objects written while a reader is active.
+- Reuse the existing footer-prefetch machinery rather than adding a parallel path.
+- Cost proportional to metadata size, not object size.
+- Precision measurable from day one, on the same metrics as the read-triggered trigger.
+- Off by default; shares the existing `cache.parquet_optimization` gate.
+
+## Non-goals
+
+- Warming whole objects. `cache.warm_on_write` already does that, and for large parquet files it moves two orders of magnitude more bytes than the metadata alone.
+- Helping ad-hoc queries over data older than any recent write. Those still rely on the read-triggered prefetch from #174; a future RFC may add read-side adjacency prediction for them.
+- Any change to the read path. This adds a trigger, not a serve mode.
+
+## Background: what a footer costs
+
+Parquet stores its metadata at the **end** of the object: the last 8 bytes are a 4-byte little-endian metadata length followed by the `PAR1` magic, with the metadata occupying the length bytes immediately before them. A reader cannot read any data before it reads that metadata.
+
+Footer size scales with the number of row groups and columns, because the footer carries per-row-group, per-column statistics. For wide schemas it is a meaningful fraction of the object rather than a fixed small tail.
+
+Measured on a production deployment with a wide schema (hundreds of columns), footers ran at roughly **1.25% of object size** — a few MB on objects of a few hundred MB. Against a 1 MiB `block_size` that metadata spans several blocks, so a reader opening such a file finds several blocks absent.
+
+Two implications for sizing:
+
+- Warming metadata costs on the order of 1% of what warming whole objects costs.
+- The relevant comparison for "does the metadata fit the cached tail block?" is not `block_size` but the **remainder** block, `ContentLength mod block_size`, which averages half a block. Metadata exceeds it far more often than a naive `footer > block_size` test would suggest.
+
+Deployments with narrow schemas will see much smaller footers and should expect this optimization to do correspondingly less; the histogram below is how to tell.
+
+## Design
+
+### Trigger
+
+On a successful write of a key ending in `.parquet` — `PutObject`, `CompleteMultipartUpload`, and the copy path — schedule a background footer warm. Gated on `cache.parquet_optimization` and on block caching being enabled.
+
+The trigger fires **after** the client's write response is committed, so it adds no latency to the write.
+
+### Establishing the entry
+
+At write time TAG has no cached metadata for the object, so unlike the read-triggered path there is no `meta` to start from. A single ranged request supplies everything:
+
+```
+GET <object>   Range: bytes=-8
+```
+
+The `206` response yields all three required inputs at once:
+
+- **body** — the 8-byte trailer, parsed for the metadata length
+- **`Content-Range: bytes X-Y/Z`** — `Z` is the object size, so no `HEAD` is needed
+- **`ETag`** — keys the blocks and the meta entry
+
+The **suffix** form is deliberate: it requires no prior knowledge of the object's size. That is the property that lets this run for an object TAG has never seen, without a second round trip and without consulting the writer's catalog.
+
+The returned interval is validated to be exactly the object's last 8 bytes before any block index is derived from it. A server that answers a different interval — or ignores the range and returns `200` — is rejected; in the `200` case the body is closed **without** draining, since draining a whole object for connection reuse is precisely the cost this design exists to avoid.
+
+### Populating
+
+With `ContentLength`, `ETag` and the metadata length in hand, the covering block range is computed as in #174 and handed to the existing block-mode populate path, which fetches those blocks and writes the block-mode meta **last**, tombstone-aware. That ordering is the visibility gate from RFC 0001 and is preserved unchanged.
+
+Objects whose metadata fits inside the tail block warm that one block, which is their entire footer.
+
+### Bounds
+
+Inherited from #174 rather than reinvented:
+
+- Capped at a fixed maximum block count; blocks already cached are skipped.
+- Coalesced per object, so a retried or duplicated write warms once.
+- Fetches take the populate budget **non-blocking**, so warming is shed rather than queued when real reads are contending. Under load, serving wins.
+- A malformed or non-parquet trailer aborts the warm silently: a `.parquet` suffix is a hint, not a guarantee.
+- Anonymous writes are skipped — a public write implies nothing about read access.
+
+### Interaction with eviction
+
+Where the query window slides, objects older than the window stop being read. A FIFO eviction policy ages out oldest-first, which matches that access pattern. Under LRU the warmed-but-unread tail is reclaimed on pressure instead; either way an unused warm is bounded by the cache, not permanent.
+
+## Metrics
+
+No new metric families. The counters from #174 are already labeled by trigger:
+
+- `tag_cache_block_prefetched_total{trigger="write_warm"}` — blocks warmed at write time
+- `tag_cache_block_prefetch_used_total` — those later served from cache
+- `tag_cache_parquet_footer_bytes` — the footer-size distribution, which is how a deployment tells whether its schema makes this worthwhile at all
+
+Precision is `used / prefetched`, counted per **block** rather than per read, cleared atomically, and expiring — so the ratio is a **floor**, never an inflated claim.
+
+The decision rule is explicit: **compare `write_warm` precision against `parquet_footer` precision.** If it is materially lower, readers are not following writers in this deployment and the trigger should be turned off. The metric decides, not the argument in this document.
+
+## Rollout
+
+1. Ship behind `cache.parquet_optimization`, shared with #174.
+2. Compare `prefetched{trigger="write_warm"}` against `prefetch_used_total`, and watch block miss rate on first opens.
+3. If precision holds, cold-footer reads should approach zero while a reader is active.
+
+Reverting is a configuration change, not a rollback: clearing the flag disables both triggers.
+
+## Alternatives considered
+
+**Warm the whole object** (`cache.warm_on_write`). Already exists, and moves roughly 80× more bytes for the same benefit on a footer-driven workload. Rejected on cost.
+
+**Parse the writer's catalog/manifest.** Would give every object's key and size without extra requests. Rejected because manifests are large, rewritten continuously, describe far more than any query reads, and would put parsing on the serve path — while write-time warming needs no prediction at all. It also couples TAG to one writer's catalog format, where the suffix-range approach depends only on the parquet spec.
+
+**Tee the footer out of the upload body.** For multipart uploads the final part contains the trailer, so TAG could capture it without a second request. Rejected for phase 1: it couples the warm path to multipart internals and to whether the client uses multipart, to save one small ranged GET per object. Worth revisiting if that request ever shows up in the write-path budget.
+
+**Read-triggered adjacent-partition prefetch.** Complementary rather than competing: it is the answer for ad-hoc queries over older data, where no recent write predicts the read. Left for a later RFC.

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -1493,21 +1493,32 @@ func (s *Service) triggerBlockModePopulate(bucket, key, accessKey, secretKey str
 			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block-mode populate skipped - block fetch failed")
 			return
 		}
-		// Re-check that no entry was established concurrently before stamping block-mode meta.
-		// The schedule-time !found gate can go stale during the block fetch above: a racing
-		// full-GET miss may have whole-cached the object. Overwriting that with block-mode meta
-		// would demote a complete whole-mode entry to a partial one, so back off and let it win
-		// (the touched blocks we fetched are harmless orphans that age out).
-		if _, found, _ := s.cache.GetMeta(ctx, bucket, key); found {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Block-mode meta write skipped - entry established concurrently")
-			return
-		}
-		ttl := int(s.config.Cache.TTL.Seconds())
-		wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime)
-		if err != nil || !wrote {
-			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Bool("wrote", wrote).Msg("Block-mode meta not written (tombstone or error)")
-			return
-		}
-		log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", len(touched)).Int64("block_size", meta.BlockSize).Msg("Block-mode entry populated")
+		s.finalizeBlockModeMeta(ctx, bucket, key, meta, len(touched), writeStartTime)
 	}()
+}
+
+// finalizeBlockModeMeta stamps the block-mode meta once its blocks have landed — the
+// "blocks first, meta last" visibility gate from RFC 0001. Split out so callers that
+// need to act between the two steps (write-time footer warming records per-block
+// attribution there) share this logic instead of re-deriving its race handling.
+//
+// writeStartTime must be stamped BEFORE the blocks were fetched, so an invalidation
+// landing mid-populate is newer and blocks the meta write.
+func (s *Service) finalizeBlockModeMeta(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, blockCount int, writeStartTime int64) {
+	// Re-check that no entry was established concurrently before stamping block-mode meta.
+	// The schedule-time !found gate can go stale during the block fetch: a racing
+	// full-GET miss may have whole-cached the object. Overwriting that with block-mode meta
+	// would demote a complete whole-mode entry to a partial one, so back off and let it win
+	// (the blocks we fetched are keyed by ETag, so a matching entry still resolves them).
+	if _, found, _ := s.cache.GetMeta(ctx, bucket, key); found {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Block-mode meta write skipped - entry established concurrently")
+		return
+	}
+	ttl := int(s.config.Cache.TTL.Seconds())
+	wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime)
+	if err != nil || !wrote {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Bool("wrote", wrote).Msg("Block-mode meta not written (tombstone or error)")
+		return
+	}
+	log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", blockCount).Int64("block_size", meta.BlockSize).Msg("Block-mode entry populated")
 }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -310,16 +311,36 @@ func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey stri
 	if len(blocks) == 0 {
 		return
 	}
-	// Counted as requested rather than as landed: triggerBlockModePopulate reports
-	// asynchronously, and over-counting the denominator understates precision, which
-	// is the safe direction for a number used to decide whether to keep this on.
+	// The shared populate path refuses a fan-out above this, and a silent refusal
+	// after the counters had already moved would report warms that never happened.
+	// Check it here so the skip is explicit and unmeasured.
+	if int64(len(blocks)) > maxRangeBlockFanout {
+		log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", len(blocks)).
+			Msg("Parquet footer warm skipped - metadata spans more blocks than the populate fan-out allows")
+		return
+	}
+
+	// Stamp before fetching so an invalidation landing mid-warm is newer and blocks
+	// the meta write below.
+	writeStartTime := time.Now().UnixNano()
+	if err := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, blocks); err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm - block fetch failed")
+		return
+	}
+
+	// Counted only once the blocks are actually cached. Counting at schedule time
+	// would credit a warm that never landed: the blocks would still be recorded for
+	// attribution, so a later read that fetched them itself would be scored as a
+	// prefetch hit and INFLATE precision -- in a metric whose whole job is to decide
+	// whether this trigger earns its keep.
 	for _, idx := range blocks {
 		metrics.CacheBlockPrefetched.WithLabelValues("write_warm").Inc()
 		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx)
 	}
-	// Fetches the blocks and writes the block-mode meta LAST, tombstone-aware -- the
-	// visibility gate from RFC 0001. Nothing here bypasses that ordering.
-	s.triggerBlockModePopulate(bucket, key, accessKey, secretKey, meta, blocks)
+
+	// Meta last, tombstone-aware -- the RFC 0001 visibility gate. Blocks stay useful
+	// even if this backs off, since they are keyed by ETag.
+	s.finalizeBlockModeMeta(ctx, bucket, key, meta, len(blocks), writeStartTime)
 }
 
 // readParquetTrailerFromUpstream fetches the object's last 8 bytes. A suffix range is

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -3,6 +3,9 @@ package proxy
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -25,10 +28,12 @@ import (
 // ContentLength mod block_size, averaging half a block. So the prefetch is needed
 // whenever footer+8 exceeds that remainder, not merely when it exceeds block_size.
 //
-// Measured on the ORD parseable bucket (26 objects, two days): footers run ~1.25%
-// of object size -- 3.0 MB at 244 MB, 4.7 MB at 394 MB -- so against 1 MiB blocks
-// the metadata spans 3-5 blocks and this fires on ~69% of objects. Only the small
-// (<2 MB) files, whose footers are 20-50 KB, fit in the remainder.
+// Footer size scales with row groups and columns, since it carries per-column
+// statistics. Measured on a production deployment with a wide schema, footers ran
+// ~1.25% of object size -- several MB on a few-hundred-MB object -- so at a 1 MiB
+// block_size the metadata spans several blocks and this fires on most objects.
+// Narrow schemas produce much smaller footers; tag_cache_parquet_footer_bytes is
+// how a deployment tells which case it is in.
 //
 // It fetches only blocks the metadata provably spans, computed from the length the
 // file itself declares, so speculation is bounded by the object, not by a guess.
@@ -239,4 +244,161 @@ func (s *Service) noteAssembledPrefetchHits(bucket, key string, meta *cache.Cach
 		}
 		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 	}
+}
+
+// Write-time footer warming (RFC 0002).
+//
+// The read-triggered prefetch above can only help a file's SECOND read: the first
+// one is what fires it. Under a sliding-window reader -- a dashboard querying
+// [now-1h, now] on a refresh timer -- that is the only read that ever misses,
+// because every later refresh finds the window already warm. So the remaining
+// cold reads are exactly the files written since the last refresh.
+//
+// TAG proxies those writes, so it can warm them before the first query rather than
+// during it. A just-written file is inside the window by definition; this schedules
+// a fetch rather than guessing at one.
+
+// warmParquetFooterOnWrite caches a freshly written parquet object's metadata blocks.
+// It returns immediately; the work runs detached, after the client's write response
+// has already been committed.
+func (s *Service) warmParquetFooterOnWrite(r *http.Request, bucket, key string) {
+	if s.config == nil || !s.config.Cache.ParquetOptimization || !s.cache.IsEnabled() {
+		return
+	}
+	if !s.config.Cache.IsBlockCachingEnabled() || s.config.Cache.BlockSize <= 0 {
+		return
+	}
+	if !isParquetKey(key) {
+		return
+	}
+	// Warming reads the object back, so it needs credentials that can read it. An
+	// anonymous write tells us nothing about read access, so skip rather than guess.
+	_, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil || accessKey == "" || secretKey == "" {
+		return
+	}
+
+	// One warm per object version in flight, reusing the read-path coalescer: a
+	// retried CompleteMultipartUpload must not warm twice.
+	dedupKey := "pqw:" + bucket + "/" + key
+	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer s.activeBackgroundFetches.Delete(dedupKey)
+		s.warmParquetFooterBlocks(bucket, key, accessKey, secretKey)
+	}()
+}
+
+// warmParquetFooterBlocks resolves the object's size, ETag and metadata length with a
+// single suffix-range read, then populates the blocks the metadata spans.
+func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey string) {
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
+
+	meta, footerLen, ok := s.readParquetTrailerFromUpstream(ctx, bucket, key, accessKey, secretKey)
+	if !ok {
+		return
+	}
+	metrics.CacheParquetFooterBytes.Observe(float64(footerLen))
+
+	blocks := parquetFooterBlocks(meta, footerLen)
+	if len(blocks) == 0 {
+		return
+	}
+	// Counted as requested rather than as landed: triggerBlockModePopulate reports
+	// asynchronously, and over-counting the denominator understates precision, which
+	// is the safe direction for a number used to decide whether to keep this on.
+	for _, idx := range blocks {
+		metrics.CacheBlockPrefetched.WithLabelValues("write_warm").Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx)
+	}
+	// Fetches the blocks and writes the block-mode meta LAST, tombstone-aware -- the
+	// visibility gate from RFC 0001. Nothing here bypasses that ordering.
+	s.triggerBlockModePopulate(bucket, key, accessKey, secretKey, meta, blocks)
+}
+
+// readParquetTrailerFromUpstream fetches the object's last 8 bytes. A suffix range is
+// used deliberately: it needs no prior knowledge of the object's size, and the 206's
+// Content-Range reports that size back -- which is what lets this run for an object
+// TAG has never seen, without a HEAD and without consulting a manifest.
+func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, key, accessKey, secretKey string) (*cache.CachedObjectMeta, int64, bool) {
+	resp, err := s.forwarder.DoConditionalGetRequest(ctx, bucket, key, accessKey, secretKey, "", 0,
+		fmt.Sprintf("bytes=-%d", parquetTrailerSize))
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm - trailer read failed")
+		return nil, 0, false
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		// The range was ignored and the whole object is coming. Close WITHOUT
+		// draining: draining for connection reuse would pull hundreds of MB through
+		// the warm path, which is the exact cost the suffix range exists to avoid.
+		_ = resp.Body.Close()
+		return nil, 0, false
+	}
+	defer func() {
+		// A valid 206 here is 8 bytes and is fully consumed below, so this drains
+		// nothing in the normal case. Bounded anyway: an over-long body must not be
+		// read to EOF just to make the connection reusable.
+		_, _ = io.CopyN(io.Discard, resp.Body, parquetTrailerSize)
+		_ = resp.Body.Close()
+	}()
+
+	// Trust the interval, not just the total: derive block indices only from a range
+	// that really is the object's last parquetTrailerSize bytes. A server that
+	// answered a different interval would otherwise have its bytes parsed as a
+	// trailer.
+	first, last, contentLength, hasBounds := parseContentRange(resp.Header.Get("Content-Range"))
+	if !hasBounds || contentLength <= parquetTrailerSize {
+		return nil, 0, false
+	}
+	if first != contentLength-parquetTrailerSize || last != contentLength-1 {
+		log.Debug().Str("bucket", bucket).Str("key", key).
+			Str("content_range", resp.Header.Get("Content-Range")).
+			Msg("Parquet footer warm - upstream answered a different interval than the suffix range")
+		return nil, 0, false
+	}
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		// The ETag keys every block and the meta entry; without it nothing can be stored.
+		return nil, 0, false
+	}
+	if !s.isBlockEligibleSize(contentLength) {
+		// Sub-block objects are whole-cached, and their footer is the whole object.
+		return nil, 0, false
+	}
+
+	buf := make([]byte, parquetTrailerSize)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		return nil, 0, false
+	}
+	footerLen, valid := parseParquetTrailer(buf, contentLength)
+	if !valid {
+		// A ".parquet" suffix is a hint, not a guarantee.
+		return nil, 0, false
+	}
+
+	return &cache.CachedObjectMeta{
+		ETag:          etag,
+		BlockSize:     s.config.Cache.BlockSize,
+		ContentLength: contentLength,
+	}, footerLen, true
+}
+
+// parquetFooterBlocks returns the block indices the metadata region spans, including
+// the tail block. Empty when the object is degenerate.
+func parquetFooterBlocks(meta *cache.CachedObjectMeta, footerLen int64) []int64 {
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	firstBlock := (meta.ContentLength - parquetTrailerSize - footerLen) / meta.BlockSize
+	if firstBlock < 0 {
+		firstBlock = 0
+	}
+	if tailBlock-firstBlock+1 > maxParquetFooterPrefetchBlocks {
+		firstBlock = tailBlock - maxParquetFooterPrefetchBlocks + 1
+	}
+	blocks := make([]int64, 0, tailBlock-firstBlock+1)
+	for i := firstBlock; i <= tailBlock; i++ {
+		blocks = append(blocks, i)
+	}
+	return blocks
 }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -392,6 +392,13 @@ func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, ke
 		// Sub-block objects are whole-cached, and their footer is the whole object.
 		return nil, 0, false
 	}
+	// Same gate every other populate path applies: an object the client marked
+	// no-store/private, or one over the size threshold, must not be cached here
+	// either. Built from the response headers so Cache-Control is actually seen.
+	if probe := s.buildBlockMeta(bucket, key, resp.Header, contentLength); !probe.IsCacheable(s.config.Cache.SizeThreshold) {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm skipped - object is not cacheable")
+		return nil, 0, false
+	}
 
 	buf := make([]byte, parquetTrailerSize)
 	if _, err := io.ReadFull(resp.Body, buf); err != nil {

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -278,8 +278,12 @@ func (s *Service) warmParquetFooterOnWrite(r *http.Request, bucket, key string) 
 		return
 	}
 
-	// One warm per object version in flight, reusing the read-path coalescer: a
-	// retried CompleteMultipartUpload must not warm twice.
+	// One warm per object in flight, reusing the read-path coalescer, so a retried
+	// CompleteMultipartUpload does not warm twice. Deliberately NOT keyed by version:
+	// the ETag is only learned from the trailer read below, so it cannot be in the
+	// key. A second write landing mid-warm is therefore skipped, and that version is
+	// warmed by the read-triggered path on its first read instead -- one cold read,
+	// not a permanent gap.
 	dedupKey := "pqw:" + bucket + "/" + key
 	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
 		return
@@ -378,11 +382,11 @@ func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, ke
 		return nil, 0, false
 	}
 
-	return &cache.CachedObjectMeta{
-		ETag:          etag,
-		BlockSize:     s.config.Cache.BlockSize,
-		ContentLength: contentLength,
-	}, footerLen, true
+	// Build the entry the same way the range path does, from the 206's headers.
+	// A hand-rolled struct would omit StatusCode -- and this meta is the visibility
+	// gate, so a later HEAD hit would call WriteHeader(0) and panic net/http -- as
+	// well as Content-Type, Last-Modified and user metadata that clients expect.
+	return s.buildBlockMeta(bucket, key, resp.Header, contentLength), footerLen, true
 }
 
 // parquetFooterBlocks returns the block indices the metadata region spans, including

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -433,3 +433,204 @@ func newParquetTestService(t *testing.T, content []byte, blockSize int64) *Servi
 	}
 	return s
 }
+
+// The block set must cover the whole metadata region through the tail, and stay
+// bounded when a declared footer length is pathological.
+func TestParquetFooterBlocks(t *testing.T) {
+	const blockSize = 1024
+	t.Run("spans metadata through the tail", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 6 * blockSize}
+		// metadata starts at 6144-8-2644 = 3492, inside block 3; tail is block 5.
+		got := parquetFooterBlocks(meta, 2644)
+		if !slices.Equal(got, []int64{3, 4, 5}) {
+			t.Fatalf("blocks = %v, want [3 4 5]", got)
+		}
+	})
+
+	t.Run("footer inside the tail block is just that block", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 6 * blockSize}
+		if got := parquetFooterBlocks(meta, 100); !slices.Equal(got, []int64{5}) {
+			t.Fatalf("blocks = %v, want [5]", got)
+		}
+	})
+
+	t.Run("stays bounded for a pathological footer", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 5000 * blockSize}
+		got := parquetFooterBlocks(meta, 4000*blockSize)
+		if len(got) != maxParquetFooterPrefetchBlocks {
+			t.Fatalf("blocks = %d, want the %d cap", len(got), maxParquetFooterPrefetchBlocks)
+		}
+		if got[len(got)-1] != 4999 {
+			t.Fatalf("last block = %d, want the tail block 4999", got[len(got)-1])
+		}
+	})
+}
+
+// suffixRangeForwarder answers a bytes=-8 suffix range the way S3 does: 206 with
+// Content-Range reporting the total size, which is what lets the warm path run for
+// an object TAG has never seen.
+type suffixRangeForwarder struct {
+	mockForwarder
+	body   []byte
+	etag   string
+	status int
+
+	mu     sync.Mutex
+	ranges []string
+}
+
+func (f *suffixRangeForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
+	f.mu.Lock()
+	f.ranges = append(f.ranges, rangeHeader)
+	f.mu.Unlock()
+
+	total := int64(len(f.body))
+	var n int64 = parquetTrailerSize
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=-%d", &n); err != nil {
+		return nil, fmt.Errorf("unexpected range %q", rangeHeader)
+	}
+	chunk := f.body[total-n:]
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", total-n, total-1, total))
+	if f.etag != "" {
+		header.Set("ETag", f.etag)
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusPartialContent
+	}
+	return &http.Response{
+		StatusCode:    status,
+		ContentLength: int64(len(chunk)),
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(chunk)),
+	}, nil
+}
+
+func newWarmTestService(t *testing.T, body []byte, etag string, status int) (*Service, *suffixRangeForwarder) {
+	t.Helper()
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = 1024
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &suffixRangeForwarder{body: body, etag: etag, status: status}
+	return NewService(fwd, store, cfg), fwd
+}
+
+func warmTestObject(footerLen int64) []byte {
+	const blockSize, blocks = 1024, 6
+	body := make([]byte, blockSize*blocks)
+	binary.LittleEndian.PutUint32(body[len(body)-parquetTrailerSize:], uint32(footerLen))
+	copy(body[len(body)-4:], parquetMagic)
+	return body
+}
+
+// The whole point: an object TAG has never seen resolves its size, ETag and footer
+// length from ONE suffix-range read -- no HEAD, no manifest, no cached metadata.
+func TestReadParquetTrailerFromUpstream(t *testing.T) {
+	t.Run("resolves size, etag and footer length", func(t *testing.T) {
+		body := warmTestObject(2644)
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+
+		meta, footerLen, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk")
+		if !ok {
+			t.Fatal("trailer read failed")
+		}
+		if meta.ContentLength != int64(len(body)) || meta.ETag != `"v1"` || footerLen != 2644 {
+			t.Fatalf("meta = %+v footerLen=%d, want len=%d etag=\"v1\" footer=2644", meta, footerLen, len(body))
+		}
+		if got := fwd.ranges; !slices.Equal(got, []string{"bytes=-8"}) {
+			t.Fatalf("upstream ranges = %v, want one suffix range", got)
+		}
+	})
+
+	t.Run("rejects a 200 rather than draining a whole object", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, http.StatusOK)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted a 200 - the range was ignored and the body is the whole object")
+		}
+	})
+
+	t.Run("rejects a missing ETag", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), "", 0)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted an object with no ETag - nothing could be keyed")
+		}
+	})
+
+	t.Run("rejects an interval that is not the object tail", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
+		s.forwarder = &wrongIntervalForwarder{body: warmTestObject(2644), etag: `"v1"`}
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted bytes from an interval other than the object's last 8")
+		}
+	})
+
+	t.Run("rejects a non-parquet trailer", func(t *testing.T) {
+		body := warmTestObject(2644)
+		copy(body[len(body)-4:], "XXXX")
+		s, _ := newWarmTestService(t, body, `"v1"`, 0)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted a key that merely ends in .parquet")
+		}
+	})
+}
+
+// The trigger must stay off unless the optimization is on and the key is parquet,
+// and must not fire twice for a retried write.
+func TestWarmParquetFooterOnWrite_Gating(t *testing.T) {
+	body := warmTestObject(2644)
+
+	t.Run("disabled does nothing", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.config.Cache.ParquetOptimization = false
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.parquet", nil), "b", "a.parquet")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v with the optimization off", fwd.ranges)
+		}
+	})
+
+	t.Run("non-parquet key does nothing", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.json", nil), "b", "a.json")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v for a non-parquet key", fwd.ranges)
+		}
+	})
+
+	t.Run("a retried write coalesces", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.activeBackgroundFetches.Store("pqw:b/a.parquet", struct{}{})
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.parquet", nil), "b", "a.parquet")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v while another warm was in flight", fwd.ranges)
+		}
+		if _, ok := s.activeBackgroundFetches.Load("pqw:b/a.parquet"); !ok {
+			t.Fatal("coalesced trigger cleared the marker owned by the in-flight warm")
+		}
+	})
+}
+
+// wrongIntervalForwarder answers the suffix range with trailer-shaped bytes taken
+// from the WRONG interval, and reports that interval honestly in Content-Range.
+// Block indices are derived from these bounds, so they must be checked.
+type wrongIntervalForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+}
+
+func (f *wrongIntervalForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, _ string) (*http.Response, error) {
+	total := int64(len(f.body))
+	header := make(http.Header)
+	// Valid trailer bytes, but from the middle of the object rather than its tail.
+	header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", parquetTrailerSize-1, total))
+	header.Set("ETag", f.etag)
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: parquetTrailerSize,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(f.body[total-parquetTrailerSize:])),
+	}, nil
+}

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -559,6 +559,25 @@ func TestReadParquetTrailerFromUpstream(t *testing.T) {
 		}
 	})
 
+	// The warm meta is the visibility gate for the entry, so it must be a complete
+	// object meta -- not just the three fields the block maths needs. A zero
+	// StatusCode reaches WriteHeader on a later HEAD hit and panics net/http.
+	t.Run("builds a complete object meta", func(t *testing.T) {
+		body := warmTestObject(2644)
+		s, _ := newWarmTestService(t, body, `"v1"`, 0)
+
+		meta, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk")
+		if !ok {
+			t.Fatal("trailer read failed")
+		}
+		if meta.StatusCode < 100 || meta.StatusCode > 999 {
+			t.Fatalf("StatusCode = %d, which panics net/http at WriteHeader", meta.StatusCode)
+		}
+		if meta.Bucket != "b" || meta.Key != "a.parquet" {
+			t.Fatalf("meta identity = %q/%q, want b/a.parquet", meta.Bucket, meta.Key)
+		}
+	})
+
 	t.Run("rejects an interval that is not the object tail", func(t *testing.T) {
 		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
 		s.forwarder = &wrongIntervalForwarder{body: warmTestObject(2644), etag: `"v1"`}

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -586,6 +586,15 @@ func TestReadParquetTrailerFromUpstream(t *testing.T) {
 		}
 	})
 
+	// Every other populate path refuses these; this one must too.
+	t.Run("rejects an object the client marked uncacheable", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
+		s.forwarder = &noStoreForwarder{body: warmTestObject(2644), etag: `"v1"`}
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("warmed an object marked Cache-Control: no-store")
+		}
+	})
+
 	t.Run("rejects a non-parquet trailer", func(t *testing.T) {
 		body := warmTestObject(2644)
 		copy(body[len(body)-4:], "XXXX")
@@ -646,6 +655,28 @@ func (f *wrongIntervalForwarder) DoConditionalGetRequest(_ context.Context, _, _
 	// Valid trailer bytes, but from the middle of the object rather than its tail.
 	header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", parquetTrailerSize-1, total))
 	header.Set("ETag", f.etag)
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: parquetTrailerSize,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(f.body[total-parquetTrailerSize:])),
+	}, nil
+}
+
+// noStoreForwarder answers the suffix range for an object the client marked
+// uncacheable, which every populate path is required to refuse.
+type noStoreForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+}
+
+func (f *noStoreForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, _ string) (*http.Response, error) {
+	total := int64(len(f.body))
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", total-parquetTrailerSize, total-1, total))
+	header.Set("ETag", f.etag)
+	header.Set("Cache-Control", "no-store")
 	return &http.Response{
 		StatusCode:    http.StatusPartialContent,
 		ContentLength: parquetTrailerSize,

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -534,6 +534,9 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 		if !teeHandled {
 			s.warmOnWrite(r, bucket, key)
 		}
+		// Independent of warmOnWrite: that caches whole objects and is off here,
+		// while this caches only the metadata region (RFC 0002).
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 	// Forward errored or upstream rejected the write: nothing cached, so release any budget
 	// reserved for the tee.
@@ -683,6 +686,7 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	if err == nil && s3WriteSucceeded(capture) && s.cache.IsEnabled() {
 		s.invalidateObject(context.Background(), bucket, key)
 		s.warmOnWrite(r, bucket, key)
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 
 	return err
@@ -835,6 +839,9 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 		// Warm-on-write is the only way to make a multipart-completed object hot:
 		// TAG never sees its assembled body, so a write-through tee is impossible.
 		s.warmOnWrite(r, bucket, key)
+		// The path that matters for parquet: ingestors write via multipart, so this
+		// is where a freshly written file's metadata gets warmed (RFC 0002).
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 
 	// Cache successful completions in ocache for idempotent replays. Only cache a


### PR DESCRIPTION
Implements [RFC 0002](docs/rfcs/0002-parquet-footer-warming.md). Adds a second trigger under the existing `cache.parquet_optimization` flag: cache a parquet object's metadata blocks when TAG proxies the **write**, instead of waiting for a reader to miss them.

## Why the read-triggered prefetch isn't enough

The prefetch added in #174 is reactive by construction — the first read of a file is what fires it, so it can only help the second and later reads. For a **sliding-window** reader, the first read is the only one that misses.

A dashboard querying `[now - W, now]` every `R` re-reads the same window, so:

- The window's files are read `W/R` times, and every read after the first finds them cached.
- The window **slides**: each interval, newly written files enter it and old ones leave.

So the only cold footer reads are files written since the last refresh — and a read-triggered prefetch cannot help those, because for them the triggering read *is* the cold read.

This is a common shape wherever ingesters continuously write parquet and a dashboard queries recent data through the same cache. When one TAG cluster proxies both sides, **the write is an exact predictor of the read**.

## How it works

One suffix-range read supplies everything:

```
GET <object>   Range: bytes=-8
```

| From | Gives |
| --- | --- |
| body | the 8-byte trailer → metadata length |
| `Content-Range: bytes X-Y/Z` | `Z`, the object size — no `HEAD` needed |
| `ETag` header | keys the blocks and the meta entry |

The **suffix** form is the point: it needs no prior knowledge of the object's size. That is what lets this run for an object TAG has never seen, without a second round trip and without coupling TAG to any writer's catalog format.

Blocks are then populated through the existing block-mode path, so the RFC 0001 ordering is untouched: **blocks first, tombstone-aware meta last** as the visibility gate.

## Bounds — inherited, not reinvented

- Block-count cap; blocks already cached are skipped.
- Coalesced per object, so a retried `CompleteMultipartUpload` warms once.
- Populate budget taken **non-blocking** — warming sheds rather than queues when real reads contend.
- Fires after the client's write response is committed, so it adds no write latency.
- Anonymous writes skipped (a public write implies nothing about read access).
- A `.parquet` suffix is a hint, not a guarantee — a bad trailer aborts silently.

## Why not `warm_on_write`

It already exists and caches **whole objects**. Footers are a small fraction of object size — on a wide-schema deployment, measured around 1.25% — so this moves roughly 1% of the bytes for the benefit that actually matters here.

## Measurement is the decision rule

No new metric families. Reuses `tag_cache_block_prefetched_total{trigger="write_warm"}` against `tag_cache_block_prefetch_used_total`, so precision is directly comparable to `parquet_footer`'s.

If `write_warm` precision comes in materially lower, readers aren't following writers in that deployment and the trigger should be turned off. That's the stated rule in the RFC — the metric decides, not the argument.

`tag_cache_parquet_footer_bytes` is how a deployment tells whether its schema makes any of this worthwhile: a wide schema puts several MB of metadata on a large object, a narrow one keeps it inside the tail block where there is nothing to prefetch.

## Review fixes

Both bots caught a real bug and I'd documented the opposite of what the code did:

- **Non-206 drained the full body.** The deferred `io.Copy(io.Discard, ...)` ran on the `200` early-return too, so a server ignoring the range pulled the entire object through the warm path — exactly the cost the suffix range exists to avoid, and the opposite of what the comment claimed. Now the `200` path closes **without** draining, and the `206` drain is bounded.
- **Range interval unvalidated.** Only the total was checked, so bytes from a different interval could have been parsed as a trailer and used to derive block indices. Now the interval must be exactly `[total-8, total-1]`, with a regression test that feeds trailer-shaped bytes from the wrong offset.
- Reused the existing `parseContentRange` from `service.go` rather than adding a second parser.

## Testing

`parquetFooterBlocks` (spans metadata through the tail, footer-inside-tail, pathological-footer cap), `readParquetTrailerFromUpstream` (resolves size/ETag/footer from one suffix range; rejects a `200`, a missing ETag, a wrong interval, and a non-parquet trailer), and trigger gating (disabled, non-parquet key, retried write coalesces).

`make test` green across all packages; `make lint` clean; `-race` clean.

## Rollout

Off by default. Where `cache.parquet_optimization` is already enabled for #174, merging and deploying turns this on too — worth watching `write_warm` precision against `parquet_footer` for the first hour. Reverting is a config change, not a rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache populate and successful write paths (PUT, copy, multipart complete) and issues extra ranged GETs with write credentials. Gated, off by default, and does not change the serve path.
> 
> **Overview**
> Adds a **write-time** parquet footer warm (RFC 0002) under the existing `cache.parquet_optimization` flag, so metadata blocks are cached when TAG proxies the upload instead of only after a reader misses.
> 
> After a successful `PutObject`, copy, or `CompleteMultipartUpload`, a detached job issues one suffix-range GET (`bytes=-8`) to learn size, ETag, and footer length, then populates the spanning blocks through the existing block-mode path. Work runs after the client response, coalesces per key, skips anonymous writes, and does not drain a `200` that ignored the range.
> 
> Prefetch counters now distinguish `write_warm` vs `parquet_footer`. Block-mode meta stamping is shared via `finalizeBlockModeMeta` so warming can attribute blocks before the RFC 0001 visibility gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fed8cc39af396ee4a691d4784c5dc836ab3282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->