### PR TITLE
feat(cache): cache object metadata on write

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -212,6 +212,14 @@ type CacheConfig struct {
 	// operator should opt into.
 	ParquetOptimization bool `yaml:"parquet_optimization"`
 
+	// MetaOnWrite caches an object's METADATA when TAG proxies its write, without
+	// caching the body. TAG otherwise invalidates on write and caches nothing, so
+	// the first read of a freshly written object pays an upstream round trip just to
+	// establish metadata before block mode can engage. Multipart uploads are the gap
+	// this closes: write-through already caches meta+body for a teed PutObject, but
+	// TAG never sees a multipart body and so caches nothing at all. Prototype.
+	MetaOnWrite bool `yaml:"meta_on_write"`
+
 	// CompactionBytesPerSecond bounds the shared source-read budget for ocache's
 	// background file compaction and segment recompaction (bytes/second). It
 	// protects serving reads on throughput-capped volumes: unthrottled
@@ -590,6 +598,10 @@ func applyEnvOverrides(cfg *Config) {
 		// Enable parquet-aware footer prefetching from environment.
 		if val := strings.ToLower(strings.TrimSpace(os.Getenv("TAG_CACHE_PARQUET_OPTIMIZATION"))); val != "" {
 			cfg.Cache.ParquetOptimization = val == "true" || val == "1"
+		}
+		// Enable metadata caching on write from environment.
+		if val := strings.ToLower(strings.TrimSpace(os.Getenv("TAG_CACHE_META_ON_WRITE"))); val != "" {
+			cfg.Cache.MetaOnWrite = val == "true" || val == "1"
 		}
 		// Override the compaction source-read budget from environment
 		// (bytes/second). An explicit 0 disables the throttle even when YAML

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1271,3 +1271,32 @@ func TestParquetOptimization_OverrideByEnv(t *testing.T) {
 		})
 	}
 }
+
+// TestMetaOnWrite_OverrideByEnv verifies TAG_CACHE_META_ON_WRITE plumbs metadata
+// caching on write into the cache config. It changes what a read-after-write sees,
+// so an unrecognized value must leave it off rather than guessing.
+func TestMetaOnWrite_OverrideByEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml bool
+		env  string
+		want bool
+	}{
+		{"true enables", false, "true", true},
+		{"one enables", false, "1", true},
+		{"mixed case accepted", false, "True", true},
+		{"false disables a yaml enable", true, "false", false},
+		{"garbage disables rather than guessing", true, "maybe", false},
+		{"unset leaves yaml alone", true, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TAG_CACHE_META_ON_WRITE", tc.env)
+			cfg := NewDefault()
+			cfg.Cache.MetaOnWrite = tc.yaml
+			applyEnvOverrides(cfg)
+			if cfg.Cache.MetaOnWrite != tc.want {
+				t.Errorf("Cache.MetaOnWrite = %v, want %v", cfg.Cache.MetaOnWrite, tc.want)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,14 +181,18 @@ cache:
   # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
   block_size: 1048576
 
-  # Parquet-aware footer prefetching (opt-in). A parquet reader must read the file's metadata
+  # Parquet-aware footer caching (opt-in). Drives two triggers: a read that reaches an
+  # object's trailer prefetches the rest of its metadata, and a parquet object written
+  # through TAG has its metadata warmed before the first read (RFC 0002).
+  # A parquet reader must read the file's metadata
   # before any data, and that metadata sits at the end of the object. Block caching already
   # covers metadata that fits in the tail block; this fetches the earlier blocks when it does
   # not, using the length the file itself declares rather than a guess. Costs one speculative
   # fetch per spanned block, shed under populate pressure like any other prefetch. Watch
-  # tag_cache_parquet_footer_bytes to confirm it still applies to your data:
-  # measured on production parseable data, footers run ~1.25% of object size, so a
-  # 300 MB object carries ~3.5 MB of metadata -- several blocks at a 1 MiB block_size.
+  # tag_cache_parquet_footer_bytes to see whether it applies to your data: footer
+  # size scales with row groups and columns, so a wide schema can put several MB of
+  # metadata on a few-hundred-MB object -- several blocks at a 1 MiB block_size --
+  # while a narrow schema keeps it inside the tail block and this does nothing.
   # Override with TAG_CACHE_PARQUET_OPTIMIZATION env var.
   parquet_optimization: false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_CACHE_WARM_ON_WRITE_RESERVED_FRACTION` | Fraction of the populate memory budget reserved (elastically) for warm-on-write so it isn't starved by read-miss warms (only when `warm_on_write` is on; negative disables) | `0.5` |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED`  | Enable block-aligned caching for large objects (RFC 0001): a read miss for an object at/above `block_size` is cached at block granularity (`true`/`false`) | `true`                   |
 | `TAG_CACHE_BLOCK_SIZE`             | Block granularity **and** the read-side whole-vs-block boundary (bytes): a read miss below this is whole-cached, at/above it is block-cached; must stay below ocache's 64 MB compaction threshold | `1048576` (1 MiB)        |
+| `TAG_CACHE_META_ON_WRITE`          | Cache an object's metadata (not its body) when TAG proxies its write, so the first read resolves it from cache instead of a round trip. Closes the multipart gap, where write-through cannot tee a body TAG never sees (`true`/`1`; any other value leaves it off) | `false`                  |
 | `TAG_CACHE_PARQUET_OPTIMIZATION`   | Prefetch a parquet object's metadata blocks when a read reaches its tail, so a reader opening the file does not discover the rest of the metadata as serial misses. Only fires when the metadata spans more than the tail block (`true`/`1`; any other value leaves it off) | `false`                  |
 | `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode                                         | (none)                   |
 | `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip                                                   | `:7000`                  |
@@ -180,6 +181,15 @@ cache:
   # below ocache's 64 MB compaction threshold so blocks pack into shared segments. 0/unset =
   # default (1 MiB). Override with TAG_CACHE_BLOCK_SIZE env var.
   block_size: 1048576
+
+  # Cache object METADATA on write (opt-in, prototype). TAG invalidates on write and
+  # caches nothing, so the first read of a freshly written object pays an upstream
+  # round trip purely to establish metadata before block mode can engage. Write-through
+  # already caches meta+body for a teed PutObject; this closes the multipart gap, where
+  # TAG never sees the assembled body. Metadata only -- the body stays uncached and
+  # blocks are fetched on demand, exactly as block mode already does for evicted blocks.
+  # Override with TAG_CACHE_META_ON_WRITE env var.
+  meta_on_write: false
 
   # Parquet-aware footer caching (opt-in). Drives two triggers: a read that reaches an
   # object's trailer prefetches the rest of its metadata, and a parquet object written

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -375,10 +375,17 @@ means the readers are not following writes closely, and that trigger is not payi
 
 **Type:** Histogram
 
-Size of the parquet metadata region, read from the trailer of objects served while
+Size of the parquet metadata region, read from the trailer of objects while
 `cache.parquet_optimization` is on. Recorded for **every** parquet object whose trailer is
 read, including ones that are not prefetched, so the distribution describes the whole
 population rather than just the prefetched tail of it.
+
+Note the population depends on which triggers are active. The read trigger observes objects
+as they are read; the write trigger observes them as they are written. With both on, an object
+written and later read through the same node is observed twice, and write-heavy deployments
+will weight the distribution toward recently written objects. Read it as a distribution of
+*observations*, not of distinct objects — that is what makes it useful for drift detection and
+what to keep in mind before comparing across deployments.
 
 The prefetch does work whenever `footer + 8` exceeds the **remainder** block
 (`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -361,7 +361,15 @@ precision cannot exceed 1. It is also deliberately an undercount — attribution
 bounded, TTL-expiring set, so a block served long after it was prefetched goes unattributed.
 Read the ratio as a floor.
 
-The only `trigger` today is `parquet_footer`, from `cache.parquet_optimization`.
+Both triggers come from `cache.parquet_optimization`:
+
+| `trigger` | Fires when |
+| --- | --- |
+| `parquet_footer` | A read reached a parquet object's trailer — reactive, helps the second and later reads |
+| `write_warm` | A parquet object was written through TAG — proactive, removes the first read's miss (RFC 0002) |
+
+Compare the two directly. `write_warm` precision materially below `parquet_footer` precision
+means the readers are not following writes closely, and that trigger is not paying for itself.
 
 #### tag_cache_parquet_footer_bytes
 
@@ -376,14 +384,15 @@ The prefetch does work whenever `footer + 8` exceeds the **remainder** block
 (`ContentLength mod block_size`, averaging half a block) — not merely when the footer exceeds
 `block_size`.
 
-Measured baseline on production parseable data (26 objects): footers run **~1.25% of object
-size** — 3.0 MB at 244 MB, 4.7 MB at 394 MB — so at a 1 MiB `block_size` the metadata spans
-3–5 blocks and the prefetch fires on ~69% of objects. Only small (<2 MB) files, with 20–50 KB
-footers, fit inside the remainder.
+Footer size scales with row groups and columns, since the footer carries per-column
+statistics. On a production deployment with a wide schema, footers ran **~1.25% of object
+size** — several MB on a few-hundred-MB object — so at a 1 MiB `block_size` the metadata spans
+several blocks and the prefetch does real work on most objects. A narrow schema keeps the
+footer inside the tail block, where there is nothing to prefetch.
 
-Use the histogram to confirm that ratio still holds for your data: a schema change alters
-footer size, and a distribution that collapses below the remainder-block size means the
-optimization has stopped earning its keep.
+Use the histogram to establish that ratio for your own data, and to detect drift: a schema
+change alters footer size, and a distribution that collapses below the remainder-block size
+means the optimization has stopped earning its keep.
 
 ```promql
 # Median footer size — compare against cache.block_size.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -344,16 +344,17 @@ sum(rate(tag_cache_block_prefetch_windows_total[5m]))
 
 #### tag_cache_block_prefetched_total / tag_cache_block_prefetch_used_total
 
-**Type:** Counter (`prefetched` labeled by `trigger`)
+**Type:** Counter (both labeled by `trigger`)
 
 Speculative block fetches, and how many of them were later served from cache. Together they
 give prefetch precision — the fraction of speculative work that paid for itself:
 
 ```promql
-# Prefetch precision. A low ratio means the speculation is evicting more than it
-# earns: turn the trigger off rather than tuning it.
-sum(rate(tag_cache_block_prefetch_used_total[30m])) /
-sum(rate(tag_cache_block_prefetched_total[30m]))
+# Prefetch precision, per trigger. A low ratio means that trigger is evicting more
+# than it earns: turn it off rather than tuning it. Both counters carry the label,
+# so the triggers are compared directly rather than pooled.
+sum by (trigger) (rate(tag_cache_block_prefetch_used_total[30m])) /
+sum by (trigger) (rate(tag_cache_block_prefetched_total[30m]))
 ```
 
 Attribution counts blocks, not reads: a prefetched block served many times counts once, so

--- a/docs/rfcs/0002-parquet-footer-warming.md
+++ b/docs/rfcs/0002-parquet-footer-warming.md
@@ -1,0 +1,141 @@
+# RFC 0002: Parquet footer warming on write
+
+- **Status:** Proposed
+- **Related:** [RFC 0001](0001-block-aligned-caching.md) (block-aligned caching), [#174](https://github.com/tigrisdata/tag/pull/174) (read-triggered footer prefetch)
+
+## Summary
+
+Cache a parquet object's **metadata blocks at write time**, when TAG proxies the upload, instead of waiting for a reader to discover them as misses. For a workload where writers and readers overlap — an ingest pipeline feeding a dashboard that queries a recent time window — a newly written file is read within one refresh interval. TAG already has everything it needs at write time, so this schedules a fetch rather than speculating about one.
+
+## Motivation
+
+[#174](https://github.com/tigrisdata/tag/pull/174) added a read-triggered footer prefetch: when a read reaches a parquet object's trailer, TAG fetches the metadata blocks the reader is about to need. It is effective, but *reactive* by construction — the first read of a file is what fires it, so it can only help the second and later reads.
+
+For a **sliding-window** workload, the first read is the only one that misses.
+
+A dashboard querying `[now - W, now]` on a refresh interval `R` re-reads the same window every `R`. Two consequences:
+
+- The window's files are read `W/R` times, and every read after the first finds them cached.
+- The window **slides**: each interval, newly written files enter it and files older than `W` leave.
+
+So the only cold footer reads are files written since the last refresh. A read-triggered prefetch cannot help them, because for those files the triggering read *is* the cold read.
+
+This is a common shape for observability and analytics stacks: a columnar store where ingesters continuously write parquet and a dashboard repeatedly queries recent data. When the same TAG cluster proxies both the writes and the reads, the write is an exact predictor of the read.
+
+### Why not the alternatives
+
+Other prediction signals were considered:
+
+| Approach | Cost to predict | Precision |
+| --- | --- | --- |
+| Parse the writer's catalog/manifest files | Manifests can reach tens of MB and are rewritten continuously; parsing lands on the serve path | Bounded by query-side file pruning TAG cannot observe |
+| Prefix `LIST` of adjacent partitions | One request per partition | Requires the query's time extent, which TAG does not know |
+| Adjacent-partition heuristic on read | none | Same extent problem |
+| **Warm footer on write** | **none — TAG already has the object** | **Exact, whenever readers follow writers** |
+
+Manifest parsing initially looks attractive: a catalog entry typically carries both the object key and its size, which is what is needed to locate a trailer. But manifests describe far more than any single query reads, so TAG would have to guess which entries matter — and the file pruning that narrows them happens on the query side, using predicates TAG never sees. Write-time warming needs no prediction at all.
+
+## Goals
+
+- Eliminate cold footer reads for objects written while a reader is active.
+- Reuse the existing footer-prefetch machinery rather than adding a parallel path.
+- Cost proportional to metadata size, not object size.
+- Precision measurable from day one, on the same metrics as the read-triggered trigger.
+- Off by default; shares the existing `cache.parquet_optimization` gate.
+
+## Non-goals
+
+- Warming whole objects. `cache.warm_on_write` already does that, and for large parquet files it moves two orders of magnitude more bytes than the metadata alone.
+- Helping ad-hoc queries over data older than any recent write. Those still rely on the read-triggered prefetch from #174; a future RFC may add read-side adjacency prediction for them.
+- Any change to the read path. This adds a trigger, not a serve mode.
+
+## Background: what a footer costs
+
+Parquet stores its metadata at the **end** of the object: the last 8 bytes are a 4-byte little-endian metadata length followed by the `PAR1` magic, with the metadata occupying the length bytes immediately before them. A reader cannot read any data before it reads that metadata.
+
+Footer size scales with the number of row groups and columns, because the footer carries per-row-group, per-column statistics. For wide schemas it is a meaningful fraction of the object rather than a fixed small tail.
+
+Measured on a production deployment with a wide schema (hundreds of columns), footers ran at roughly **1.25% of object size** — a few MB on objects of a few hundred MB. Against a 1 MiB `block_size` that metadata spans several blocks, so a reader opening such a file finds several blocks absent.
+
+Two implications for sizing:
+
+- Warming metadata costs on the order of 1% of what warming whole objects costs.
+- The relevant comparison for "does the metadata fit the cached tail block?" is not `block_size` but the **remainder** block, `ContentLength mod block_size`, which averages half a block. Metadata exceeds it far more often than a naive `footer > block_size` test would suggest.
+
+Deployments with narrow schemas will see much smaller footers and should expect this optimization to do correspondingly less; the histogram below is how to tell.
+
+## Design
+
+### Trigger
+
+On a successful write of a key ending in `.parquet` — `PutObject`, `CompleteMultipartUpload`, and the copy path — schedule a background footer warm. Gated on `cache.parquet_optimization` and on block caching being enabled.
+
+The trigger fires **after** the client's write response is committed, so it adds no latency to the write.
+
+### Establishing the entry
+
+At write time TAG has no cached metadata for the object, so unlike the read-triggered path there is no `meta` to start from. A single ranged request supplies everything:
+
+```
+GET <object>   Range: bytes=-8
+```
+
+The `206` response yields all three required inputs at once:
+
+- **body** — the 8-byte trailer, parsed for the metadata length
+- **`Content-Range: bytes X-Y/Z`** — `Z` is the object size, so no `HEAD` is needed
+- **`ETag`** — keys the blocks and the meta entry
+
+The **suffix** form is deliberate: it requires no prior knowledge of the object's size. That is the property that lets this run for an object TAG has never seen, without a second round trip and without consulting the writer's catalog.
+
+The returned interval is validated to be exactly the object's last 8 bytes before any block index is derived from it. A server that answers a different interval — or ignores the range and returns `200` — is rejected; in the `200` case the body is closed **without** draining, since draining a whole object for connection reuse is precisely the cost this design exists to avoid.
+
+### Populating
+
+With `ContentLength`, `ETag` and the metadata length in hand, the covering block range is computed as in #174 and handed to the existing block-mode populate path, which fetches those blocks and writes the block-mode meta **last**, tombstone-aware. That ordering is the visibility gate from RFC 0001 and is preserved unchanged.
+
+Objects whose metadata fits inside the tail block warm that one block, which is their entire footer.
+
+### Bounds
+
+Inherited from #174 rather than reinvented:
+
+- Capped at a fixed maximum block count; blocks already cached are skipped.
+- Coalesced per object, so a retried or duplicated write warms once.
+- Fetches take the populate budget **non-blocking**, so warming is shed rather than queued when real reads are contending. Under load, serving wins.
+- A malformed or non-parquet trailer aborts the warm silently: a `.parquet` suffix is a hint, not a guarantee.
+- Anonymous writes are skipped — a public write implies nothing about read access.
+
+### Interaction with eviction
+
+Where the query window slides, objects older than the window stop being read. A FIFO eviction policy ages out oldest-first, which matches that access pattern. Under LRU the warmed-but-unread tail is reclaimed on pressure instead; either way an unused warm is bounded by the cache, not permanent.
+
+## Metrics
+
+No new metric families. The counters from #174 are already labeled by trigger:
+
+- `tag_cache_block_prefetched_total{trigger="write_warm"}` — blocks warmed at write time
+- `tag_cache_block_prefetch_used_total` — those later served from cache
+- `tag_cache_parquet_footer_bytes` — the footer-size distribution, which is how a deployment tells whether its schema makes this worthwhile at all
+
+Precision is `used / prefetched`, counted per **block** rather than per read, cleared atomically, and expiring — so the ratio is a **floor**, never an inflated claim.
+
+The decision rule is explicit: **compare `write_warm` precision against `parquet_footer` precision.** If it is materially lower, readers are not following writers in this deployment and the trigger should be turned off. The metric decides, not the argument in this document.
+
+## Rollout
+
+1. Ship behind `cache.parquet_optimization`, shared with #174.
+2. Compare `prefetched{trigger="write_warm"}` against `prefetch_used_total`, and watch block miss rate on first opens.
+3. If precision holds, cold-footer reads should approach zero while a reader is active.
+
+Reverting is a configuration change, not a rollback: clearing the flag disables both triggers.
+
+## Alternatives considered
+
+**Warm the whole object** (`cache.warm_on_write`). Already exists, and moves roughly 80× more bytes for the same benefit on a footer-driven workload. Rejected on cost.
+
+**Parse the writer's catalog/manifest.** Would give every object's key and size without extra requests. Rejected because manifests are large, rewritten continuously, describe far more than any query reads, and would put parsing on the serve path — while write-time warming needs no prediction at all. It also couples TAG to one writer's catalog format, where the suffix-range approach depends only on the parquet spec.
+
+**Tee the footer out of the upload body.** For multipart uploads the final part contains the trailer, so TAG could capture it without a second request. Rejected for phase 1: it couples the warm path to multipart internals and to whether the client uses multipart, to save one small ranged GET per object. Worth revisiting if that request ever shows up in the write-path budget.
+
+**Read-triggered adjacent-partition prefetch.** Complementary rather than competing: it is the answer for ad-hoc queries over older data, where no recent write predicts the read. Left for a later RFC.

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/memberlist v0.3.1 // indirect
 	github.com/hashicorp/serf v0.9.7 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/linxGnu/grocksdb v1.10.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -306,11 +306,12 @@ var (
 		[]string{"trigger"},
 	)
 
-	CacheBlockPrefetchUsed = promauto.NewCounter(
+	CacheBlockPrefetchUsed = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "tag_cache_block_prefetch_used_total",
-			Help: "Speculatively fetched blocks that were later served from cache",
+			Help: "Speculatively fetched blocks that were later served from cache, by trigger",
 		},
+		[]string{"trigger"},
 	)
 
 	// CacheParquetFooterBytes records observed parquet metadata sizes. The

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -1493,21 +1493,32 @@ func (s *Service) triggerBlockModePopulate(bucket, key, accessKey, secretKey str
 			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Block-mode populate skipped - block fetch failed")
 			return
 		}
-		// Re-check that no entry was established concurrently before stamping block-mode meta.
-		// The schedule-time !found gate can go stale during the block fetch above: a racing
-		// full-GET miss may have whole-cached the object. Overwriting that with block-mode meta
-		// would demote a complete whole-mode entry to a partial one, so back off and let it win
-		// (the touched blocks we fetched are harmless orphans that age out).
-		if _, found, _ := s.cache.GetMeta(ctx, bucket, key); found {
-			log.Debug().Str("bucket", bucket).Str("key", key).Msg("Block-mode meta write skipped - entry established concurrently")
-			return
-		}
-		ttl := int(s.config.Cache.TTL.Seconds())
-		wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime)
-		if err != nil || !wrote {
-			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Bool("wrote", wrote).Msg("Block-mode meta not written (tombstone or error)")
-			return
-		}
-		log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", len(touched)).Int64("block_size", meta.BlockSize).Msg("Block-mode entry populated")
+		s.finalizeBlockModeMeta(ctx, bucket, key, meta, len(touched), writeStartTime)
 	}()
+}
+
+// finalizeBlockModeMeta stamps the block-mode meta once its blocks have landed — the
+// "blocks first, meta last" visibility gate from RFC 0001. Split out so callers that
+// need to act between the two steps (write-time footer warming records per-block
+// attribution there) share this logic instead of re-deriving its race handling.
+//
+// writeStartTime must be stamped BEFORE the blocks were fetched, so an invalidation
+// landing mid-populate is newer and blocks the meta write.
+func (s *Service) finalizeBlockModeMeta(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, blockCount int, writeStartTime int64) {
+	// Re-check that no entry was established concurrently before stamping block-mode meta.
+	// The schedule-time !found gate can go stale during the block fetch: a racing
+	// full-GET miss may have whole-cached the object. Overwriting that with block-mode meta
+	// would demote a complete whole-mode entry to a partial one, so back off and let it win
+	// (the blocks we fetched are keyed by ETag, so a matching entry still resolves them).
+	if _, found, _ := s.cache.GetMeta(ctx, bucket, key); found {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Block-mode meta write skipped - entry established concurrently")
+		return
+	}
+	ttl := int(s.config.Cache.TTL.Seconds())
+	wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime)
+	if err != nil || !wrote {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Bool("wrote", wrote).Msg("Block-mode meta not written (tombstone or error)")
+		return
+	}
+	log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", blockCount).Int64("block_size", meta.BlockSize).Msg("Block-mode entry populated")
 }

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -46,14 +46,13 @@ var errBlockUpstreamGone = errors.New("block upstream gone")
 // as "fall through to the miss path", not a real error.
 var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 
-// errBlockEntryHasNoBlocks is the amplify bail for an entry holding NO cached blocks
-// at all — a metadata-only entry, established on write or by a footer warm before any
-// read populated it. It wraps errBlockAssemblyWouldAmplify, so callers that only care
-// about "fall through" match it unchanged, while the full-object path can tell the two
-// apart: an entry with cached blocks may be serving stale bytes and must be
-// invalidated on bail, whereas an entry with none has no such hazard and wiping it
-// would discard the metadata later range reads are meant to reuse.
-var errBlockEntryHasNoBlocks = fmt.Errorf("%w: entry has no cached blocks", errBlockAssemblyWouldAmplify)
+// errNoRequestedBlocksCached is the amplify bail for a request whose covering blocks
+// are ALL absent. The predicate is per-request, not per-entry: only a full-object
+// serve spans every block, so only there does it mean the entry itself holds nothing.
+// It wraps errBlockAssemblyWouldAmplify, so callers that only care about "fall
+// through" match it unchanged, while the full-object path uses the distinction to skip
+// an invalidation that would protect nothing (see serveCompleteFromBlocks).
+var errNoRequestedBlocksCached = fmt.Errorf("%w: none of the requested blocks are cached", errBlockAssemblyWouldAmplify)
 
 // maxInlineFetchesPerServe bounds how many absent blocks one COMMITTED block serve recovers via
 // individual aligned upstream fetches. BlocksComplete is a hint: blocks and meta evict/expire
@@ -803,9 +802,11 @@ func (s *Service) serveFullObjectFromBlockCache(
 			//
 			// An entry holding NO blocks is exempt: there are no cached bytes to serve stale, so
 			// the invalidation protects nothing, and wiping it would discard a metadata-only entry
-			// (meta-on-write, or a footer warm before its first read) that later range reads are
-			// meant to reuse — making this full GET destructive rather than merely slow.
-			if !errors.Is(ferr, errBlockEntryHasNoBlocks) {
+			// (meta-on-write) that later range reads are meant to reuse — making this full GET
+			// destructive rather than merely slow. Note a footer-warmed entry holds blocks and is
+			// NOT exempt: it still takes the invalidating branch, since those cached blocks are
+			// exactly the stale-serve hazard this guards.
+			if !errors.Is(ferr, errNoRequestedBlocksCached) {
 				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
 			}
 			return false, nil
@@ -1398,7 +1399,7 @@ func (s *Service) ensureBlocksCached(ctx context.Context, bucket, key, accessKey
 	if (bailIfMostlyMissing && int64(len(missing))*2 > total) ||
 		(maxFetchFanout > 0 && int64(len(missing)) > maxFetchFanout) {
 		if int64(len(missing)) == total {
-			return errBlockEntryHasNoBlocks
+			return errNoRequestedBlocksCached
 		}
 		return errBlockAssemblyWouldAmplify
 	}

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -46,6 +46,15 @@ var errBlockUpstreamGone = errors.New("block upstream gone")
 // as "fall through to the miss path", not a real error.
 var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 
+// errBlockEntryHasNoBlocks is the amplify bail for an entry holding NO cached blocks
+// at all — a metadata-only entry, established on write or by a footer warm before any
+// read populated it. It wraps errBlockAssemblyWouldAmplify, so callers that only care
+// about "fall through" match it unchanged, while the full-object path can tell the two
+// apart: an entry with cached blocks may be serving stale bytes and must be
+// invalidated on bail, whereas an entry with none has no such hazard and wiping it
+// would discard the metadata later range reads are meant to reuse.
+var errBlockEntryHasNoBlocks = fmt.Errorf("%w: entry has no cached blocks", errBlockAssemblyWouldAmplify)
+
 // maxInlineFetchesPerServe bounds how many absent blocks one COMMITTED block serve recovers via
 // individual aligned upstream fetches. BlocksComplete is a hint: blocks and meta evict/expire
 // independently, so a surviving meta over mass-evicted blocks would otherwise turn one full GET
@@ -786,12 +795,19 @@ func (s *Service) serveFullObjectFromBlockCache(
 	if ferr := s.ensureBlocksCached(ctx, bucket, key, accessKey, secretKey, meta, 0, lastBlock, true, 0); ferr != nil {
 		if errors.Is(ferr, errBlockAssemblyWouldAmplify) {
 			log.Debug().Str("bucket", bucket).Str("key", key).Int64("blocks", lastBlock+1).Msg("Full-object block assembly would amplify - falling through to single upstream GET")
-			// Don't leave the mostly-missing entry in place: the bail skips the per-block staleness
+			// Don't leave a mostly-missing entry in place: the bail skips the per-block staleness
 			// check, so if the object was deleted/overwritten out of band its already-cached blocks
 			// would keep serving stale bytes on later range reads until TTL. Invalidate it (only if
 			// still this version, so a concurrently re-established entry isn't wiped) and let the
 			// miss path re-establish the current version via a single streaming re-split.
-			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+			//
+			// An entry holding NO blocks is exempt: there are no cached bytes to serve stale, so
+			// the invalidation protects nothing, and wiping it would discard a metadata-only entry
+			// (meta-on-write, or a footer warm before its first read) that later range reads are
+			// meant to reuse — making this full GET destructive rather than merely slow.
+			if !errors.Is(ferr, errBlockEntryHasNoBlocks) {
+				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
+			}
 			return false, nil
 		}
 		log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Full-object block assembly failed - falling through to upstream")
@@ -1381,6 +1397,9 @@ func (s *Service) ensureBlocksCached(ctx context.Context, bucket, key, accessKey
 	// avoiding a hit-ratio skew (failed fetches correlate with more-missing requests).
 	if (bailIfMostlyMissing && int64(len(missing))*2 > total) ||
 		(maxFetchFanout > 0 && int64(len(missing)) > maxFetchFanout) {
+		if int64(len(missing)) == total {
+			return errBlockEntryHasNoBlocks
+		}
 		return errBlockAssemblyWouldAmplify
 	}
 	if len(missing) == 0 {

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -33,6 +33,7 @@ type blockMockForwarder struct {
 	blockGetNoETag      bool         // if set, per-block 206 fetches omit the ETag header
 	blockGetShortBody   bool         // if set, per-block 206 body is shorter than its Content-Length
 	blockGets           atomic.Int32 // count of per-block DoConditionalGetRequest calls
+	forwards            atomic.Int32 // count of client-range forwards (DoRequestWithCreds)
 }
 
 func newBlockMock(object []byte, etag string) *blockMockForwarder {
@@ -40,6 +41,7 @@ func newBlockMock(object []byte, etag string) *blockMockForwarder {
 	// The client forward serves the requested range, or the whole object for a full GET. A
 	// deleted object (blockGet404) 404s the forward too, not only per-block fetches.
 	m.mockForwarder.doRequestFunc = func(_ context.Context, r *http.Request, _, _ string) (*http.Response, error) {
+		m.forwards.Add(1)
 		if m.blockGet404 {
 			return &http.Response{StatusCode: http.StatusNotFound, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}, nil
 		}
@@ -1826,3 +1828,6 @@ func TestBlockCache_SequentialClientWriteFailureDoesNotFetchRemainder(t *testing
 		t.Errorf("client write failure triggered %d upstream requests, want 0 (no remainder salvage)", got)
 	}
 }
+
+// clientForwards reports how many client-range forwards have hit upstream.
+func (m *blockMockForwarder) clientForwards() int32 { return m.forwards.Load() }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -104,10 +104,13 @@ func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey s
 	}
 	go func() {
 		defer s.activeBackgroundFetches.Delete(dedupKey)
-		if s.recentFooterWork != nil {
-			defer s.recentFooterWork.Add(versionKey, struct{}{})
+		// Cooldown ONLY on a completed scan. Recording it unconditionally would apply
+		// the full window to a budget shed or a transient fetch failure, turning one
+		// shed under load into minutes of silence and more serial footer misses --
+		// precisely when the prefetch is most worth retrying.
+		if s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta, trailer) && s.recentFooterWork != nil {
+			s.recentFooterWork.Add(versionKey, struct{}{})
 		}
-		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta, trailer)
 	}()
 }
 
@@ -130,13 +133,17 @@ func (s *Service) parquetFooterPrefetchWanted(key string, meta *cache.CachedObje
 
 // prefetchParquetFooterBlocks reads the metadata length the object declares,
 // then fetches the metadata blocks that are not already cached.
-func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, trailer []byte) {
+// It reports whether the scan ran to completion; a caller may use that to decide
+// whether to suppress repeat work, which must not happen after a failure.
+func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey string, meta *cache.CachedObjectMeta, trailer []byte) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
 	defer cancel()
 
 	footerLen, ok := s.parquetFooterLength(ctx, bucket, key, meta, trailer)
 	if !ok {
-		return
+		// Usually a key that merely ends in ".parquet" — a stable property, so treat
+		// it as complete and stop re-examining the object on every tail read.
+		return true
 	}
 	metrics.CacheParquetFooterBytes.Observe(float64(footerLen))
 
@@ -147,8 +154,9 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 	firstBlock := metaStart / meta.BlockSize
 	if firstBlock >= tailBlock {
 		// Metadata fits the remainder block the triggering read already cached.
-		// Measured: only the small (<2 MB) objects land here.
-		return
+		// Measured: only the small (<2 MB) objects land here. A stable property of
+		// the object, so complete.
+		return true
 	}
 	if tailBlock-firstBlock > maxParquetFooterPrefetchBlocks {
 		firstBlock = tailBlock - maxParquetFooterPrefetchBlocks
@@ -158,7 +166,7 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 
 	for i := firstBlock; i < tailBlock; i++ {
 		if ctx.Err() != nil {
-			return
+			return false // timed out mid-scan; retryable
 		}
 		if s.cache.BlockExists(ctx, bucket, key, meta.ETag, meta.BlockSize, i) {
 			continue
@@ -169,11 +177,15 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 		if err := s.fetchOneBlock(ctx, bucket, key, accessKey, secretKey, meta, i); err != nil {
 			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Int64("block", i).
 				Msg("Parquet footer prefetch failed")
-			return
+			// A budget shed or transient upstream error. Retryable, and specifically
+			// must NOT start a cooldown: shedding happens under load, which is when a
+			// later read most wants this to have another go.
+			return false
 		}
 		metrics.CacheBlockPrefetched.WithLabelValues(triggerReadPrefetch).Inc()
 		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, i, triggerReadPrefetch)
 	}
+	return true
 }
 
 // parquetFooterLength returns the declared metadata length, preferring a trailer
@@ -234,19 +246,31 @@ func (s *Service) notePrefetchedBlock(bucket, key, etag string, blockSize, idx i
 	s.prefetchedBlocks.Add(cache.MakeBlockKey(bucket, key, etag, blockSize, idx), trigger)
 }
 
-// notePrefetchHit attributes a cache hit to an earlier prefetch, once. Removing
-// the entry keeps the ratio a count of blocks rather than of reads, so a block
-// read many times cannot inflate precision.
+// notePrefetchHit attributes a cache hit to an earlier prefetch, exactly once.
+// Clearing the entry keeps the ratio a count of blocks rather than of reads, so a
+// block read many times cannot inflate precision.
+//
+// The lookup and the removal must be ONE atomic step. expirable.LRU.Remove is
+// atomic but discards the value, and the trigger label is only recoverable from
+// that value — so a Get-then-Remove pair is the obvious shape and is wrong: two
+// serves racing on the same block both observe it and both increment, letting
+// precision exceed 1. The mutex buys back the atomicity that reading the value
+// costs. It is only taken when the feature is on, since prefetchedBlocks is nil
+// otherwise.
 func (s *Service) notePrefetchHit(bucket, key, etag string, blockSize, idx int64) {
 	if s.prefetchedBlocks == nil {
 		return
 	}
-	// Remove reports whether the key was present and clears it under one lock, so
-	// two serves racing on the same block cannot both attribute it. A Get-then-
-	// Remove pair would let precision exceed 1.
 	k := cache.MakeBlockKey(bucket, key, etag, blockSize, idx)
-	if trigger, ok := s.prefetchedBlocks.Get(k); ok {
+
+	s.prefetchAttributionMu.Lock()
+	trigger, ok := s.prefetchedBlocks.Get(k)
+	if ok {
 		s.prefetchedBlocks.Remove(k)
+	}
+	s.prefetchAttributionMu.Unlock()
+
+	if ok {
 		metrics.CacheBlockPrefetchUsed.WithLabelValues(trigger).Inc()
 	}
 }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -310,16 +311,36 @@ func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey stri
 	if len(blocks) == 0 {
 		return
 	}
-	// Counted as requested rather than as landed: triggerBlockModePopulate reports
-	// asynchronously, and over-counting the denominator understates precision, which
-	// is the safe direction for a number used to decide whether to keep this on.
+	// The shared populate path refuses a fan-out above this, and a silent refusal
+	// after the counters had already moved would report warms that never happened.
+	// Check it here so the skip is explicit and unmeasured.
+	if int64(len(blocks)) > maxRangeBlockFanout {
+		log.Debug().Str("bucket", bucket).Str("key", key).Int("blocks", len(blocks)).
+			Msg("Parquet footer warm skipped - metadata spans more blocks than the populate fan-out allows")
+		return
+	}
+
+	// Stamp before fetching so an invalidation landing mid-warm is newer and blocks
+	// the meta write below.
+	writeStartTime := time.Now().UnixNano()
+	if err := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, blocks); err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm - block fetch failed")
+		return
+	}
+
+	// Counted only once the blocks are actually cached. Counting at schedule time
+	// would credit a warm that never landed: the blocks would still be recorded for
+	// attribution, so a later read that fetched them itself would be scored as a
+	// prefetch hit and INFLATE precision -- in a metric whose whole job is to decide
+	// whether this trigger earns its keep.
 	for _, idx := range blocks {
 		metrics.CacheBlockPrefetched.WithLabelValues("write_warm").Inc()
 		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx)
 	}
-	// Fetches the blocks and writes the block-mode meta LAST, tombstone-aware -- the
-	// visibility gate from RFC 0001. Nothing here bypasses that ordering.
-	s.triggerBlockModePopulate(bucket, key, accessKey, secretKey, meta, blocks)
+
+	// Meta last, tombstone-aware -- the RFC 0001 visibility gate. Blocks stay useful
+	// even if this backs off, since they are keyed by ETag.
+	s.finalizeBlockModeMeta(ctx, bucket, key, meta, len(blocks), writeStartTime)
 }
 
 // readParquetTrailerFromUpstream fetches the object's last 8 bytes. A suffix range is

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -3,6 +3,9 @@ package proxy
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -25,10 +28,12 @@ import (
 // ContentLength mod block_size, averaging half a block. So the prefetch is needed
 // whenever footer+8 exceeds that remainder, not merely when it exceeds block_size.
 //
-// Measured on the ORD parseable bucket (26 objects, two days): footers run ~1.25%
-// of object size -- 3.0 MB at 244 MB, 4.7 MB at 394 MB -- so against 1 MiB blocks
-// the metadata spans 3-5 blocks and this fires on ~69% of objects. Only the small
-// (<2 MB) files, whose footers are 20-50 KB, fit in the remainder.
+// Footer size scales with row groups and columns, since it carries per-column
+// statistics. Measured on a production deployment with a wide schema, footers ran
+// ~1.25% of object size -- several MB on a few-hundred-MB object -- so at a 1 MiB
+// block_size the metadata spans several blocks and this fires on most objects.
+// Narrow schemas produce much smaller footers; tag_cache_parquet_footer_bytes is
+// how a deployment tells which case it is in.
 //
 // It fetches only blocks the metadata provably spans, computed from the length the
 // file itself declares, so speculation is bounded by the object, not by a guess.
@@ -239,4 +244,161 @@ func (s *Service) noteAssembledPrefetchHits(bucket, key string, meta *cache.Cach
 		}
 		s.notePrefetchHit(bucket, key, meta.ETag, meta.BlockSize, i)
 	}
+}
+
+// Write-time footer warming (RFC 0002).
+//
+// The read-triggered prefetch above can only help a file's SECOND read: the first
+// one is what fires it. Under a sliding-window reader -- a dashboard querying
+// [now-1h, now] on a refresh timer -- that is the only read that ever misses,
+// because every later refresh finds the window already warm. So the remaining
+// cold reads are exactly the files written since the last refresh.
+//
+// TAG proxies those writes, so it can warm them before the first query rather than
+// during it. A just-written file is inside the window by definition; this schedules
+// a fetch rather than guessing at one.
+
+// warmParquetFooterOnWrite caches a freshly written parquet object's metadata blocks.
+// It returns immediately; the work runs detached, after the client's write response
+// has already been committed.
+func (s *Service) warmParquetFooterOnWrite(r *http.Request, bucket, key string) {
+	if s.config == nil || !s.config.Cache.ParquetOptimization || !s.cache.IsEnabled() {
+		return
+	}
+	if !s.config.Cache.IsBlockCachingEnabled() || s.config.Cache.BlockSize <= 0 {
+		return
+	}
+	if !isParquetKey(key) {
+		return
+	}
+	// Warming reads the object back, so it needs credentials that can read it. An
+	// anonymous write tells us nothing about read access, so skip rather than guess.
+	_, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil || accessKey == "" || secretKey == "" {
+		return
+	}
+
+	// One warm per object version in flight, reusing the read-path coalescer: a
+	// retried CompleteMultipartUpload must not warm twice.
+	dedupKey := "pqw:" + bucket + "/" + key
+	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer s.activeBackgroundFetches.Delete(dedupKey)
+		s.warmParquetFooterBlocks(bucket, key, accessKey, secretKey)
+	}()
+}
+
+// warmParquetFooterBlocks resolves the object's size, ETag and metadata length with a
+// single suffix-range read, then populates the blocks the metadata spans.
+func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey string) {
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
+
+	meta, footerLen, ok := s.readParquetTrailerFromUpstream(ctx, bucket, key, accessKey, secretKey)
+	if !ok {
+		return
+	}
+	metrics.CacheParquetFooterBytes.Observe(float64(footerLen))
+
+	blocks := parquetFooterBlocks(meta, footerLen)
+	if len(blocks) == 0 {
+		return
+	}
+	// Counted as requested rather than as landed: triggerBlockModePopulate reports
+	// asynchronously, and over-counting the denominator understates precision, which
+	// is the safe direction for a number used to decide whether to keep this on.
+	for _, idx := range blocks {
+		metrics.CacheBlockPrefetched.WithLabelValues("write_warm").Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx)
+	}
+	// Fetches the blocks and writes the block-mode meta LAST, tombstone-aware -- the
+	// visibility gate from RFC 0001. Nothing here bypasses that ordering.
+	s.triggerBlockModePopulate(bucket, key, accessKey, secretKey, meta, blocks)
+}
+
+// readParquetTrailerFromUpstream fetches the object's last 8 bytes. A suffix range is
+// used deliberately: it needs no prior knowledge of the object's size, and the 206's
+// Content-Range reports that size back -- which is what lets this run for an object
+// TAG has never seen, without a HEAD and without consulting a manifest.
+func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, key, accessKey, secretKey string) (*cache.CachedObjectMeta, int64, bool) {
+	resp, err := s.forwarder.DoConditionalGetRequest(ctx, bucket, key, accessKey, secretKey, "", 0,
+		fmt.Sprintf("bytes=-%d", parquetTrailerSize))
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm - trailer read failed")
+		return nil, 0, false
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		// The range was ignored and the whole object is coming. Close WITHOUT
+		// draining: draining for connection reuse would pull hundreds of MB through
+		// the warm path, which is the exact cost the suffix range exists to avoid.
+		_ = resp.Body.Close()
+		return nil, 0, false
+	}
+	defer func() {
+		// A valid 206 here is 8 bytes and is fully consumed below, so this drains
+		// nothing in the normal case. Bounded anyway: an over-long body must not be
+		// read to EOF just to make the connection reusable.
+		_, _ = io.CopyN(io.Discard, resp.Body, parquetTrailerSize)
+		_ = resp.Body.Close()
+	}()
+
+	// Trust the interval, not just the total: derive block indices only from a range
+	// that really is the object's last parquetTrailerSize bytes. A server that
+	// answered a different interval would otherwise have its bytes parsed as a
+	// trailer.
+	first, last, contentLength, hasBounds := parseContentRange(resp.Header.Get("Content-Range"))
+	if !hasBounds || contentLength <= parquetTrailerSize {
+		return nil, 0, false
+	}
+	if first != contentLength-parquetTrailerSize || last != contentLength-1 {
+		log.Debug().Str("bucket", bucket).Str("key", key).
+			Str("content_range", resp.Header.Get("Content-Range")).
+			Msg("Parquet footer warm - upstream answered a different interval than the suffix range")
+		return nil, 0, false
+	}
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		// The ETag keys every block and the meta entry; without it nothing can be stored.
+		return nil, 0, false
+	}
+	if !s.isBlockEligibleSize(contentLength) {
+		// Sub-block objects are whole-cached, and their footer is the whole object.
+		return nil, 0, false
+	}
+
+	buf := make([]byte, parquetTrailerSize)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		return nil, 0, false
+	}
+	footerLen, valid := parseParquetTrailer(buf, contentLength)
+	if !valid {
+		// A ".parquet" suffix is a hint, not a guarantee.
+		return nil, 0, false
+	}
+
+	return &cache.CachedObjectMeta{
+		ETag:          etag,
+		BlockSize:     s.config.Cache.BlockSize,
+		ContentLength: contentLength,
+	}, footerLen, true
+}
+
+// parquetFooterBlocks returns the block indices the metadata region spans, including
+// the tail block. Empty when the object is degenerate.
+func parquetFooterBlocks(meta *cache.CachedObjectMeta, footerLen int64) []int64 {
+	tailBlock := (meta.ContentLength - 1) / meta.BlockSize
+	firstBlock := (meta.ContentLength - parquetTrailerSize - footerLen) / meta.BlockSize
+	if firstBlock < 0 {
+		firstBlock = 0
+	}
+	if tailBlock-firstBlock+1 > maxParquetFooterPrefetchBlocks {
+		firstBlock = tailBlock - maxParquetFooterPrefetchBlocks + 1
+	}
+	blocks := make([]int64, 0, tailBlock-firstBlock+1)
+	for i := firstBlock; i <= tailBlock; i++ {
+		blocks = append(blocks, i)
+	}
+	return blocks
 }

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -48,6 +48,11 @@ const (
 	// larger than this is pathological (or a corrupt length that passed the
 	// sanity checks), and prefetching it would evict more than it can repay.
 	maxParquetFooterPrefetchBlocks = 32
+
+	// Trigger labels for the prefetch counters. Precision is compared BETWEEN these,
+	// so both the prefetched and the used counter must carry them.
+	triggerReadPrefetch = "parquet_footer"
+	triggerWriteWarm    = "write_warm"
 )
 
 // isParquetKey reports whether the key names a parquet object. Matching on the
@@ -81,16 +86,27 @@ func (s *Service) maybePrefetchParquetFooter(bucket, key, accessKey, secretKey s
 		trailer = append([]byte(nil), served[off:off+parquetTrailerSize]...)
 	}
 
-	// Every tail read of a hot object hits this path, so coalesce: one prefetch
-	// per object version at a time. Without this a repeatedly-read object would
-	// spawn a goroutine and a cache read per request to reach the same
-	// already-satisfied conclusion.
-	dedupKey := "pq:" + bucket + "/" + key + "/" + meta.ETag
+	// Two separate guards, because in-flight coalescing alone does not stop the
+	// repeat work. The dedup key is released as soon as the goroutine returns, and
+	// for an already-warm object it returns almost immediately -- so every tail read
+	// would still spawn a goroutine that re-probes the metadata blocks, which are
+	// mostly remote in a cluster. The cooldown suppresses the scan itself for a
+	// while after one completes.
+	versionKey := bucket + "/" + key + "/" + meta.ETag
+	if s.recentFooterWork != nil {
+		if _, recent := s.recentFooterWork.Get(versionKey); recent {
+			return
+		}
+	}
+	dedupKey := "pq:" + versionKey
 	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
 		return
 	}
 	go func() {
 		defer s.activeBackgroundFetches.Delete(dedupKey)
+		if s.recentFooterWork != nil {
+			defer s.recentFooterWork.Add(versionKey, struct{}{})
+		}
 		s.prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey, meta, trailer)
 	}()
 }
@@ -155,8 +171,8 @@ func (s *Service) prefetchParquetFooterBlocks(bucket, key, accessKey, secretKey 
 				Msg("Parquet footer prefetch failed")
 			return
 		}
-		metrics.CacheBlockPrefetched.WithLabelValues("parquet_footer").Inc()
-		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, i)
+		metrics.CacheBlockPrefetched.WithLabelValues(triggerReadPrefetch).Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, i, triggerReadPrefetch)
 	}
 }
 
@@ -209,11 +225,13 @@ func (s *Service) readParquetFooterLength(ctx context.Context, bucket, key strin
 // serve of it can be attributed. The set is bounded and TTL-expiring: an entry
 // that ages out simply stops being attributable, which understates precision
 // rather than overstating it.
-func (s *Service) notePrefetchedBlock(bucket, key, etag string, blockSize, idx int64) {
+func (s *Service) notePrefetchedBlock(bucket, key, etag string, blockSize, idx int64, trigger string) {
 	if s.prefetchedBlocks == nil {
 		return
 	}
-	s.prefetchedBlocks.Add(cache.MakeBlockKey(bucket, key, etag, blockSize, idx), struct{}{})
+	// The trigger is stored, not just counted: precision is only meaningful per
+	// trigger, and it cannot be recovered at hit time otherwise.
+	s.prefetchedBlocks.Add(cache.MakeBlockKey(bucket, key, etag, blockSize, idx), trigger)
 }
 
 // notePrefetchHit attributes a cache hit to an earlier prefetch, once. Removing
@@ -226,8 +244,10 @@ func (s *Service) notePrefetchHit(bucket, key, etag string, blockSize, idx int64
 	// Remove reports whether the key was present and clears it under one lock, so
 	// two serves racing on the same block cannot both attribute it. A Get-then-
 	// Remove pair would let precision exceed 1.
-	if s.prefetchedBlocks.Remove(cache.MakeBlockKey(bucket, key, etag, blockSize, idx)) {
-		metrics.CacheBlockPrefetchUsed.Inc()
+	k := cache.MakeBlockKey(bucket, key, etag, blockSize, idx)
+	if trigger, ok := s.prefetchedBlocks.Get(k); ok {
+		s.prefetchedBlocks.Remove(k)
+		metrics.CacheBlockPrefetchUsed.WithLabelValues(trigger).Inc()
 	}
 }
 
@@ -301,6 +321,16 @@ func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey stri
 	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
 	defer cancel()
 
+	// Stamp BEFORE the upstream trailer read, not after: an invalidation landing
+	// during that round trip must be newer than this timestamp or it will not block
+	// the meta write below. That is not theoretical -- blocks are ETag-keyed and
+	// survive the meta delete, and runBlockFetch short-circuits on BlockExists
+	// without contacting upstream, so a warm whose footer blocks are all still
+	// cached performs NO upstream validation and would happily re-publish meta for
+	// a deleted object. meta_on_write.go and write_through.go both stamp before
+	// their HEAD for the same reason.
+	writeStartTime := time.Now().UnixNano()
+
 	meta, footerLen, ok := s.readParquetTrailerFromUpstream(ctx, bucket, key, accessKey, secretKey)
 	if !ok {
 		return
@@ -320,22 +350,27 @@ func (s *Service) warmParquetFooterBlocks(bucket, key, accessKey, secretKey stri
 		return
 	}
 
-	// Stamp before fetching so an invalidation landing mid-warm is newer and blocks
-	// the meta write below.
-	writeStartTime := time.Now().UnixNano()
+	// Which blocks this warm will actually fetch. fetchBlocksToCache silently skips
+	// ones already cached -- by a prior warm, a read-triggered prefetch, or a retried
+	// write -- and crediting those would report work that never happened and score
+	// them as hits on the next read, inflating the very ratio the rollout decision
+	// rests on. The read-triggered path tests presence before counting; match it.
+	absent := make([]int64, 0, len(blocks))
+	for _, idx := range blocks {
+		if !s.cache.BlockExists(ctx, bucket, key, meta.ETag, meta.BlockSize, idx) {
+			absent = append(absent, idx)
+		}
+	}
+
 	if err := s.fetchBlocksToCache(ctx, bucket, key, accessKey, secretKey, meta, blocks); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm - block fetch failed")
 		return
 	}
 
-	// Counted only once the blocks are actually cached. Counting at schedule time
-	// would credit a warm that never landed: the blocks would still be recorded for
-	// attribution, so a later read that fetched them itself would be scored as a
-	// prefetch hit and INFLATE precision -- in a metric whose whole job is to decide
-	// whether this trigger earns its keep.
-	for _, idx := range blocks {
-		metrics.CacheBlockPrefetched.WithLabelValues("write_warm").Inc()
-		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx)
+	// Counted only once the blocks are cached, and only those this warm fetched.
+	for _, idx := range absent {
+		metrics.CacheBlockPrefetched.WithLabelValues(triggerWriteWarm).Inc()
+		s.notePrefetchedBlock(bucket, key, meta.ETag, meta.BlockSize, idx, triggerWriteWarm)
 	}
 
 	// Meta last, tombstone-aware -- the RFC 0001 visibility gate. Blocks stay useful

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -392,6 +392,13 @@ func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, ke
 		// Sub-block objects are whole-cached, and their footer is the whole object.
 		return nil, 0, false
 	}
+	// Same gate every other populate path applies: an object the client marked
+	// no-store/private, or one over the size threshold, must not be cached here
+	// either. Built from the response headers so Cache-Control is actually seen.
+	if probe := s.buildBlockMeta(bucket, key, resp.Header, contentLength); !probe.IsCacheable(s.config.Cache.SizeThreshold) {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Parquet footer warm skipped - object is not cacheable")
+		return nil, 0, false
+	}
 
 	buf := make([]byte, parquetTrailerSize)
 	if _, err := io.ReadFull(resp.Body, buf); err != nil {

--- a/proxy/block_cache_parquet.go
+++ b/proxy/block_cache_parquet.go
@@ -278,8 +278,12 @@ func (s *Service) warmParquetFooterOnWrite(r *http.Request, bucket, key string) 
 		return
 	}
 
-	// One warm per object version in flight, reusing the read-path coalescer: a
-	// retried CompleteMultipartUpload must not warm twice.
+	// One warm per object in flight, reusing the read-path coalescer, so a retried
+	// CompleteMultipartUpload does not warm twice. Deliberately NOT keyed by version:
+	// the ETag is only learned from the trailer read below, so it cannot be in the
+	// key. A second write landing mid-warm is therefore skipped, and that version is
+	// warmed by the read-triggered path on its first read instead -- one cold read,
+	// not a permanent gap.
 	dedupKey := "pqw:" + bucket + "/" + key
 	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
 		return
@@ -378,11 +382,11 @@ func (s *Service) readParquetTrailerFromUpstream(ctx context.Context, bucket, ke
 		return nil, 0, false
 	}
 
-	return &cache.CachedObjectMeta{
-		ETag:          etag,
-		BlockSize:     s.config.Cache.BlockSize,
-		ContentLength: contentLength,
-	}, footerLen, true
+	// Build the entry the same way the range path does, from the 206's headers.
+	// A hand-rolled struct would omit StatusCode -- and this meta is the visibility
+	// gate, so a later HEAD hit would call WriteHeader(0) and panic net/http -- as
+	// well as Content-Type, Last-Modified and user metadata that clients expect.
+	return s.buildBlockMeta(bucket, key, resp.Header, contentLength), footerLen, true
 }
 
 // parquetFooterBlocks returns the block indices the metadata region spans, including

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -433,3 +433,204 @@ func newParquetTestService(t *testing.T, content []byte, blockSize int64) *Servi
 	}
 	return s
 }
+
+// The block set must cover the whole metadata region through the tail, and stay
+// bounded when a declared footer length is pathological.
+func TestParquetFooterBlocks(t *testing.T) {
+	const blockSize = 1024
+	t.Run("spans metadata through the tail", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 6 * blockSize}
+		// metadata starts at 6144-8-2644 = 3492, inside block 3; tail is block 5.
+		got := parquetFooterBlocks(meta, 2644)
+		if !slices.Equal(got, []int64{3, 4, 5}) {
+			t.Fatalf("blocks = %v, want [3 4 5]", got)
+		}
+	})
+
+	t.Run("footer inside the tail block is just that block", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 6 * blockSize}
+		if got := parquetFooterBlocks(meta, 100); !slices.Equal(got, []int64{5}) {
+			t.Fatalf("blocks = %v, want [5]", got)
+		}
+	})
+
+	t.Run("stays bounded for a pathological footer", func(t *testing.T) {
+		meta := &cache.CachedObjectMeta{BlockSize: blockSize, ContentLength: 5000 * blockSize}
+		got := parquetFooterBlocks(meta, 4000*blockSize)
+		if len(got) != maxParquetFooterPrefetchBlocks {
+			t.Fatalf("blocks = %d, want the %d cap", len(got), maxParquetFooterPrefetchBlocks)
+		}
+		if got[len(got)-1] != 4999 {
+			t.Fatalf("last block = %d, want the tail block 4999", got[len(got)-1])
+		}
+	})
+}
+
+// suffixRangeForwarder answers a bytes=-8 suffix range the way S3 does: 206 with
+// Content-Range reporting the total size, which is what lets the warm path run for
+// an object TAG has never seen.
+type suffixRangeForwarder struct {
+	mockForwarder
+	body   []byte
+	etag   string
+	status int
+
+	mu     sync.Mutex
+	ranges []string
+}
+
+func (f *suffixRangeForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, rangeHeader string) (*http.Response, error) {
+	f.mu.Lock()
+	f.ranges = append(f.ranges, rangeHeader)
+	f.mu.Unlock()
+
+	total := int64(len(f.body))
+	var n int64 = parquetTrailerSize
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=-%d", &n); err != nil {
+		return nil, fmt.Errorf("unexpected range %q", rangeHeader)
+	}
+	chunk := f.body[total-n:]
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", total-n, total-1, total))
+	if f.etag != "" {
+		header.Set("ETag", f.etag)
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusPartialContent
+	}
+	return &http.Response{
+		StatusCode:    status,
+		ContentLength: int64(len(chunk)),
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(chunk)),
+	}, nil
+}
+
+func newWarmTestService(t *testing.T, body []byte, etag string, status int) (*Service, *suffixRangeForwarder) {
+	t.Helper()
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = 1024
+	cfg.Cache.ParquetOptimization = true
+	store := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	fwd := &suffixRangeForwarder{body: body, etag: etag, status: status}
+	return NewService(fwd, store, cfg), fwd
+}
+
+func warmTestObject(footerLen int64) []byte {
+	const blockSize, blocks = 1024, 6
+	body := make([]byte, blockSize*blocks)
+	binary.LittleEndian.PutUint32(body[len(body)-parquetTrailerSize:], uint32(footerLen))
+	copy(body[len(body)-4:], parquetMagic)
+	return body
+}
+
+// The whole point: an object TAG has never seen resolves its size, ETag and footer
+// length from ONE suffix-range read -- no HEAD, no manifest, no cached metadata.
+func TestReadParquetTrailerFromUpstream(t *testing.T) {
+	t.Run("resolves size, etag and footer length", func(t *testing.T) {
+		body := warmTestObject(2644)
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+
+		meta, footerLen, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk")
+		if !ok {
+			t.Fatal("trailer read failed")
+		}
+		if meta.ContentLength != int64(len(body)) || meta.ETag != `"v1"` || footerLen != 2644 {
+			t.Fatalf("meta = %+v footerLen=%d, want len=%d etag=\"v1\" footer=2644", meta, footerLen, len(body))
+		}
+		if got := fwd.ranges; !slices.Equal(got, []string{"bytes=-8"}) {
+			t.Fatalf("upstream ranges = %v, want one suffix range", got)
+		}
+	})
+
+	t.Run("rejects a 200 rather than draining a whole object", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, http.StatusOK)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted a 200 - the range was ignored and the body is the whole object")
+		}
+	})
+
+	t.Run("rejects a missing ETag", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), "", 0)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted an object with no ETag - nothing could be keyed")
+		}
+	})
+
+	t.Run("rejects an interval that is not the object tail", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
+		s.forwarder = &wrongIntervalForwarder{body: warmTestObject(2644), etag: `"v1"`}
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted bytes from an interval other than the object's last 8")
+		}
+	})
+
+	t.Run("rejects a non-parquet trailer", func(t *testing.T) {
+		body := warmTestObject(2644)
+		copy(body[len(body)-4:], "XXXX")
+		s, _ := newWarmTestService(t, body, `"v1"`, 0)
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("accepted a key that merely ends in .parquet")
+		}
+	})
+}
+
+// The trigger must stay off unless the optimization is on and the key is parquet,
+// and must not fire twice for a retried write.
+func TestWarmParquetFooterOnWrite_Gating(t *testing.T) {
+	body := warmTestObject(2644)
+
+	t.Run("disabled does nothing", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.config.Cache.ParquetOptimization = false
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.parquet", nil), "b", "a.parquet")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v with the optimization off", fwd.ranges)
+		}
+	})
+
+	t.Run("non-parquet key does nothing", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.json", nil), "b", "a.json")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v for a non-parquet key", fwd.ranges)
+		}
+	})
+
+	t.Run("a retried write coalesces", func(t *testing.T) {
+		s, fwd := newWarmTestService(t, body, `"v1"`, 0)
+		s.activeBackgroundFetches.Store("pqw:b/a.parquet", struct{}{})
+		s.warmParquetFooterOnWrite(httptest.NewRequest(http.MethodPut, "/b/a.parquet", nil), "b", "a.parquet")
+		if len(fwd.ranges) != 0 {
+			t.Fatalf("warmed %v while another warm was in flight", fwd.ranges)
+		}
+		if _, ok := s.activeBackgroundFetches.Load("pqw:b/a.parquet"); !ok {
+			t.Fatal("coalesced trigger cleared the marker owned by the in-flight warm")
+		}
+	})
+}
+
+// wrongIntervalForwarder answers the suffix range with trailer-shaped bytes taken
+// from the WRONG interval, and reports that interval honestly in Content-Range.
+// Block indices are derived from these bounds, so they must be checked.
+type wrongIntervalForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+}
+
+func (f *wrongIntervalForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, _ string) (*http.Response, error) {
+	total := int64(len(f.body))
+	header := make(http.Header)
+	// Valid trailer bytes, but from the middle of the object rather than its tail.
+	header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", parquetTrailerSize-1, total))
+	header.Set("ETag", f.etag)
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: parquetTrailerSize,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(f.body[total-parquetTrailerSize:])),
+	}, nil
+}

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -559,6 +559,25 @@ func TestReadParquetTrailerFromUpstream(t *testing.T) {
 		}
 	})
 
+	// The warm meta is the visibility gate for the entry, so it must be a complete
+	// object meta -- not just the three fields the block maths needs. A zero
+	// StatusCode reaches WriteHeader on a later HEAD hit and panics net/http.
+	t.Run("builds a complete object meta", func(t *testing.T) {
+		body := warmTestObject(2644)
+		s, _ := newWarmTestService(t, body, `"v1"`, 0)
+
+		meta, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk")
+		if !ok {
+			t.Fatal("trailer read failed")
+		}
+		if meta.StatusCode < 100 || meta.StatusCode > 999 {
+			t.Fatalf("StatusCode = %d, which panics net/http at WriteHeader", meta.StatusCode)
+		}
+		if meta.Bucket != "b" || meta.Key != "a.parquet" {
+			t.Fatalf("meta identity = %q/%q, want b/a.parquet", meta.Bucket, meta.Key)
+		}
+	})
+
 	t.Run("rejects an interval that is not the object tail", func(t *testing.T) {
 		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
 		s.forwarder = &wrongIntervalForwarder{body: warmTestObject(2644), etag: `"v1"`}

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -586,6 +586,15 @@ func TestReadParquetTrailerFromUpstream(t *testing.T) {
 		}
 	})
 
+	// Every other populate path refuses these; this one must too.
+	t.Run("rejects an object the client marked uncacheable", func(t *testing.T) {
+		s, _ := newWarmTestService(t, warmTestObject(2644), `"v1"`, 0)
+		s.forwarder = &noStoreForwarder{body: warmTestObject(2644), etag: `"v1"`}
+		if _, _, ok := s.readParquetTrailerFromUpstream(context.Background(), "b", "a.parquet", "ak", "sk"); ok {
+			t.Fatal("warmed an object marked Cache-Control: no-store")
+		}
+	})
+
 	t.Run("rejects a non-parquet trailer", func(t *testing.T) {
 		body := warmTestObject(2644)
 		copy(body[len(body)-4:], "XXXX")
@@ -646,6 +655,28 @@ func (f *wrongIntervalForwarder) DoConditionalGetRequest(_ context.Context, _, _
 	// Valid trailer bytes, but from the middle of the object rather than its tail.
 	header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", parquetTrailerSize-1, total))
 	header.Set("ETag", f.etag)
+	return &http.Response{
+		StatusCode:    http.StatusPartialContent,
+		ContentLength: parquetTrailerSize,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(f.body[total-parquetTrailerSize:])),
+	}, nil
+}
+
+// noStoreForwarder answers the suffix range for an object the client marked
+// uncacheable, which every populate path is required to refuse.
+type noStoreForwarder struct {
+	mockForwarder
+	body []byte
+	etag string
+}
+
+func (f *noStoreForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _, _ string, _ int64, _ string) (*http.Response, error) {
+	total := int64(len(f.body))
+	header := make(http.Header)
+	header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", total-parquetTrailerSize, total-1, total))
+	header.Set("ETag", f.etag)
+	header.Set("Cache-Control", "no-store")
 	return &http.Response{
 		StatusCode:    http.StatusPartialContent,
 		ContentLength: parquetTrailerSize,

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -133,10 +133,12 @@ func TestReadParquetFooterLength(t *testing.T) {
 // Precision accounting must count blocks, not reads: a prefetched block served
 // repeatedly is one useful prefetch, not many.
 func TestPrefetchAttribution_CountsEachBlockOnce(t *testing.T) {
-	s := NewService(nil, nil, config.NewDefault())
+	cfg := config.NewDefault()
+	cfg.Cache.ParquetOptimization = true
+	s := NewService(nil, nil, cfg)
 	const blockSize = 1024
 
-	s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, 7)
+	s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, 7, triggerWriteWarm)
 	key := cache.MakeBlockKey("b", "a.parquet", `"v1"`, blockSize, 7)
 	if _, ok := s.prefetchedBlocks.Get(key); !ok {
 		t.Fatal("prefetched block was not recorded")

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -685,4 +686,43 @@ func (f *noStoreForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _
 		Header:        header,
 		Body:          io.NopCloser(bytes.NewReader(f.body[total-parquetTrailerSize:])),
 	}, nil
+}
+
+// Attribution must survive concurrent serves of the same prefetched block. This
+// regressed once already: recovering the trigger label requires reading the LRU
+// value, which turned an atomic Remove into a Get-then-Remove pair, and two racing
+// serves could both observe the entry and both count it -- pushing precision above
+// 1 in the metric that decides whether these triggers stay on.
+func TestPrefetchAttribution_ConcurrentServesCountOnce(t *testing.T) {
+	cfg := config.NewDefault()
+	cfg.Cache.ParquetOptimization = true
+	s := NewService(nil, nil, cfg)
+	const blockSize = 1024
+
+	for round := 0; round < 200; round++ {
+		s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, int64(round), triggerWriteWarm)
+
+		var wg sync.WaitGroup
+		var winners atomic.Int32
+		for racer := 0; racer < 8; racer++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				k := cache.MakeBlockKey("b", "a.parquet", `"v1"`, blockSize, int64(round))
+				s.prefetchAttributionMu.Lock()
+				_, ok := s.prefetchedBlocks.Get(k)
+				if ok {
+					s.prefetchedBlocks.Remove(k)
+				}
+				s.prefetchAttributionMu.Unlock()
+				if ok {
+					winners.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+		if got := winners.Load(); got != 1 {
+			t.Fatalf("round %d: %d serves attributed the same block, want exactly 1", round, got)
+		}
+	}
 }

--- a/proxy/block_cache_parquet_test.go
+++ b/proxy/block_cache_parquet_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	cacheclient "github.com/tigrisdata/ocache/client"
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/metrics"
 )
 
 // parquetTailBlock builds an object tail that a parquet reader would recognise:
@@ -693,36 +694,38 @@ func (f *noStoreForwarder) DoConditionalGetRequest(_ context.Context, _, _, _, _
 // value, which turned an atomic Remove into a Get-then-Remove pair, and two racing
 // serves could both observe the entry and both count it -- pushing precision above
 // 1 in the metric that decides whether these triggers stay on.
+//
+// It drives notePrefetchHit itself and asserts on the counter that ships. An
+// earlier version of this test reimplemented the lock-and-clear inline, which
+// exercised a copy of the logic rather than the function, and so would have stayed
+// green if the production path lost its mutex -- the exact regression it exists to
+// catch.
 func TestPrefetchAttribution_ConcurrentServesCountOnce(t *testing.T) {
 	cfg := config.NewDefault()
 	cfg.Cache.ParquetOptimization = true
 	s := NewService(nil, nil, cfg)
 	const blockSize = 1024
 
-	for round := 0; round < 200; round++ {
-		s.notePrefetchedBlock("b", "a.parquet", `"v1"`, blockSize, int64(round), triggerWriteWarm)
+	counter := metrics.CacheBlockPrefetchUsed.WithLabelValues(triggerWriteWarm)
+	before := testutil.ToFloat64(counter)
+
+	const rounds = 200
+	for round := 0; round < rounds; round++ {
+		key := fmt.Sprintf("a-%d.parquet", round)
+		s.notePrefetchedBlock("b", key, `"v1"`, blockSize, 7, triggerWriteWarm)
 
 		var wg sync.WaitGroup
-		var winners atomic.Int32
 		for racer := 0; racer < 8; racer++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				k := cache.MakeBlockKey("b", "a.parquet", `"v1"`, blockSize, int64(round))
-				s.prefetchAttributionMu.Lock()
-				_, ok := s.prefetchedBlocks.Get(k)
-				if ok {
-					s.prefetchedBlocks.Remove(k)
-				}
-				s.prefetchAttributionMu.Unlock()
-				if ok {
-					winners.Add(1)
-				}
+				s.notePrefetchHit("b", key, `"v1"`, blockSize, 7)
 			}()
 		}
 		wg.Wait()
-		if got := winners.Load(); got != 1 {
-			t.Fatalf("round %d: %d serves attributed the same block, want exactly 1", round, got)
-		}
+	}
+
+	if got := testutil.ToFloat64(counter) - before; got != rounds {
+		t.Fatalf("attributed %v blocks across %d races, want exactly %d - a block counted more than once inflates precision above 1", got, rounds, rounds)
 	}
 }

--- a/proxy/meta_on_write.go
+++ b/proxy/meta_on_write.go
@@ -1,0 +1,133 @@
+package proxy
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// Metadata caching on write (prototype).
+//
+// TAG invalidates on write and caches nothing, so the FIRST read of a freshly
+// written object must miss on metadata, round-trip upstream to establish it, and
+// only then engage block mode. That miss is paid once per object, on the read that
+// is most likely to be latency-sensitive.
+//
+// TAG already knows the object exists — it just proxied the write — and
+// write_through.go already caches meta+body for a teed PutObject. What is missing
+// is the multipart case, where TAG never sees the assembled body and therefore
+// caches nothing at all. This closes that gap for METADATA only: the body stays
+// uncached and blocks are fetched on demand, exactly as block mode already does
+// for evicted blocks.
+//
+// It uses write_through's guards rather than inventing new ones: an authoritative
+// HEAD supplies the meta, the ETag must match what the write returned (a concurrent
+// overwrite means the HEAD describes a different object), and IsCacheable decides
+// whether the object may be cached at all.
+
+// cacheBlockMetaOnWrite establishes a block-mode entry for a just-written object
+// without caching its body. Returns immediately; the HEAD runs detached, after the
+// client's write response has been committed.
+//
+// writtenETag is the ETag the write returned, or "" when the caller does not have
+// one — in which case the entry is not established, since without it a concurrent
+// overwrite cannot be detected.
+func (s *Service) cacheBlockMetaOnWrite(r *http.Request, bucket, key, writtenETag string) {
+	if s.config == nil || !s.config.Cache.MetaOnWrite || !s.cache.IsEnabled() {
+		return
+	}
+	if !s.config.Cache.IsBlockCachingEnabled() || s.config.Cache.BlockSize <= 0 {
+		return
+	}
+	if writtenETag == "" {
+		return
+	}
+	_, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil || accessKey == "" || secretKey == "" {
+		return
+	}
+
+	dedupKey := "meta:" + bucket + "/" + key
+	if _, loaded := s.activeBackgroundFetches.LoadOrStore(dedupKey, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer s.activeBackgroundFetches.Delete(dedupKey)
+		s.establishBlockMetaFromHead(bucket, key, accessKey, secretKey, writtenETag)
+	}()
+}
+
+// establishBlockMetaFromHead HEADs the object and stamps a block-mode entry whose
+// blocks are all absent. That is a legal state: block mode already serves entries
+// with missing blocks by fetching them on demand (RFC 0001), which is the same path
+// an evicted block takes. What it buys is that the first read resolves metadata from
+// cache instead of paying an upstream round trip to discover it.
+func (s *Service) establishBlockMetaFromHead(bucket, key, accessKey, secretKey, writtenETag string) {
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+	defer cancel()
+
+	// Stamp before the HEAD, so an invalidation landing mid-flight is newer than this
+	// timestamp and blocks the meta write.
+	writeStartTime := time.Now().UnixNano()
+
+	resp, err := s.forwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, "", 0)
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Meta-on-write - HEAD failed")
+		return
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	// Only establish the version we actually wrote. A concurrent overwrite returns a
+	// different ETag, and caching that meta would describe an object whose blocks a
+	// later read would fetch under a different version — the same torn-pair hazard
+	// write_through guards against.
+	if resp.Header.Get("ETag") != writtenETag {
+		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Meta-on-write skipped - superseded by a concurrent overwrite")
+		return
+	}
+
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
+	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
+		return
+	}
+	if !s.isBlockEligibleSize(meta.ContentLength) {
+		// Sub-block objects are whole-cached; establishing a block-mode entry for one
+		// would misdescribe how it will be stored.
+		return
+	}
+	meta.BlockSize = s.config.Cache.BlockSize
+
+	// Deliberately NOT BlocksComplete: no block has been written, so a full-object
+	// serve must take the probe pass rather than stream optimistically.
+	s.finalizeBlockModeMeta(ctx, bucket, key, meta, 0, writeStartTime)
+}
+
+// completedMultipartETag extracts the ETag from a CompleteMultipartUpload response.
+// S3 returns it in the XML body, not (necessarily) as a header, so reading the header
+// alone would leave writtenETag empty and silently disable this on the very path it
+// exists for -- multipart is where TAG caches nothing today. The header is still
+// preferred when present, since it costs nothing to check.
+func completedMultipartETag(capture *ResponseCapture) string {
+	if capture == nil {
+		return ""
+	}
+	if etag := capture.Headers.Get("ETag"); etag != "" {
+		return etag
+	}
+	var result struct {
+		XMLName xml.Name `xml:"CompleteMultipartUploadResult"`
+		ETag    string   `xml:"ETag"`
+	}
+	if err := xml.Unmarshal(capture.Body, &result); err != nil {
+		return ""
+	}
+	return result.ETag
+}

--- a/proxy/meta_on_write_measure_test.go
+++ b/proxy/meta_on_write_measure_test.go
@@ -1,0 +1,292 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// Measures what a parquet reader's FIRST open costs in upstream round trips, which
+// is the question meta-on-write and footer warming both claim to answer.
+//
+// The reader's opening sequence is fixed by the format: read the 8-byte trailer to
+// learn the metadata length, then read the metadata region. Everything below counts
+// upstream requests across exactly those two reads, varying only what the cache was
+// given beforehand.
+func TestMeasure_FirstOpenUpstreamRoundTrips(t *testing.T) {
+	const (
+		blockSize = 4
+		bucket    = "b"
+		key       = "m.parquet"
+		etag      = `"v1"`
+	)
+	// 10 blocks; metadata spans the last 3 (blocks 7,8,9).
+	object := make([]byte, blockSize*10)
+	footerLen := int64(blockSize*3 - parquetTrailerSize - 1)
+	binary.LittleEndian.PutUint32(object[len(object)-parquetTrailerSize:], uint32(footerLen))
+	copy(object[len(object)-4:], parquetMagic)
+	total := int64(len(object))
+	metaStart := total - parquetTrailerSize - footerLen
+
+	// The two reads a parquet reader actually issues, in order.
+	trailerRange := fmt.Sprintf("bytes=%d-%d", total-parquetTrailerSize, total-1)
+	metadataRange := fmt.Sprintf("bytes=%d-%d", metaStart, total-1)
+
+	run := func(t *testing.T, label string, prime func(*Service, *cache.Cache, *cache.CachedObjectMeta)) int32 {
+		t.Helper()
+		mock := newBlockMock(object, etag)
+		svc, c := newBlockService(t, mock)
+		svc.config.Cache.ParquetOptimization = true
+
+		if prime != nil {
+			// Build the entry exactly as the range path does, from a realistic 206's
+			// headers -- a hand-made struct is not what the serve path expects to find.
+			h := http.Header{}
+			h.Set("ETag", etag)
+			h.Set("Content-Type", "application/octet-stream")
+			h.Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			h.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", total-1, total))
+			prime(svc, c, svc.buildBlockMeta(bucket, key, h, total))
+		}
+
+		mock.blockGets.Store(0)
+		before := mock.clientForwards()
+
+		for _, rng := range []string{trailerRange, metadataRange} {
+			rec := httptest.NewRecorder()
+			if err := svc.HandleGetObject(rec, blockGet(bucket, key, rng)); err != nil {
+				t.Fatalf("read %s: %v", rng, err)
+			}
+			if rec.Code != 206 {
+				t.Fatalf("read %s: status %d, want 206", rng, rec.Code)
+			}
+		}
+		// Background populates are detached; give them a bounded chance to land so
+		// they are counted rather than silently excluded.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if metaCached(c, bucket, key, 10*time.Millisecond) {
+				break
+			}
+		}
+		blocks, fwd := mock.blockGets.Load(), mock.clientForwards()-before
+		t.Logf("  %-22s client forwards=%d  block fetches=%d  total=%d", label, fwd, blocks, blocks+fwd)
+		return blocks + fwd
+	}
+
+	// (a) Today: nothing cached. The first read must establish metadata upstream.
+	cold := run(t, "cold", nil)
+
+	// (b) Meta-on-write: metadata present, every block absent.
+	metaOnly := run(t, "meta-on-write", func(svc *Service, c *cache.Cache, meta *cache.CachedObjectMeta) {
+		mustPrimeMeta(t, c, bucket, key, meta)
+	})
+
+	// (c) Meta-on-write + footer warm: metadata present and the footer blocks cached.
+	metaAndFooter := run(t, "meta+footer", func(svc *Service, c *cache.Cache, meta *cache.CachedObjectMeta) {
+		for _, idx := range parquetFooterBlocks(meta, footerLen) {
+			start, end := blockBounds(idx, blockSize, total)
+			if err := c.PutBlock(context.Background(), bucket, key, etag, blockSize, idx, object[start:end+1], 3600); err != nil {
+				t.Fatalf("prime block %d: %v", idx, err)
+			}
+		}
+		mustPrimeMeta(t, c, bucket, key, meta)
+	})
+
+	t.Logf("first-open upstream round trips: cold=%d  meta-on-write=%d  meta+footer-warm=%d", cold, metaOnly, metaAndFooter)
+
+	if metaAndFooter != 0 {
+		t.Errorf("meta+footer-warm should serve the first open entirely from cache, got %d upstream round trips", metaAndFooter)
+	}
+	if metaOnly >= cold {
+		t.Errorf("meta-on-write did not reduce first-open round trips: cold=%d meta-on-write=%d", cold, metaOnly)
+	}
+	if metaAndFooter >= metaOnly {
+		t.Errorf("footer warming added nothing over meta-on-write: meta-on-write=%d meta+footer=%d", metaOnly, metaAndFooter)
+	}
+}
+
+// mustPrimeMeta writes the entry and asserts it landed. PutMetaTombstoneAware
+// reports refusal through its bool, not an error, so discarding that return makes a
+// silently empty cache look like a primed one -- which is exactly how the first run
+// of this measurement produced "no improvement".
+func mustPrimeMeta(t *testing.T, c *cache.Cache, bucket, key string, meta *cache.CachedObjectMeta) {
+	t.Helper()
+	wrote, err := c.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 3600, time.Now().UnixNano())
+	if err != nil || !wrote {
+		t.Fatalf("prime meta: wrote=%v err=%v", wrote, err)
+	}
+	if _, found, _ := c.GetMeta(context.Background(), bucket, key); !found {
+		t.Fatal("prime meta: entry not readable after write")
+	}
+}
+
+// S3 returns the completed object's ETag in the CompleteMultipartUpload XML body,
+// not reliably as a header. Reading only the header would leave the ETag empty and
+// silently disable meta-on-write on multipart -- the one path it exists for.
+func TestCompletedMultipartETag(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Location>https://example/b/k</Location>
+  <Bucket>b</Bucket>
+  <Key>k</Key>
+  <ETag>"abc-3"</ETag>
+</CompleteMultipartUploadResult>`
+
+	t.Run("reads the ETag from the XML body", func(t *testing.T) {
+		got := completedMultipartETag(&ResponseCapture{Headers: http.Header{}, Body: []byte(body)})
+		if got != `"abc-3"` {
+			t.Fatalf("etag = %q, want \"abc-3\"", got)
+		}
+	})
+
+	t.Run("prefers the header when present", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("ETag", `"from-header"`)
+		if got := completedMultipartETag(&ResponseCapture{Headers: h, Body: []byte(body)}); got != `"from-header"` {
+			t.Fatalf("etag = %q, want the header value", got)
+		}
+	})
+
+	t.Run("returns empty rather than guessing", func(t *testing.T) {
+		for _, b := range [][]byte{nil, []byte("not xml"), []byte(`<Error><Code>NoSuchUpload</Code></Error>`)} {
+			if got := completedMultipartETag(&ResponseCapture{Headers: http.Header{}, Body: b}); got != "" {
+				t.Fatalf("etag = %q for body %q, want empty", got, b)
+			}
+		}
+	})
+}
+
+// headForwarder answers the authoritative HEAD that meta-on-write uses, and counts
+// how often it was asked -- a trigger that stays silent must not reach upstream.
+type headForwarder struct {
+	mockForwarder
+	etag   string
+	size   int64
+	extra  map[string]string
+	status int
+
+	mu    sync.Mutex
+	heads int
+}
+
+func (f *headForwarder) DoConditionalHeadRequest(_ context.Context, _, _, _, _, _ string, _ int64) (*http.Response, error) {
+	f.mu.Lock()
+	f.heads++
+	f.mu.Unlock()
+	h := http.Header{}
+	h.Set("ETag", f.etag)
+	h.Set("Content-Length", fmt.Sprint(f.size))
+	for k, v := range f.extra {
+		h.Set(k, v)
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{StatusCode: status, Header: h, ContentLength: f.size, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+}
+
+func (f *headForwarder) headCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.heads
+}
+
+func TestCacheBlockMetaOnWrite(t *testing.T) {
+	const (
+		bucket = "b"
+		key    = "o.bin"
+		etag   = `"v1"`
+		size   = int64(64)
+	)
+	newSvc := func(t *testing.T, fwd *headForwarder) (*Service, *cache.Cache) {
+		t.Helper()
+		cfg := config.NewDefault()
+		cfg.Cache.SetBlockCachingEnabled(true)
+		cfg.Cache.BlockSize = 4
+		cfg.Cache.SizeThreshold = 1 << 20
+		cfg.Cache.MetaOnWrite = true
+		c := cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+		return NewService(fwd, c, cfg), c
+	}
+	req := func() *http.Request { return fullGet(bucket, key) }
+
+	// Established synchronously so the assertion does not race the goroutine.
+	t.Run("establishes a block-mode entry for the written version", func(t *testing.T) {
+		fwd := &headForwarder{etag: etag, size: size}
+		svc, c := newSvc(t, fwd)
+		svc.establishBlockMetaFromHead(bucket, key, "ak", "sk", etag)
+
+		meta, found, _ := c.GetMeta(context.Background(), bucket, key)
+		if !found {
+			t.Fatal("no entry established")
+		}
+		if meta.BlockSize != 4 || meta.ContentLength != size || meta.ETag != etag {
+			t.Fatalf("meta = %+v, want blockSize=4 len=%d etag=%s", meta, size, etag)
+		}
+		if meta.BlocksComplete {
+			t.Error("BlocksComplete set, but no block was written - a full serve would stream optimistically over absent blocks")
+		}
+	})
+
+	t.Run("refuses a version other than the one written", func(t *testing.T) {
+		fwd := &headForwarder{etag: `"someone-elses"`, size: size}
+		svc, c := newSvc(t, fwd)
+		svc.establishBlockMetaFromHead(bucket, key, "ak", "sk", etag)
+		if _, found, _ := c.GetMeta(context.Background(), bucket, key); found {
+			t.Fatal("cached meta for an object a concurrent write had replaced")
+		}
+	})
+
+	t.Run("refuses an object the client marked uncacheable", func(t *testing.T) {
+		fwd := &headForwarder{etag: etag, size: size, extra: map[string]string{"Cache-Control": "no-store"}}
+		svc, c := newSvc(t, fwd)
+		svc.establishBlockMetaFromHead(bucket, key, "ak", "sk", etag)
+		if _, found, _ := c.GetMeta(context.Background(), bucket, key); found {
+			t.Fatal("cached an object marked no-store")
+		}
+	})
+
+	t.Run("refuses a sub-block object", func(t *testing.T) {
+		fwd := &headForwarder{etag: etag, size: 2} // smaller than block_size
+		svc, c := newSvc(t, fwd)
+		svc.establishBlockMetaFromHead(bucket, key, "ak", "sk", etag)
+		if _, found, _ := c.GetMeta(context.Background(), bucket, key); found {
+			t.Fatal("established a block-mode entry for an object that is whole-cached")
+		}
+	})
+
+	// The trigger must not reach upstream at all when it is off or has no version.
+	t.Run("stays off the wire when disabled or unversioned", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			enabled bool
+			etag    string
+		}{
+			{"disabled", false, etag},
+			{"no etag from the write", true, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				fwd := &headForwarder{etag: etag, size: size}
+				svc, _ := newSvc(t, fwd)
+				svc.config.Cache.MetaOnWrite = tc.enabled
+				svc.cacheBlockMetaOnWrite(req(), bucket, key, tc.etag)
+				if got := fwd.headCount(); got != 0 {
+					t.Fatalf("issued %d HEADs, want none", got)
+				}
+			})
+		}
+	})
+}

--- a/proxy/meta_on_write_measure_test.go
+++ b/proxy/meta_on_write_measure_test.go
@@ -290,3 +290,42 @@ func TestCacheBlockMetaOnWrite(t *testing.T) {
 		}
 	})
 }
+
+// A metadata-only entry must survive a full-object GET. The full-GET path bails when
+// most blocks are absent and invalidates the entry, which is right when it holds
+// cached blocks that could serve stale bytes — but an entry with NO blocks has no
+// such hazard, and wiping it would make the full GET destroy exactly what
+// meta-on-write (and a footer warm before its first read) just established.
+func TestFullGet_PreservesMetadataOnlyEntry(t *testing.T) {
+	const (
+		blockSize = 4
+		bucket    = "b"
+		key       = "o.bin"
+		etag      = `"v1"`
+	)
+	object := make([]byte, blockSize*10)
+	for i := range object {
+		object[i] = byte('a' + i%26)
+	}
+
+	mock := newBlockMock(object, etag)
+	svc, c := newBlockService(t, mock)
+
+	h := http.Header{}
+	h.Set("ETag", etag)
+	h.Set("Content-Type", "application/octet-stream")
+	h.Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	mustPrimeMeta(t, c, bucket, key, svc.buildBlockMeta(bucket, key, h, int64(len(object))))
+
+	rec := httptest.NewRecorder()
+	if err := svc.HandleGetObject(rec, fullGet(bucket, key)); err != nil {
+		t.Fatalf("full GET: %v", err)
+	}
+	if rec.Code != 200 || rec.Body.Len() != len(object) {
+		t.Fatalf("full GET served status=%d len=%d, want 200 and %d bytes", rec.Code, rec.Body.Len(), len(object))
+	}
+
+	if _, found, _ := c.GetMeta(context.Background(), bucket, key); !found {
+		t.Fatal("full GET destroyed the metadata-only entry that later range reads were meant to reuse")
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -534,6 +534,9 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 		if !teeHandled {
 			s.warmOnWrite(r, bucket, key)
 		}
+		// Independent of warmOnWrite: that caches whole objects and is off here,
+		// while this caches only the metadata region (RFC 0002).
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 	// Forward errored or upstream rejected the write: nothing cached, so release any budget
 	// reserved for the tee.
@@ -683,6 +686,7 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	if err == nil && s3WriteSucceeded(capture) && s.cache.IsEnabled() {
 		s.invalidateObject(context.Background(), bucket, key)
 		s.warmOnWrite(r, bucket, key)
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 
 	return err
@@ -835,6 +839,9 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 		// Warm-on-write is the only way to make a multipart-completed object hot:
 		// TAG never sees its assembled body, so a write-through tee is impossible.
 		s.warmOnWrite(r, bucket, key)
+		// The path that matters for parquet: ingestors write via multipart, so this
+		// is where a freshly written file's metadata gets warmed (RFC 0002).
+		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
 
 	// Cache successful completions in ocache for idempotent replays. Only cache a

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -76,7 +76,11 @@ type Service struct {
 	// prefetchedBlocks remembers recently prefetched block keys so a later serve
 	// of one can be attributed, giving prefetch precision. Bounded and
 	// TTL-expiring: this is measurement, and must not become a memory term.
-	prefetchedBlocks *expirable.LRU[string, struct{}]
+	prefetchedBlocks *expirable.LRU[string, string]
+	// recentFooterWork suppresses repeat footer scans for an object version that was
+	// already examined. Without it every tail read of a fully-warmed object re-probes
+	// its metadata blocks, which in cluster mode are mostly remote.
+	recentFooterWork *expirable.LRU[string, struct{}]
 }
 
 // NewService creates a new proxy service.
@@ -143,7 +147,7 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		Int64("serve_staging_cap_bytes", stagingCap).
 		Msg("Cache-populate limits configured")
 
-	return &Service{
+	svc := &Service{
 		forwarder:        forwarder,
 		cache:            cache,
 		config:           cfg,
@@ -152,8 +156,16 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		perPopulateCap:   perPopulateCap,
 		broadcastManager: broadcast.NewManager(channelBuf),
 		blockFetches:     make(map[string]*blockFetchState),
-		prefetchedBlocks: expirable.NewLRU[string, struct{}](maxPrefetchedBlockTracking, nil, prefetchTrackingTTL),
 	}
+	// Left nil unless the feature that populates it is on. The serve path attributes
+	// every cached block through notePrefetchHit, and that costs a block-key build plus
+	// a locked LRU op per block -- hundreds per full-object serve. A default-off feature
+	// must not charge the hot path for bookkeeping nobody reads.
+	if cfg.Cache.ParquetOptimization {
+		svc.prefetchedBlocks = expirable.NewLRU[string, string](maxPrefetchedBlockTracking, nil, prefetchTrackingTTL)
+		svc.recentFooterWork = expirable.NewLRU[string, struct{}](maxPrefetchedBlockTracking, nil, footerWorkCooldown)
+	}
+	return svc
 }
 
 // perPopulateBufferBytes returns the maximum bytes a single cache-populate can
@@ -208,6 +220,11 @@ const (
 	// prefetch that is not used within this window was not useful in the sense
 	// that motivates prefetching — hiding latency from the read that follows it.
 	prefetchTrackingTTL = 30 * time.Minute
+
+	// footerWorkCooldown is how long a footer scan is suppressed for one object
+	// version after it completes. Short enough that an evicted footer is re-warmed
+	// promptly, long enough that a hot object is not re-scanned per read.
+	footerWorkCooldown = 5 * time.Minute
 )
 
 // stagingWeight is the byte weight a block-serve staging buffer reserves against the

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -77,6 +77,10 @@ type Service struct {
 	// of one can be attributed, giving prefetch precision. Bounded and
 	// TTL-expiring: this is measurement, and must not become a memory term.
 	prefetchedBlocks *expirable.LRU[string, string]
+	// prefetchAttributionMu makes the lookup-and-clear in notePrefetchHit atomic.
+	// The LRU's own ops are atomic individually, but recovering the trigger requires
+	// reading the value before removing it, and that pair must not interleave.
+	prefetchAttributionMu sync.Mutex
 	// recentFooterWork suppresses repeat footer scans for an object version that was
 	// already examined. Without it every tail read of a fully-warmed object re-probes
 	// its metadata blocks, which in cluster mode are mostly remote.

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -842,6 +842,10 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 		// The path that matters for parquet: ingestors write via multipart, so this
 		// is where a freshly written file's metadata gets warmed (RFC 0002).
 		s.warmParquetFooterOnWrite(r, bucket, key)
+		// Prototype: establish the metadata entry so the first read does not pay an
+		// upstream round trip to discover it. Multipart is the gap — write-through
+		// cannot tee a body TAG never sees.
+		s.cacheBlockMetaOnWrite(r, bucket, key, completedMultipartETag(capture))
 	}
 
 	// Cache successful completions in ocache for idempotent replays. Only cache a


### PR DESCRIPTION
TAG invalidates on write and caches nothing, so the **first read of a freshly written object pays an upstream round trip purely to establish metadata** before block mode can engage. `write_through.go` already caches meta+body for a teed `PutObject`; the gap is **multipart**, where TAG never sees the assembled body and so caches nothing at all.

This closes that gap for **metadata only** — the body stays uncached and blocks are fetched on demand, exactly as block mode already does for an evicted block.

## Measured

Counting upstream round trips across a parquet reader's opening sequence (trailer read, then metadata read):

| Configuration | client forwards | block fetches | **total** |
| --- | --- | --- | --- |
| Today (cold) | 2 | 3 | **5** |
| Meta-on-write | **0** | 3 | **3** |
| Meta-on-write + footer warm (#177) | 0 | **0** | **0** |

The split is the point. This removes the **metadata-discovery forwards** — 2 of 5, and for *every* object rather than only parquet. It **cannot** touch the block fetches, because those blocks simply are not cached yet; only warming puts them there.

So it **composes with #177 rather than replacing it.** I had hypothesised that meta-on-write might make footer warming unnecessary. The measurement says otherwise: they remove different costs.

The measurement ships as a test (`TestMeasure_FirstOpenUpstreamRoundTrips`), so the claim is checked rather than asserted, and a regression in either mechanism fails it.

## Design

Reuses `write_through`'s guards rather than inventing new ones:

- An **authoritative HEAD** supplies the meta (`MetaFromHTTPHeaders`), so headers are real rather than reconstructed.
- The **ETag must match what the write returned** — a concurrent overwrite means the HEAD describes a different object, the same torn-pair hazard write-through guards against.
- **`IsCacheable`** decides whether the object may be cached at all (`no-store`/`private`, size threshold).
- Sub-block objects are refused: they are whole-cached, and a block-mode entry would misdescribe how they will be stored.

An entry whose blocks are all absent is a **legal state** — block mode already fetches missing blocks on demand (RFC 0001), which is the path an evicted block takes. `BlocksComplete` is deliberately left **false**, so a full-object serve still probes instead of streaming optimistically over blocks that are not there.

Wired into the multipart completion path only, which is the actual gap; `PutObject` is already covered by write-through's tee.

## Two silent no-ops caught before opening this

**S3 returns a completed multipart object's ETag in the XML body, not reliably as a header.** Reading only the header left the ETag empty, and the empty-ETag guard then disabled the feature entirely — on the one path it exists for. Now parsed from the body, with the header preferred when present, and tested against a real `CompleteMultipartUploadResult`.

**The measurement first reported "no improvement",** which was the test lying rather than a result. `PutMetaTombstoneAware` signals refusal through its **bool** return rather than an error, so a discarded bool plus `writeStartTime=0` left the cache empty while looking primed — and an empty cache is indistinguishable from a primed one in the output. The priming helper now asserts both the write and a read-back.

## Testing

Entry establishment (correct block-mode meta, `BlocksComplete` false), refusal of a version other than the one written, of `no-store` objects, and of sub-block objects; the disabled and no-ETag triggers verified to issue **no HEAD at all**; multipart ETag extraction from body/header/garbage; and `TestMetaOnWrite_OverrideByEnv` per the repo's env-override convention, including that an unrecognized value leaves it off.

`make test` green across all packages; `make lint` clean; `-race` clean.

## Rollout

Off by default behind `cache.meta_on_write`. It changes what a read-after-write observes — from "always upstream" to "cached metadata, version-guarded" — so it deserves a canary rather than a fleet-wide flip. The ETag guard is what makes that safe; the failure mode it prevents is caching metadata for a version a concurrent write already replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-after-cache and full-GET invalidation so metadata-only entries can survive, which is correctness-sensitive if ETag/tombstone guards fail. Both features are off by default.
> 
> **Overview**
> Cuts first-read-after-write cost by caching **metadata without the body** (`cache.meta_on_write`) and by **warming parquet footer blocks at write time** (`cache.parquet_optimization`, RFC 0002). Both run after the client write is committed.
> 
> **Meta-on-write** (prototype, off by default) HEADs the just-written object and stamps a block-mode entry with no blocks. It is wired on **CompleteMultipartUpload** (the path write-through cannot tee), parses the ETag from the XML body when the header is missing, and refuses a HEAD whose ETag does not match the write.
> 
> **Footer warming** schedules a suffix-range `bytes=-8` fetch for `.parquet` keys on Put/Copy/CompleteMultipart, then populates the metadata-covering blocks. Prefetch metrics are now labeled by `trigger` (`parquet_footer` vs `write_warm`) so precision can be compared. Read-triggered footer scans get a cooldown so hot objects are not re-probed every tail read.
> 
> A full GET that would amplify because **no covering blocks are cached** no longer invalidates the entry, so a metadata-only (or not-yet-read footer-warm) entry is not wiped. Attribution of prefetch hits is mutexed so concurrent serves cannot inflate precision above 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1dc163bc6542b4771e5fe6467f019e4d0203e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->