### PR TITLE
fix: negative env values disable inflight and write limits

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -617,7 +617,8 @@ func applyEnvOverrides(cfg *Config) {
 			cfg.Cache.EvictionPolicy = val
 		}
 		// Override concurrent cache-write limit from environment
-		if n, ok := envInt("TAG_CACHE_MAX_CONCURRENT_WRITES"); ok && n > 0 {
+		// n != 0 for the same 0-default / negative-disables contract as above.
+		if n, ok := envInt("TAG_CACHE_MAX_CONCURRENT_WRITES"); ok && n != 0 {
 			cfg.Cache.MaxConcurrentWrites = n
 		}
 		// Override cache-populate memory budget from environment (negative disables)
@@ -679,8 +680,10 @@ func applyEnvOverrides(cfg *Config) {
 	}
 
 	// Override the ingress in-flight request limit from environment
+	// n != 0, not n > 0: the documented contract is 0/unset = default and
+	// NEGATIVE = disabled, matching the yaml field and the populate-memory override.
 	if val := os.Getenv("TAG_MAX_INFLIGHT_REQUESTS"); val != "" {
-		if n, err := strconv.Atoi(val); err == nil && n > 0 {
+		if n, err := strconv.Atoi(val); err == nil && n != 0 {
 			cfg.Server.MaxInflightRequests = n
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1333,3 +1333,24 @@ func TestMetaOnWrite_OverrideByEnv(t *testing.T) {
 		})
 	}
 }
+
+// The documented contract for both knobs: 0/unset uses the default, a NEGATIVE
+// value disables — the env path must honor it like the yaml path does.
+func TestLoad_NegativeEnvDisablesLimits(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, []byte("cache:\n  enabled: true\n"), 0o644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	t.Setenv("TAG_MAX_INFLIGHT_REQUESTS", "-1")
+	t.Setenv("TAG_CACHE_MAX_CONCURRENT_WRITES", "-1")
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Server.MaxInflightRequests != -1 {
+		t.Errorf("MaxInflightRequests = %d, want -1 (disabled)", cfg.Server.MaxInflightRequests)
+	}
+	if cfg.Cache.MaxConcurrentWrites != -1 {
+		t.Errorf("MaxConcurrentWrites = %d, want -1 (disabled)", cfg.Cache.MaxConcurrentWrites)
+	}
+}


### PR DESCRIPTION
Greptile flagged on the release PR (#195) that docs/deploy.md promises `TAG_MAX_INFLIGHT_REQUESTS` negative = disabled, but the env parser silently dropped negatives (`n > 0`). The docs and the yaml field's contract are the intent — the parser is the bug, and `TAG_CACHE_MAX_CONCURRENT_WRITES` had the same guard. Both now use `n != 0`, matching `TAG_CACHE_MAX_POPULATE_MEMORY`. Covered by TestLoad_NegativeEnvDisablesLimits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness fix for operator-tunable overload/backpressure knobs; negative values now disable limits as documented, which can increase unbounded concurrency if misconfigured.
> 
> **Overview**
> Fixes environment parsing for **`TAG_MAX_INFLIGHT_REQUESTS`** and **`TAG_CACHE_MAX_CONCURRENT_WRITES`**, which previously required `n > 0` and therefore ignored negative values even though deploy docs and the YAML fields treat **negative as “disabled”** (same as **`TAG_CACHE_MAX_POPULATE_MEMORY`**).
> 
> Both overrides now apply when `n != 0`, so `0`/unset still falls through to defaults while values like `-1` actually disable the limit. **`TestLoad_NegativeEnvDisablesLimits`** locks in that behavior for a full `Load()` with both env vars set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723f48fda084a995a146ceeb630ddc4ddb02b2fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->