### PR TITLE
docs: compare footer size against the tail block, not block_size

### DIFF
--- a/docs/parquet-optimization.md
+++ b/docs/parquet-optimization.md
@@ -69,11 +69,13 @@ For arbitrarily sized objects the tail averages half a block, so a footer of a f
 **To find out for your data**, enable the flag on one node and read the histogram:
 
 ```promql
-# Median parquet footer size. Compare against cache.block_size.
+# Median parquet footer size, in bytes.
 histogram_quantile(0.5, sum(rate(tag_cache_parquet_footer_bytes_bucket[1h])) by (le))
 ```
 
-`tag_cache_parquet_footer_bytes` is recorded for **every** parquet object whose trailer is read — including ones that are not prefetched — so it describes the whole population, not just the part that was acted on. If the distribution sits well below your typical tail-block size, this optimization has nothing to do and should stay off.
+`tag_cache_parquet_footer_bytes` is recorded for **every** parquet object whose trailer is read — including ones that are not prefetched — so it describes the whole population, not just the part that was acted on.
+
+Compare that figure against the **tail block, not `block_size`**. Since the tail averages half a block across arbitrarily sized objects, `block_size / 2` is the practical yardstick: a median footer near or above it means the prefetch fires on a large share of your objects, and a median well below it means this optimization has little to do and should stay off. Comparing against the full `block_size` understates how often it fires and will talk you out of a change worth making.
 
 ---
 


### PR DESCRIPTION
The histogram query in `docs/parquet-optimization.md` told operators to compare the median footer size against `cache.block_size`, two paragraphs below the text explaining that the baseline is the **tail block**, not `block_size`. Same defect Greptile flagged as P1 on the external copy in the external docs copy, which is merged — this keeps the two from diverging.

The error has a direction worth noting: comparing against the full `block_size` **understates** how often the prefetch fires, so it talks operators out of enabling something worth enabling.

Now gives `block_size / 2` as the practical yardstick for a population, since the tail averages half a block, while keeping `footer_bytes + 8 > tail_bytes` as the exact per-object rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no code, config, or runtime behavior changes.
> 
> **Overview**
> Fixes operator guidance in `docs/parquet-optimization.md` so the median `tag_cache_parquet_footer_bytes` histogram is compared against the **tail block** (`block_size / 2` as a population yardstick), not full `cache.block_size`.
> 
> That mismatch understated how often parquet footer prefetch fires and could talk operators out of enabling a useful setting. The per-object rule `footer_bytes + 8 > tail_bytes` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0105ffad7dce873f6f6450a1249d698428a8c1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
