### PR TITLE
feat: honor Cache-Control: only-if-cached on GET and HEAD

### DIFF
--- a/docs/cache-control.md
+++ b/docs/cache-control.md
@@ -38,6 +38,17 @@ Send `Cache-Control: no-store` to skip the cache entirely. TAG forwards the requ
 curl -H "Cache-Control: no-store" http://localhost:8080/my-bucket/my-key
 ```
 
+## Cache-Only Reads
+
+Send `Cache-Control: only-if-cached` (RFC 7234 §5.2.1.7) on a GET or HEAD to forbid origin contact entirely: TAG serves the stored response, or answers `504 Gateway Timeout` locally without touching upstream. Combined with `no-cache`, the stored response is served as-is — with the origin off-limits there is nothing to revalidate against.
+
+This makes cheap, authoritative "is it cached?" probes possible for clients that maintain their own fallback path.
+
+```bash
+# Serve from cache or fail fast — never contact upstream
+curl -H "Cache-Control: only-if-cached" http://localhost:8080/my-bucket/my-key
+```
+
 ## Automatic Cache Invalidation
 
 TAG automatically invalidates cached objects when they are modified through TAG:

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -90,6 +90,12 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	bucket, key := ParseBucketKey(r)
 	forceRevalidate := shouldForceRevalidate(r)
 	bypassCache := shouldBypassCache(r)
+	onlyIfCached := requestsOnlyIfCached(r)
+	if onlyIfCached {
+		// Origin contact is forbidden: a stored response is served without
+		// revalidation, and anything else becomes a local 504 below.
+		forceRevalidate = false
+	}
 	rangeHeader := r.Header.Get("Range")
 
 	// Conditional request headers
@@ -245,6 +251,15 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 				}
 			}
 		}
+	}
+
+	// Cache-Control: only-if-cached — nothing served above means nothing can
+	// be served without the origin: answer 504 locally (RFC 7234 §5.2.1.7).
+	if onlyIfCached {
+		writeCacheStatus(w, XCacheMiss)
+		w.WriteHeader(http.StatusGatewayTimeout)
+		metrics.RecordRequest("GetObject", "only_if_cached", time.Since(start).Seconds())
+		return nil
 	}
 
 	// 3. Cache miss — determine the X-Cache status once (DISABLED / BYPASS / MISS);

--- a/proxy/only_if_cached_test.go
+++ b/proxy/only_if_cached_test.go
@@ -1,0 +1,175 @@
+// Copyright 2025 Tigris Data, Inc.
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tigrisdata/tag/cache"
+)
+
+// forbidForward wires every upstream-touching mockForwarder hook to fail the
+// test: with Cache-Control: only-if-cached the origin must never be contacted.
+func forbidForward(t *testing.T) *mockForwarder {
+	t.Helper()
+	fail := func() { t.Error("origin contacted despite Cache-Control: only-if-cached") }
+	return &mockForwarder{
+		forwardFunc: func(context.Context, http.ResponseWriter, *http.Request) error {
+			fail()
+			return errors.New("forbidden forward")
+		},
+		doRequestFunc: func(context.Context, *http.Request, string, string) (*http.Response, error) {
+			fail()
+			return nil, errors.New("forbidden forward")
+		},
+	}
+}
+
+func putOnlyIfCachedObject(t *testing.T, c *cache.Cache, bucket, key, body string) *cache.CachedObjectMeta {
+	t.Helper()
+	meta := &cache.CachedObjectMeta{
+		Bucket:        bucket,
+		Key:           key,
+		ETag:          `"oic-etag"`,
+		ContentType:   "text/plain",
+		ContentLength: int64(len(body)),
+		StatusCode:    http.StatusOK,
+	}
+	if err := c.PutWithMeta(context.Background(), bucket, key, meta, []byte(body), 0); err != nil {
+		t.Fatalf("PutWithMeta() error = %v", err)
+	}
+	return meta
+}
+
+func TestOnlyIfCached_GetHitServesFromCache(t *testing.T) {
+	mock := forbidForward(t)
+	svc, c := newTestService(mock, true)
+	putOnlyIfCachedObject(t, c, "b", "k", "hello world!")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	r.Header.Set("Cache-Control", "only-if-cached")
+	if err := svc.HandleGetObject(w, r); err != nil {
+		t.Fatalf("HandleGetObject() error = %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+	if w.Body.String() != "hello world!" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "hello world!")
+	}
+	if mock.conditionalCalled {
+		t.Error("conditional revalidation must not run under only-if-cached")
+	}
+}
+
+func TestOnlyIfCached_GetMissAnswers504Locally(t *testing.T) {
+	mock := forbidForward(t)
+	svc, _ := newTestService(mock, true)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/absent", nil)
+	r.Header.Set("Cache-Control", "only-if-cached")
+	if err := svc.HandleGetObject(w, r); err != nil {
+		t.Fatalf("HandleGetObject() error = %v", err)
+	}
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", w.Code)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheMiss {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheMiss)
+	}
+}
+
+func TestOnlyIfCached_OverridesNoCacheRevalidation(t *testing.T) {
+	mock := forbidForward(t)
+	svc, c := newTestService(mock, true)
+	putOnlyIfCachedObject(t, c, "b", "k", "cached body")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	r.Header.Set("Cache-Control", "no-cache, only-if-cached")
+	if err := svc.HandleGetObject(w, r); err != nil {
+		t.Fatalf("HandleGetObject() error = %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (stored response, no revalidation)", w.Code)
+	}
+	if mock.conditionalCalled {
+		t.Error("no-cache must not force revalidation when only-if-cached forbids origin contact")
+	}
+}
+
+func TestOnlyIfCached_NoStoreStillAnswers504(t *testing.T) {
+	// no-store forbids using the cache and only-if-cached forbids the origin:
+	// nothing can be served, locally and definitively.
+	mock := forbidForward(t)
+	svc, c := newTestService(mock, true)
+	putOnlyIfCachedObject(t, c, "b", "k", "cached body")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	r.Header.Set("Cache-Control", "no-store, only-if-cached")
+	if err := svc.HandleGetObject(w, r); err != nil {
+		t.Fatalf("HandleGetObject() error = %v", err)
+	}
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", w.Code)
+	}
+}
+
+func TestOnlyIfCached_HeadHitServesMetadata(t *testing.T) {
+	mock := forbidForward(t)
+	svc, c := newTestService(mock, true)
+	putOnlyIfCachedObject(t, c, "b", "k", "hello world!")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodHead, "/b/k", nil)
+	r.Header.Set("Cache-Control", "only-if-cached")
+	if err := svc.HandleHeadObject(w, r); err != nil {
+		t.Fatalf("HandleHeadObject() error = %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get(XCacheHeader); got != XCacheHit {
+		t.Errorf("X-Cache = %q, want %q", got, XCacheHit)
+	}
+}
+
+func TestOnlyIfCached_HeadMissAnswers504Locally(t *testing.T) {
+	mock := forbidForward(t)
+	svc, _ := newTestService(mock, true)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodHead, "/b/absent", nil)
+	r.Header.Set("Cache-Control", "only-if-cached")
+	if err := svc.HandleHeadObject(w, r); err != nil {
+		t.Fatalf("HandleHeadObject() error = %v", err)
+	}
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", w.Code)
+	}
+}
+
+func TestOnlyIfCached_CacheDisabledAnswers504(t *testing.T) {
+	mock := forbidForward(t)
+	svc, _ := newTestService(mock, false)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	r.Header.Set("Cache-Control", "only-if-cached")
+	if err := svc.HandleGetObject(w, r); err != nil {
+		t.Fatalf("HandleGetObject() error = %v", err)
+	}
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", w.Code)
+	}
+}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -473,3 +473,13 @@ func shouldBypassCache(r *http.Request) bool {
 	cc := r.Header.Get("Cache-Control")
 	return strings.Contains(cc, "no-store")
 }
+
+// requestsOnlyIfCached reports whether the client forbade origin contact.
+// Per RFC 7234 §5.2.1.7, Cache-Control: only-if-cached means "serve a stored
+// response or answer 504 Gateway Timeout — never forward". It also overrides
+// no-cache/max-age=0: with origin contact forbidden, there is nothing to
+// revalidate against, so a stored response is served as-is.
+func requestsOnlyIfCached(r *http.Request) bool {
+	cc := r.Header.Get("Cache-Control")
+	return strings.Contains(strings.ToLower(cc), "only-if-cached")
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -714,6 +714,12 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 	bucket, key := ParseBucketKey(r)
 	forceRevalidate := shouldForceRevalidate(r)
 	bypassCache := shouldBypassCache(r)
+	onlyIfCached := requestsOnlyIfCached(r)
+	if onlyIfCached {
+		// Origin contact is forbidden: serve stored metadata without
+		// revalidation, or answer 504 locally below.
+		forceRevalidate = false
+	}
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleHeadObject")
 
@@ -752,6 +758,15 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 			}
 			// forceRevalidate but no ETag — fall through to upstream
 		}
+	}
+
+	// Cache-Control: only-if-cached — nothing served above means nothing can
+	// be served without the origin: answer 504 locally (RFC 7234 §5.2.1.7).
+	if onlyIfCached {
+		writeCacheStatus(w, XCacheMiss)
+		w.WriteHeader(http.StatusGatewayTimeout)
+		metrics.RecordRequest("HeadObject", "only_if_cached", time.Since(start).Seconds())
+		return nil
 	}
 
 	// Cache miss - forward to upstream. Set the X-Cache header (and the matching


### PR DESCRIPTION
First piece of #201 (tiered store mode), standalone: RFC 7234 §5.2.1.7 support. A GET or HEAD carrying `Cache-Control: only-if-cached` is served from cache or answered with a local `504 Gateway Timeout` — the origin is never contacted, in any mode. `only-if-cached` overrides `no-cache`/`max-age=0` revalidation (with origin contact forbidden there is nothing to revalidate against), and combined with `no-store` the answer is a definitive local 504.

Makes cheap, authoritative existence probes possible for clients with their own fallback path — in tiered mode this is what turns a miss into a final answer.

Tests pin: hit served with zero origin contact (all forwarder hooks fail the test if touched), miss → 504 + `X-Cache: MISS`, revalidation suppressed, no-store composition, HEAD variants, cache-disabled 504. Docs: cache-control.md section added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core read paths for GET/HEAD and alters status semantics (504 vs upstream fetch), but behavior is gated on an explicit client header and is covered by focused tests.
> 
> **Overview**
> Adds **RFC 7234 `Cache-Control: only-if-cached`** on GET and HEAD: TAG returns a cached response when one exists, or a **local `504 Gateway Timeout`** with `X-Cache: MISS` when it cannot serve without the origin—**no upstream forward or revalidation**.
> 
> When this directive is present, client-driven **`no-cache` / `max-age=0` revalidation is disabled** (stored bytes are served as-is). **`no-store` plus `only-if-cached`** still yields 504 because neither cache nor origin may be used. Metrics record an **`only_if_cached`** outcome for these responses.
> 
> Documentation in `cache-control.md` describes cache-only probes; tests assert zero origin contact on hits and the miss/disabled-cache/HEAD combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407666dc2fb26e301730eff75f09a3b07ea08315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->