### PR TITLE
docs: origin-less mode user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For production, TAG ships manifests, Compose files, and guides under [`deploy/`]
 - **Docker** — single-node and cluster Compose in [`deploy/docker/`](deploy/docker/); see [docs/docker.md](docs/docker.md).
 - **TLS/HTTPS** — see [docs/tls.md](docs/tls.md).
 - **Parquet workloads** — caching parquet metadata ahead of the reader that needs it; see [docs/parquet-optimization.md](docs/parquet-optimization.md).
+- **Origin-less mode** — running TAG as a cache tier with no upstream, for systems that own their own fallback; see [docs/originless-mode.md](docs/originless-mode.md).
 - **Benchmarks** — see [docs/benchmarks.md](docs/benchmarks.md).
 
 ## Architecture

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `AWS_ACCESS_KEY_ID`               | S3 access key (must have read-only access for all buckets accessed through TAG) | (required)               |
 | `AWS_SECRET_ACCESS_KEY`           | S3 secret key for authentication                                                | (required)               |
 | `TAG_UPSTREAM_ENDPOINT`           | Tigris S3 endpoint URL                                                          | `https://t3.storage.dev` |
+| `TAG_UPSTREAM_DISABLED`           | Origin-less mode: no upstream at all — misses answer `NoSuchKey`, mutations `501`. `true`/`1` enable, explicit `false`/`0` override YAML, anything else is ignored. Mutually exclusive with an endpoint. See [Origin-less mode](originless-mode.md) | `false`                  |
 | `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                         | `auto`                   |
 | `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
 | `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
@@ -104,6 +105,13 @@ upstream:
   # When false, TAG validates and re-signs requests (signing mode).
   # Default: true
   transparent_proxy: true
+
+  # Origin-less mode: run with no upstream at all. Cache misses answer NoSuchKey
+  # and every mutation answers 501; TAG serves only what its cache already holds.
+  # Mutually exclusive with endpoint — setting both is a startup error.
+  # See docs/originless-mode.md before enabling.
+  # Default: false
+  disabled: false
 
 # Cache configuration (embedded OCache)
 cache:
@@ -340,7 +348,7 @@ upstream:
 
 Notes:
 
-- The `endpoint` must be an absolute `http://` or `https://` URL with a host; TAG refuses to start otherwise (in any mode).
+- The `endpoint` must be an absolute `http://` or `https://` URL with a host; TAG refuses to start otherwise. The one configuration without an endpoint is [origin-less mode](originless-mode.md), which has no upstream to validate.
 - Set `region` to match the backend. The default `auto` is Tigris-specific; region-sensitive services such as AWS S3 return signature errors unless the region matches the endpoint (e.g., `us-east-1` for `s3.us-east-1.amazonaws.com`).
 - Transparent proxy mode and its zero-config, no-double-auth experience are Tigris-only. Third-party backends are supported on a best-effort, community-supported basis.
 - TAG logs a warning at startup when signing mode runs against a non-Tigris endpoint.

--- a/docs/originless-mode.md
+++ b/docs/originless-mode.md
@@ -48,6 +48,8 @@ One rule decides every answer:
 
 An entry whose blocks were partly evicted, or whose body is gone leaving orphaned metadata, answers `NoSuchKey` to `GET`, `HEAD`, and conditionals alike — it never answers `HEAD 200` or `304 Not Modified` from metadata it cannot back with bytes. This matters because callers use `HEAD` as an existence check to decide whether to (re)populate the tier: a false "exists" would suppress exactly the healing that makes the entry servable again. A zero-length object is the boundary case: nothing can be missing from it, so it stays visible and servable.
 
+One qualification: the completeness check runs immediately before serving, and an eviction can land in the moment between the two. A response that has already committed its status can then be cut short mid-body — the client sees an aborted transfer (a short read against the declared `Content-Length`), not a clean `NoSuchKey`. The window is a race of microseconds, not a steady state, but callers should treat an aborted transfer from this tier the same way they treat a miss: retry against the authoritative store. Detection is unambiguous, since the received byte count never matches the declared length.
+
 ## Trust model (this phase)
 
 Only **anonymous requests for objects cached with a `public-read` ACL** are served. TAG validates signatures by learning keys from its upstream, and there is no upstream — so signed requests cannot be validated and answer `NoSuchKey`, indistinguishable from absence. Serving regardless of ACL, for deployments whose network is the trust boundary, is a planned explicit switch — not a side effect of removing the origin.

--- a/docs/originless-mode.md
+++ b/docs/originless-mode.md
@@ -1,0 +1,74 @@
+# Origin-less mode
+
+TAG normally sits in front of an upstream: misses are fetched, writes are forwarded, and cached entries are revalidated against it. Origin-less mode removes the upstream entirely. TAG serves **only what its cache already holds** — a miss is the final answer, not something to go and fetch.
+
+It exists for deployments where TAG is a cache *tier* inside a larger system, and that system owns the fallback: a caller that receives `NoSuchKey` reads from its own authoritative store instead. TAG then never needs to be durable — losing an entry costs the caller a slower read, never the data.
+
+It is **off by default**, and it is deliberately incremental: this first phase serves reads only. See [Current limits](#current-limits) before enabling it anywhere.
+
+## Enabling it
+
+```yaml
+upstream:
+  disabled: true
+```
+
+Or by environment:
+
+```bash
+TAG_UPSTREAM_DISABLED=true
+```
+
+`true`/`1` enable; an explicit `false`/`0` overrides a YAML `disabled: true`; anything unrecognized leaves the setting untouched — a typo must not silently flip a deployment's mode.
+
+Two startup behaviors worth knowing:
+
+- **Combining `disabled` with an `endpoint` is a startup error**, not something resolved silently. Honoring the endpoint would turn a cache-only tier into a proxy; honoring the flag would discard a configured origin. TAG refuses to guess.
+- **Cross-node cache auth defaults off in this mode.** Cluster gRPC auth derives its token from the AWS credentials TAG uses upstream, and this mode has none — so the default requirement would force either a startup failure or dummy keys, and dummy keys look like authentication while proving nothing. An explicit `TAG_CACHE_GRPC_AUTH=true` is still honored (and still requires credentials). The deployment's trust boundary is the network: run origin-less TAG on an internal network segment, reachable only by its intended callers.
+
+No AWS credentials are required. Startup logs a single line stating the mode and its limits.
+
+## What it serves
+
+`GET` and `HEAD` of a single object, from cache alone:
+
+- **Hit** — served exactly as the proxying mode serves it: full objects, ranges (including block-mode entries), `If-None-Match` / `If-Modified-Since` conditionals, with the `X-Cache` header set.
+- **Miss** — `NoSuchKey`, immediately. This is the signal the calling system uses to fall back to its authoritative store.
+- **Bad range on a present object** — `416 InvalidRange`, as S3 semantics require. A present object with a wrong range is not a miss.
+
+`Cache-Control: no-cache` and `no-store` from clients are **not consulted**. Both exist to reach past a cache to an origin, and there is no origin: honoring either would turn a healthy cached object into a 404. Nothing is served stale by ignoring them — with no origin, the cached copy is the only copy.
+
+Every other operation — writes, deletes, copies, multipart, listings, tagging, ACLs — answers `501 NotImplemented`. These are rejected before they touch anything, so a stray write cannot invalidate or delete cached data.
+
+### The visibility contract
+
+One rule decides every answer:
+
+> **An entry whose data is not fully present is invisible, on every request shape.**
+
+An entry whose blocks were partly evicted, or whose body is gone leaving orphaned metadata, answers `NoSuchKey` to `GET`, `HEAD`, and conditionals alike — it never answers `HEAD 200` or `304 Not Modified` from metadata it cannot back with bytes. This matters because callers use `HEAD` as an existence check to decide whether to (re)populate the tier: a false "exists" would suppress exactly the healing that makes the entry servable again. A zero-length object is the boundary case: nothing can be missing from it, so it stays visible and servable.
+
+## Trust model (this phase)
+
+Only **anonymous requests for objects cached with a `public-read` ACL** are served. TAG validates signatures by learning keys from its upstream, and there is no upstream — so signed requests cannot be validated and answer `NoSuchKey`, indistinguishable from absence. Serving regardless of ACL, for deployments whose network is the trust boundary, is a planned explicit switch — not a side effect of removing the origin.
+
+## Observability
+
+- Rejected operations are recorded under `tag_requests_total` with status `unsupported` — a caller persistently writing to an origin-less tier (a misconfigured client, for instance) shows up on the request dashboard instead of blending into the success rate.
+- Hits and misses count in `tag_cache_hits_total` / `tag_cache_misses_total` as usual, and `X-Cache` reports `HIT`/`MISS` per response.
+
+## Current limits
+
+This phase is intentionally narrow. In particular, **nothing can write to an origin-less TAG yet** — mutations are rejected, so the cache can only serve entries it already holds. Local writes (letting callers `PUT` directly into the tier) and the network-trust read switch are subsequent phases. Until then this mode is for validating the read path, not for production population.
+
+Cluster mode works — cross-node serving goes through the cache layer, not the upstream — but sizing and multi-node validation guidance will come with the deployment documentation once the mode is production-complete.
+
+## Turning it off
+
+Remove `upstream.disabled` (or set `TAG_UPSTREAM_DISABLED=false`) and configure the upstream as usual. Cached entries remain valid; the proxying mode revalidates them against the origin on their normal terms.
+
+## Reference
+
+- [Configuration](configuration.md)
+- [Cache control](cache-control.md) — client cache semantics in the proxying mode, for contrast
+- [Metrics](metrics.md)


### PR DESCRIPTION
User documentation for the origin-less mode that shipped in #184 — the feature page and configuration reference only; deploy docs deliberately deferred until the mode is production-complete.

- **`docs/originless-mode.md`** — what the mode is for (a cache tier inside a system that owns its own fallback), what it serves, and the two things an operator must understand before enabling it:
  - the **visibility contract**: an entry whose data is not fully present is invisible on every request shape, because callers use HEAD as their re-populate signal and a false "exists" suppresses healing;
  - the **current limits**, stated plainly: this phase serves reads only — nothing can write to the tier yet, so it validates the read path rather than serving production traffic.
- `docs/configuration.md` — `TAG_UPSTREAM_DISABLED` in the env table, `upstream.disabled` in the YAML reference, and a correction to the endpoint-validation note (no longer true "in any mode").
- README — one line in the production guides list.

Claims audited against the merged implementation: env parsing semantics (explicit-false override, unrecognized ignored), the startup contradiction error, the cluster-auth default, the `unsupported` metric status, and 416 semantics all verified in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior modifications.
> 
> **Overview**
> Adds operator-facing documentation for **origin-less mode** (cache-only tier with no upstream), which was implemented in a prior change.
> 
> **New `docs/originless-mode.md`** explains when to use the mode, how to enable it via `upstream.disabled` / `TAG_UPSTREAM_DISABLED`, startup rules (endpoint + disabled is an error; cluster gRPC auth defaults off), read behavior (`GET`/`HEAD` hits vs `NoSuchKey` misses, `416` for bad ranges, `501` for mutations), the **visibility contract** for partially evicted entries, the read-only **public-read / anonymous** trust model for this phase, metrics (`unsupported`, cache hit/miss), and explicit **current limits** (no writes yet; validate read path only).
> 
> **`docs/configuration.md`** documents `TAG_UPSTREAM_DISABLED` and `upstream.disabled`, and clarifies that missing an `endpoint` is only valid in origin-less mode.
> 
> **`README.md`** links the new guide from the Deployment section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27dbdfffd26cad864830d7ff2146fe94da11756d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->