### PR TITLE
fix(cache): invalidate a block-less entry on the amplify bail after all

### DIFF
--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -46,14 +46,6 @@ var errBlockUpstreamGone = errors.New("block upstream gone")
 // as "fall through to the miss path", not a real error.
 var errBlockAssemblyWouldAmplify = errors.New("block assembly would amplify")
 
-// errNoRequestedBlocksCached is the amplify bail for a request whose covering blocks
-// are ALL absent. The predicate is per-request, not per-entry: only a full-object
-// serve spans every block, so only there does it mean the entry itself holds nothing.
-// It wraps errBlockAssemblyWouldAmplify, so callers that only care about "fall
-// through" match it unchanged, while the full-object path uses the distinction to skip
-// an invalidation that would protect nothing (see serveCompleteFromBlocks).
-var errNoRequestedBlocksCached = fmt.Errorf("%w: none of the requested blocks are cached", errBlockAssemblyWouldAmplify)
-
 // maxInlineFetchesPerServe bounds how many absent blocks one COMMITTED block serve recovers via
 // individual aligned upstream fetches. BlocksComplete is a hint: blocks and meta evict/expire
 // independently, so a surviving meta over mass-evicted blocks would otherwise turn one full GET
@@ -791,21 +783,21 @@ func (s *Service) serveFullObjectFromBlockCache(
 	if ferr := s.ensureBlocksCached(ctx, bucket, key, accessKey, secretKey, meta, 0, lastBlock, true, 0); ferr != nil {
 		if errors.Is(ferr, errBlockAssemblyWouldAmplify) {
 			log.Debug().Str("bucket", bucket).Str("key", key).Int64("blocks", lastBlock+1).Msg("Full-object block assembly would amplify - falling through to single upstream GET")
-			// Don't leave a mostly-missing entry in place: the bail skips the per-block staleness
-			// check, so if the object was deleted/overwritten out of band its already-cached blocks
-			// would keep serving stale bytes on later range reads until TTL. Invalidate it (only if
-			// still this version, so a concurrently re-established entry isn't wiped) and let the
-			// miss path re-establish the current version via a single streaming re-split.
+			// Don't leave a mostly-missing entry in place: the bail decides from a probe and
+			// never contacts upstream, so it cannot know whether the object still exists. If it
+			// was deleted or overwritten out of band, keeping the entry would serve stale bytes
+			// from its cached blocks, and stale HEADERS from its metadata, until TTL. Invalidate
+			// (only if still this version, so a concurrently re-established entry isn't wiped)
+			// and let the miss path re-establish the current version.
 			//
-			// An entry holding NO blocks is exempt: there are no cached bytes to serve stale, so
-			// the invalidation protects nothing, and wiping it would discard a metadata-only entry
-			// (meta-on-write) that later range reads are meant to reuse — making this full GET
-			// destructive rather than merely slow. Note a footer-warmed entry holds blocks and is
-			// NOT exempt: it still takes the invalidating branch, since those cached blocks are
-			// exactly the stale-serve hazard this guards.
-			if !errors.Is(ferr, errNoRequestedBlocksCached) {
-				s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
-			}
+			// This applies to an entry holding NO blocks too, even though it has no cached bytes
+			// to serve stale. Its METADATA can still be stale, and a later HEAD would answer 200
+			// from it for an object that no longer exists. An earlier revision exempted such
+			// entries so a full GET could not discard a metadata-only entry (meta-on-write) that
+			// later reads would reuse — but that traded a correctness property for a performance
+			// one. Losing the entry costs one discovery round trip on the next read; keeping a
+			// stale one answers wrongly for up to the TTL.
+			s.invalidateStaleBlockMeta(bucket, key, meta.ETag)
 			return false, nil
 		}
 		log.Debug().Err(ferr).Str("bucket", bucket).Str("key", key).Msg("Full-object block assembly failed - falling through to upstream")
@@ -1394,9 +1386,6 @@ func (s *Service) ensureBlocksCached(ctx context.Context, bucket, key, accessKey
 	// avoiding a hit-ratio skew (failed fetches correlate with more-missing requests).
 	if (bailIfMostlyMissing && int64(len(missing))*2 > total) ||
 		(maxFetchFanout > 0 && int64(len(missing)) > maxFetchFanout) {
-		if int64(len(missing)) == total {
-			return errNoRequestedBlocksCached
-		}
 		return errBlockAssemblyWouldAmplify
 	}
 	if len(missing) == 0 {

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -1348,7 +1348,17 @@ func (s *Service) invalidateStaleBlockMeta(bucket, key, staleETag string) {
 	if m, found, err := s.cache.GetMeta(ctx, bucket, key); err != nil || !found || m == nil || m.ETag != staleETag {
 		return // already gone, or replaced by a newer version — leave it
 	}
-	s.cache.Delete(ctx, bucket, key)
+	if err := s.cache.Delete(ctx, bucket, key); err != nil {
+		// Record the failure rather than discarding it. This delete is what stops a
+		// stale entry answering later reads, so a silent failure leaves exactly the
+		// hazard it exists to prevent — and a delete metric that only ever reports
+		// success would hide it. invalidateObject treats its own failures the same way.
+		metrics.RecordCacheOperation("delete", "error")
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).
+			Msg("Stale block-mode meta not invalidated - entry may serve stale metadata until TTL")
+		return
+	}
+	metrics.RecordCacheOperation("delete", "success")
 }
 
 // ensureBlocksCached makes covering blocks [b0,bK] present in cache: it probes the range once,

--- a/proxy/meta_on_write_measure_test.go
+++ b/proxy/meta_on_write_measure_test.go
@@ -291,12 +291,15 @@ func TestCacheBlockMetaOnWrite(t *testing.T) {
 	})
 }
 
-// A metadata-only entry must survive a full-object GET. The full-GET path bails when
-// most blocks are absent and invalidates the entry, which is right when it holds
-// cached blocks that could serve stale bytes — but an entry with NO blocks has no
-// such hazard, and wiping it would make the full GET destroy exactly what
-// meta-on-write (and a footer warm before its first read) just established.
-func TestFullGet_PreservesMetadataOnlyEntry(t *testing.T) {
+// A full-object GET over an entry whose blocks are all absent must not leave that
+// entry behind. The bail decides from a probe and never contacts upstream, so it
+// cannot know the object still exists — and a metadata-only entry that outlives a
+// deleted object answers later HEADs with 200 and stale headers until TTL.
+//
+// The cost of invalidating is one discovery round trip on the next read. The cost of
+// keeping it is answering wrongly, so correctness wins. An earlier revision exempted
+// these entries to protect meta-on-write from exactly this; that was the wrong trade.
+func TestFullGet_InvalidatesEntryWithNoCachedBlocks(t *testing.T) {
 	const (
 		blockSize = 4
 		bucket    = "b"
@@ -325,7 +328,13 @@ func TestFullGet_PreservesMetadataOnlyEntry(t *testing.T) {
 		t.Fatalf("full GET served status=%d len=%d, want 200 and %d bytes", rec.Code, rec.Body.Len(), len(object))
 	}
 
-	if _, found, _ := c.GetMeta(context.Background(), bucket, key); !found {
-		t.Fatal("full GET destroyed the metadata-only entry that later range reads were meant to reuse")
+	// The entry may be re-established by the miss path's own populate, so assert on
+	// what matters: it must not still be the OLD entry, unvalidated against upstream.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, found, _ := c.GetMeta(context.Background(), bucket, key); !found {
+			return // invalidated as required
+		}
 	}
+	t.Fatal("full GET left a metadata-only entry in place without validating it upstream; a deleted object would answer HEAD 200 until TTL")
 }

--- a/proxy/meta_on_write_measure_test.go
+++ b/proxy/meta_on_write_measure_test.go
@@ -291,15 +291,16 @@ func TestCacheBlockMetaOnWrite(t *testing.T) {
 	})
 }
 
-// A full-object GET over an entry whose blocks are all absent must not leave that
-// entry behind. The bail decides from a probe and never contacts upstream, so it
-// cannot know the object still exists — and a metadata-only entry that outlives a
-// deleted object answers later HEADs with 200 and stale headers until TTL.
+// The hazard: an entry whose blocks are all absent outliving the object it describes.
+// The full-GET bail decides from a probe and never contacts upstream, so it cannot
+// know the object is gone — and a surviving metadata-only entry answers later HEADs
+// with 200 and stale headers until the TTL.
 //
-// The cost of invalidating is one discovery round trip on the next read. The cost of
-// keeping it is answering wrongly, so correctness wins. An earlier revision exempted
-// these entries to protect meta-on-write from exactly this; that was the wrong trade.
-func TestFullGet_InvalidatesEntryWithNoCachedBlocks(t *testing.T) {
+// Deleting the object upstream is what makes this deterministic. An earlier version
+// primed a live object and polled for the entry to disappear, which raced the miss
+// path re-populating it: correct behaviour could fail the assertion purely on
+// timing. With upstream gone there is nothing to re-populate, so absence is stable.
+func TestFullGet_DoesNotLeaveEntryForDeletedObject(t *testing.T) {
 	const (
 		blockSize = 4
 		bucket    = "b"
@@ -307,9 +308,6 @@ func TestFullGet_InvalidatesEntryWithNoCachedBlocks(t *testing.T) {
 		etag      = `"v1"`
 	)
 	object := make([]byte, blockSize*10)
-	for i := range object {
-		object[i] = byte('a' + i%26)
-	}
 
 	mock := newBlockMock(object, etag)
 	svc, c := newBlockService(t, mock)
@@ -320,21 +318,15 @@ func TestFullGet_InvalidatesEntryWithNoCachedBlocks(t *testing.T) {
 	h.Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
 	mustPrimeMeta(t, c, bucket, key, svc.buildBlockMeta(bucket, key, h, int64(len(object))))
 
+	// The object is deleted at the origin, without TAG seeing the delete.
+	mock.blockGet404 = true
+
 	rec := httptest.NewRecorder()
 	if err := svc.HandleGetObject(rec, fullGet(bucket, key)); err != nil {
 		t.Fatalf("full GET: %v", err)
 	}
-	if rec.Code != 200 || rec.Body.Len() != len(object) {
-		t.Fatalf("full GET served status=%d len=%d, want 200 and %d bytes", rec.Code, rec.Body.Len(), len(object))
-	}
 
-	// The entry may be re-established by the miss path's own populate, so assert on
-	// what matters: it must not still be the OLD entry, unvalidated against upstream.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, found, _ := c.GetMeta(context.Background(), bucket, key); !found {
-			return // invalidated as required
-		}
+	if _, found, _ := c.GetMeta(context.Background(), bucket, key); found {
+		t.Fatal("entry for a deleted object survived an unvalidated full GET; a later HEAD would answer 200 with stale headers until TTL")
 	}
-	t.Fatal("full GET left a metadata-only entry in place without validating it upstream; a deleted object would answer HEAD 200 until TTL")
 }


### PR DESCRIPTION
Greptile flagged a **P1 on the release PR** (#180), against code already on `main` from #178. It is correct, and it reverses a decision I made two PRs ago.

## The two findings point opposite ways

- **#178, Bugbot:** a full-object GET over a metadata-only entry bails, invalidates, and destroys the entry meta-on-write just established — making the feature useless against full GETs. I added an exemption: don't invalidate when the entry holds **no** blocks.
- **Now, Greptile:** that exemption leaves stale **metadata** behind. If the object was deleted or replaced out of band, later HEADs answer `200` with stale headers until the TTL (24h by default).

Both describe real consequences of the same code. What settles it is that only one of them is a correctness problem.

## Why my original reasoning was wrong

I argued that an entry with no cached blocks has nothing to serve stale. That is true of its *bytes* and false of its *metadata*.

The deeper issue: **the bail decides from a probe and never contacts upstream.** It cannot know whether the object still exists. `errBlockUpstreamGone` handles exactly this case — a block fetch that 404s invalidates the entry — but the bail never fetches, so it never learns. I was choosing between two guesses and picked the one that keeps a cache entry.

Losing the entry costs **one discovery round trip on the next read**. Keeping a stale one **answers wrongly**. That is not a close call.

## The change

The exemption is gone, and with it `errNoRequestedBlocksCached`, which existed only to carry it — `ensureBlocksCached` returns the plain amplify error again. Net effect on `block_cache.go` is a deletion.

The test is inverted: it now asserts the entry does **not** survive an unvalidated full GET, and its failure message says why (`a deleted object would answer HEAD 200 until TTL`).

## What this costs meta-on-write

A full-object GET of a written-but-unread object discards its entry, and the next read re-pays the discovery round trip. Ranged reads — the parquet access pattern this targets — are unaffected, since they never take the full-object bail.

If that turns out to matter, the right fix is to *learn* rather than guess: validate upstream before deciding, or invalidate from the fall-through's own response status. Both are real changes rather than a heuristic, and neither belongs in a fix for a stale-read bug.

`make test` green across all packages; `make lint` clean; `-race` clean.

**#180 will need re-cutting** (or re-merging `main`) to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation for full-object GETs over incomplete block entries, which can drop live meta-on-write entries and affect subsequent HEAD/GET correctness until re-discovery.
> 
> **Overview**
> Always invalidate a block-mode entry when a full-object GET bails on mostly-missing blocks, including **metadata-only** entries that previously were exempt.
> 
> The amplify bail never talks to upstream, so it cannot tell if the object was deleted or overwritten. Keeping a block-less entry avoided discarding meta-on-write work, but it also let later HEADs return 200 with stale headers until TTL. Losing the entry costs one discovery round trip; keeping a stale one is wrong.
> 
> Removes `errNoRequestedBlocksCached` (it existed only for that exemption). `invalidateStaleBlockMeta` now records delete success/failure instead of ignoring cache delete errors. The test now asserts a deleted origin object does not leave a surviving entry after an unvalidated full GET.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6392830825cc7bed10fdac22405bbdcd36b8d077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->