### PR TITLE
feat: version-preconditioned populate paths

### DIFF
--- a/cache/block_cache_test.go
+++ b/cache/block_cache_test.go
@@ -385,7 +385,7 @@ func TestPutMetaTombstoneAware(t *testing.T) {
 	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: `"v1"`, ContentLength: 100, StatusCode: 200, BlockSize: 4}
 
 	// No tombstone → meta is written.
-	wrote, err := c.PutMetaTombstoneAware(ctx, bucket, key, meta, 60, time.Now().UnixNano())
+	wrote, err := c.PutMetaTombstoneAware(ctx, bucket, key, meta, 60, time.Now().UnixNano(), VersionAny)
 	if err != nil || !wrote {
 		t.Fatalf("PutMetaTombstoneAware = (%v, %v), want (true, nil)", wrote, err)
 	}
@@ -401,7 +401,7 @@ func TestPutMetaTombstoneAware(t *testing.T) {
 	writeStart := time.Now().UnixNano()
 	time.Sleep(time.Millisecond)
 	c.WriteTombstone(ctx, bucket, key)
-	wrote, err = c.PutMetaTombstoneAware(ctx, bucket, key, meta, 60, writeStart)
+	wrote, err = c.PutMetaTombstoneAware(ctx, bucket, key, meta, 60, writeStart, VersionAny)
 	if err != nil {
 		t.Fatalf("PutMetaTombstoneAware (tombstoned) err = %v", err)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -87,6 +87,54 @@ func (c *Cache) IsEnabled() bool {
 // Two-Key Pattern: Metadata and Body stored separately
 // ============================================================================
 
+// VersionAny requests a version-BUMPING unconditional meta write: last-write-
+// wins like a plain Put, but implemented as a CAS loop so the row stays
+// version-stamped. This upholds the package invariant that NO meta key is ever
+// written with a plain Put — a plain Put resets the row to the storage layer's
+// legacy version, which blinds DeleteIfETag's version guard for every
+// subsequent conditional operation on the key.
+const VersionAny = ^uint64(0)
+
+// putMetaVersioned writes metaBytes to metaKey under a version precondition.
+// expected == VersionAny preserves plain-Put semantics (unconditional,
+// last-write-wins) via a bounded read-CAS loop; any other value — including 0,
+// put-if-absent — is a strict precondition, and a lost race returns
+// (false, nil): the newer entry wins.
+func (c *Cache) putMetaVersioned(ctx context.Context, bucket, key, metaKey string, metaBytes []byte, ttl int64, expected uint64) (bool, error) {
+	if expected != VersionAny {
+		if _, err := c.client.PutIfVersion(ctx, metaKey, metaBytes, ttl, expected); err != nil {
+			if _, mismatch := cacheclient.IsVersionMismatch(err); mismatch {
+				log.Debug().Str("bucket", bucket).Str("key", key).Uint64("expected", expected).
+					Msg("Skipping meta write - version precondition lost to a newer write")
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	}
+	// Unconditional: retry the CAS against whatever is current. Contention on a
+	// single object's metadata is bounded by the populate paths racing it, so
+	// the loop terminating early is a pathology worth surfacing, not masking.
+	const maxAttempts = 8
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		_, version, found, err := c.client.GetWithVersion(ctx, metaKey)
+		if err != nil && !isNotFoundError(err) {
+			return false, err
+		}
+		if !found {
+			version = 0
+		}
+		_, err = c.client.PutIfVersion(ctx, metaKey, metaBytes, ttl, version)
+		if err == nil {
+			return true, nil
+		}
+		if _, mismatch := cacheclient.IsVersionMismatch(err); !mismatch {
+			return false, err
+		}
+	}
+	return false, fmt.Errorf("meta write for %s/%s lost %d consecutive version races", bucket, key, 8)
+}
+
 // PutWithMeta stores object metadata and body in separate cache entries.
 // This follows the gateway's LiteCache pattern for proper S3 caching.
 // IMPORTANT: Body is written BEFORE metadata to ensure metadata presence
@@ -132,8 +180,9 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 		return err
 	}
 
-	// Store metadata AFTER body is complete
-	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
+	// Store metadata AFTER body is complete. Version-bumping unconditional:
+	// same last-write-wins semantics as before, but the row stays stamped.
+	if _, err := c.putMetaVersioned(ctx, bucket, key, metaKey, metaBytes, int64(ttl), VersionAny); err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
 		// Leave the versioned body to age out via TTL rather than deleting it
 		// synchronously: a concurrent populate of the same ETag could have a reader
@@ -163,6 +212,12 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 // visible). It is false when the write was skipped without error — the object was not
 // cacheable (no ETag) or a newer tombstone superseded it — so callers can distinguish a
 // no-op from a real write (e.g. for metrics or a fallback).
+// The expected version is the precondition of the meta write (see
+// putMetaVersioned): 0 for a populate decided while the entry was absent,
+// the observed version for a read-modify-write, VersionAny to preserve
+// last-write-wins. The tombstone check is retained alongside it — tombstones
+// still order writers that carry no useful precondition (VersionAny), and
+// belt-and-braces costs one point read.
 func (c *Cache) PutWithMetaStreamTombstoneAware(
 	ctx context.Context,
 	bucket, key string,
@@ -170,6 +225,7 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 	body io.Reader,
 	ttl int,
 	writeStartTime int64, // Unix nano timestamp when write started
+	expected uint64, // version precondition for the meta write
 ) (wrote bool, err error) {
 	if !c.IsEnabled() {
 		return false, nil
@@ -225,12 +281,18 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		return false, nil
 	}
 
-	// Write metadata AFTER body (makes entry visible)
-	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
+	// Write metadata AFTER body (makes entry visible), under the version
+	// precondition. A lost precondition leaves the newer entry in place and the
+	// just-written body to TTL, like the tombstone branch.
+	wrote, err = c.putMetaVersioned(ctx, bucket, key, metaKey, metaBytes, int64(ttl), expected)
+	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
 		// Same rationale as the tombstone branch: leave the versioned body to TTL
 		// rather than risk truncating a concurrent same-version reader.
 		return false, err
+	}
+	if !wrote {
+		return false, nil
 	}
 
 	log.Debug().
@@ -240,6 +302,29 @@ func (c *Cache) PutWithMetaStreamTombstoneAware(
 		Int("meta_size", len(metaBytes)).
 		Msg("Cached object with metadata (streamed, tombstone-aware)")
 	return true, nil
+}
+
+// GetMetaWithVersion is GetMeta plus the meta row's CAS version — the value a
+// read-modify-write passes back as its precondition. Version 0 means absent.
+func (c *Cache) GetMetaWithVersion(ctx context.Context, bucket, key string) (*CachedObjectMeta, uint64, bool, error) {
+	if !c.IsEnabled() {
+		return nil, 0, false, nil
+	}
+	metaBytes, version, found, err := c.client.GetWithVersion(ctx, MakeMetaKey(bucket, key))
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, 0, false, nil
+		}
+		return nil, 0, false, err
+	}
+	if !found || metaBytes == nil {
+		return nil, 0, false, nil
+	}
+	meta, err := DecodeMeta(metaBytes)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	return meta, version, true, nil
 }
 
 // GetMeta retrieves only object metadata from cache (no body).
@@ -695,12 +780,14 @@ func (c *Cache) PutBlockStream(ctx context.Context, bucket, key, etag string, bl
 // like PutWithMetaStreamTombstoneAware: if an invalidation landed at or after writeStartTime
 // the write is skipped and wrote=false is returned. It is the visibility gate for a block-
 // mode entry — callers write the touched blocks first, then this meta last. See RFC 0001.
+// The expected version is the meta write's precondition (see putMetaVersioned).
 func (c *Cache) PutMetaTombstoneAware(
 	ctx context.Context,
 	bucket, key string,
 	meta *CachedObjectMeta,
 	ttl int,
 	writeStartTime int64,
+	expected uint64,
 ) (wrote bool, err error) {
 	if !c.IsEnabled() {
 		return false, nil
@@ -726,11 +813,7 @@ func (c *Cache) PutMetaTombstoneAware(
 			Msg("Skipping block-mode meta write - tombstone detected")
 		return false, nil
 	}
-	if err := c.client.Put(ctx, metaKey, metaBytes, int64(ttl)); err != nil {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache meta put error")
-		return false, err
-	}
-	return true, nil
+	return c.putMetaVersioned(ctx, bucket, key, metaKey, metaBytes, int64(ttl), expected)
 }
 
 // ============================================================================

--- a/cache/delete_if_etag_test.go
+++ b/cache/delete_if_etag_test.go
@@ -95,7 +95,7 @@ func TestDeleteIfETag_WritesTombstoneOnMatch(t *testing.T) {
 
 	// ...and its tombstone-aware meta write must now be refused.
 	meta := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1"`, StatusCode: 200}
-	wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", meta, 60, populateStart)
+	wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", meta, 60, populateStart, VersionAny)
 	if err != nil {
 		t.Fatalf("PutMetaTombstoneAware: %v", err)
 	}
@@ -136,16 +136,17 @@ func TestDeleteIfETag_VersionedReplacementInsideWindowSurvives(t *testing.T) {
 
 	seedEntry(t, c, "b", "k", `"v1"`, "body-v1")
 	wrapper.replace = func() {
-		// A CAS writer replaces the entry: the version bumps past the snapshot
-		// the delete is holding. Plain-written rows read as the legacy version
-		// (1), so that is the expectation the racer swaps against.
+		// A CAS writer replaces the entry: it reads the current version (via
+		// the raw client, not the wrapper, so the injection doesn't recurse)
+		// and swaps against it, bumping past the snapshot the delete holds.
 		v2 := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v2"`, StatusCode: 200}
 		encoded, err := v2.Encode()
 		if err != nil {
 			t.Errorf("encode v2: %v", err)
 			return
 		}
-		if _, err := mem.PutIfVersion(ctx, MakeMetaKey("b", "k"), encoded, 0, 1); err != nil {
+		_, cur, _, _ := mem.GetWithVersion(ctx, MakeMetaKey("b", "k"))
+		if _, err := mem.PutIfVersion(ctx, MakeMetaKey("b", "k"), encoded, 0, cur); err != nil {
 			t.Errorf("versioned replacement: %v", err)
 		}
 	}
@@ -166,15 +167,13 @@ func TestDeleteIfETag_VersionedReplacementInsideWindowSurvives(t *testing.T) {
 	}
 }
 
-// KNOWN LIMITATION, pinned as a tripwire: a PLAIN-put replacement inside the
-// window is still deleted, because a plain Put resets the row to the legacy
-// version (storage EffectiveRowVersion semantics) — version equality carries
-// no information between plain writes. Today every populate path writes meta
-// with a plain Put, so for those racers this guard equals the previous
-// compare-then-delete: the same window as before, never wider. Moving the
-// populate paths to version-stamped writes closes it; when that lands, this
-// test MUST flip to assert the replacement survives.
-func TestDeleteIfETag_PlainReplacementInsideWindowIsStillDeleted(t *testing.T) {
+// The tripwire, flipped: every meta write in this package is now
+// version-stamped (putMetaVersioned — strict preconditions or the VersionAny
+// bumping loop), so an ordinary populate replacing the entry inside the window
+// bumps the version and the guarded delete loses. This is the state the
+// original limitation test existed to force: the guard is now exact against
+// ALL of this package's writers, not only conditional ones.
+func TestDeleteIfETag_PopulateReplacementInsideWindowSurvives(t *testing.T) {
 	wrapper := &raceOnReadClient{CacheClient: cacheclient.NewMemoryCache()}
 	cfg := config.NewDefault()
 	c := NewCacheWithClient(wrapper, &cfg.Cache)
@@ -192,8 +191,11 @@ func TestDeleteIfETag_PlainReplacementInsideWindowIsStillDeleted(t *testing.T) {
 	if !wrapper.raced {
 		t.Fatal("test wiring: the replacement was never injected")
 	}
-	if !deleted {
-		t.Fatal("plain-put replacement survived the window: the populate paths " +
-			"now stamp versions - flip this test to assert survival")
+	if deleted {
+		t.Fatal("deleted = true: the guarded delete claimed a win over a populate's replacement")
+	}
+	meta, found, _ := c.GetMeta(ctx, "b", "k")
+	if !found || meta == nil || meta.ETag != `"v2"` {
+		t.Fatalf("populate replacement inside the CAS window was deleted: found=%v meta=%+v", found, meta)
 	}
 }

--- a/cache/etag_versioning_test.go
+++ b/cache/etag_versioning_test.go
@@ -128,7 +128,7 @@ func TestETagVersionedBody_EmptyETagNotCachedViaStream(t *testing.T) {
 
 	body := bytes.NewReader([]byte("body-bytes"))
 	meta := &CachedObjectMeta{Bucket: bucket, Key: key, ETag: "", ContentLength: 10, StatusCode: 200}
-	if _, err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1); err != nil {
+	if _, err := c.PutWithMetaStreamTombstoneAware(ctx, bucket, key, meta, body, 60, 1, VersionAny); err != nil {
 		t.Fatalf("PutWithMetaStreamTombstoneAware: %v", err)
 	}
 	if _, found, _ := c.GetMeta(ctx, bucket, key); found {

--- a/cache/versioned_populate_test.go
+++ b/cache/versioned_populate_test.go
@@ -1,0 +1,103 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/config"
+)
+
+func newVersionedTestCache() (*Cache, *cacheclient.MemoryCache) {
+	cfg := config.NewDefault()
+	mem := cacheclient.NewMemoryCache()
+	return NewCacheWithClient(mem, &cfg.Cache), mem
+}
+
+// A put-if-absent populate (expected 0) must refuse when an entry exists: the
+// racer that established it fetched the same-or-newer state and wins.
+func TestPutMetaTombstoneAware_PutIfAbsentRefusesExisting(t *testing.T) {
+	c, _ := newVersionedTestCache()
+	ctx := context.Background()
+
+	existing := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"racer"`, StatusCode: 200}
+	if wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", existing, 60, time.Now().UnixNano(), 0); err != nil || !wrote {
+		t.Fatalf("seed via put-if-absent = (%v, %v), want (true, nil)", wrote, err)
+	}
+
+	late := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"late"`, StatusCode: 200}
+	wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", late, 60, time.Now().UnixNano(), 0)
+	if err != nil {
+		t.Fatalf("PutMetaTombstoneAware: %v", err)
+	}
+	if wrote {
+		t.Fatal("put-if-absent overwrote an existing entry")
+	}
+	meta, found, _ := c.GetMeta(ctx, "b", "k")
+	if !found || meta.ETag != `"racer"` {
+		t.Fatalf("racer's entry disturbed: %+v", meta)
+	}
+}
+
+// A strict-version write must refuse when the entry moved past the snapshot.
+func TestPutMetaTombstoneAware_StaleVersionRefused(t *testing.T) {
+	c, _ := newVersionedTestCache()
+	ctx := context.Background()
+
+	v1 := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1"`, StatusCode: 200}
+	if wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", v1, 60, time.Now().UnixNano(), 0); err != nil || !wrote {
+		t.Fatalf("seed: (%v, %v)", wrote, err)
+	}
+	_, version, found, err := c.GetMetaWithVersion(ctx, "b", "k")
+	if err != nil || !found {
+		t.Fatalf("GetMetaWithVersion: found=%v err=%v", found, err)
+	}
+
+	// The entry moves on (an unconditional refresh)...
+	v2 := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v2"`, StatusCode: 200}
+	if wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", v2, 60, time.Now().UnixNano(), VersionAny); err != nil || !wrote {
+		t.Fatalf("refresh: (%v, %v)", wrote, err)
+	}
+
+	// ...and the stale snapshot's write must lose.
+	stale := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1-promoted"`, StatusCode: 200}
+	wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", stale, 60, time.Now().UnixNano(), version)
+	if err != nil {
+		t.Fatalf("stale write: %v", err)
+	}
+	if wrote {
+		t.Fatal("stale-version write clobbered a newer entry")
+	}
+	meta, _, _, _ := c.GetMetaWithVersion(ctx, "b", "k")
+	if meta == nil || meta.ETag != `"v2"` {
+		t.Fatalf("newer entry disturbed: %+v", meta)
+	}
+}
+
+// VersionAny preserves last-write-wins but keeps the row version-stamped, so a
+// subsequent guarded operation still distinguishes it from the snapshot a
+// racer holds.
+func TestVersionAny_BumpsVersion(t *testing.T) {
+	c, mem := newVersionedTestCache()
+	ctx := context.Background()
+
+	v1 := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1"`, StatusCode: 200}
+	if wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", v1, 60, time.Now().UnixNano(), VersionAny); err != nil || !wrote {
+		t.Fatalf("first: (%v, %v)", wrote, err)
+	}
+	_, ver1, _, _ := mem.GetWithVersion(ctx, MakeMetaKey("b", "k"))
+
+	v2 := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v2"`, StatusCode: 200}
+	if wrote, err := c.PutMetaTombstoneAware(ctx, "b", "k", v2, 60, time.Now().UnixNano(), VersionAny); err != nil || !wrote {
+		t.Fatalf("second: (%v, %v)", wrote, err)
+	}
+	_, ver2, _, _ := mem.GetWithVersion(ctx, MakeMetaKey("b", "k"))
+
+	if ver2 <= ver1 {
+		t.Fatalf("VersionAny write did not bump the version: %d -> %d", ver1, ver2)
+	}
+	if meta, _, _ := c.GetMeta(ctx, "b", "k"); meta == nil || meta.ETag != `"v2"` {
+		t.Fatal("last-write-wins semantics broken")
+	}
+}

--- a/handlers/block_cache_prefetch_benchmark_test.go
+++ b/handlers/block_cache_prefetch_benchmark_test.go
@@ -237,6 +237,29 @@ func (c *handlerPrefetchCacheClient) Put(ctx context.Context, key string, data [
 	return c.CacheClient.Put(ctx, key, data, ttlSeconds)
 }
 
+// The CAS operations route like Get/Put: metadata (the only CAS'd keys) stays
+// on the local client, block keys go to the remote owner.
+func (c *handlerPrefetchCacheClient) GetWithVersion(ctx context.Context, key string) ([]byte, uint64, bool, error) {
+	if !handlerPrefetchBlockKey(key) {
+		return c.local.GetWithVersion(ctx, key)
+	}
+	return c.CacheClient.GetWithVersion(ctx, key)
+}
+
+func (c *handlerPrefetchCacheClient) PutIfVersion(ctx context.Context, key string, data []byte, ttlSeconds int64, expected uint64) (uint64, error) {
+	if !handlerPrefetchBlockKey(key) {
+		return c.local.PutIfVersion(ctx, key, data, ttlSeconds, expected)
+	}
+	return c.CacheClient.PutIfVersion(ctx, key, data, ttlSeconds, expected)
+}
+
+func (c *handlerPrefetchCacheClient) DeleteIfVersion(ctx context.Context, key string, expected uint64) error {
+	if !handlerPrefetchBlockKey(key) {
+		return c.local.DeleteIfVersion(ctx, key, expected)
+	}
+	return c.CacheClient.DeleteIfVersion(ctx, key, expected)
+}
+
 func (c *handlerPrefetchCacheClient) GetRangeStream(ctx context.Context, key string, start, end int64, w io.Writer) error {
 	if !handlerPrefetchBlockKey(key) {
 		return c.local.GetRangeStream(ctx, key, start, end, w)
@@ -373,7 +396,7 @@ func newHandlerPrefetchBenchmarkFixture(tb testing.TB, remote bool, blockCount i
 		StatusCode:    http.StatusOK,
 		BlockSize:     blockSize,
 	}
-	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano(), cache.VersionAny); err != nil || !wrote {
 		tb.Fatalf("seed block metadata = (wrote=%t, err=%v)", wrote, err)
 	}
 	service := proxy.NewService(handlerPrefetchForwarder{}, store, cfg)

--- a/handlers/remote_block_miss_benchmark_test.go
+++ b/handlers/remote_block_miss_benchmark_test.go
@@ -403,6 +403,29 @@ func isRemoteBenchmarkBlock(key string) bool { return strings.HasPrefix(key, "bl
 
 func (c *remoteBlockOwnerClient) IsLocal(string) bool { return false }
 
+// The CAS operations route like Get/Put: metadata (the only CAS'd keys) stays
+// on the local client, block keys go to the remote owner.
+func (c *remoteBlockOwnerClient) GetWithVersion(ctx context.Context, key string) ([]byte, uint64, bool, error) {
+	if !isRemoteBenchmarkBlock(key) {
+		return c.local.GetWithVersion(ctx, key)
+	}
+	return c.CacheClient.GetWithVersion(ctx, key)
+}
+
+func (c *remoteBlockOwnerClient) PutIfVersion(ctx context.Context, key string, data []byte, ttlSeconds int64, expected uint64) (uint64, error) {
+	if !isRemoteBenchmarkBlock(key) {
+		return c.local.PutIfVersion(ctx, key, data, ttlSeconds, expected)
+	}
+	return c.CacheClient.PutIfVersion(ctx, key, data, ttlSeconds, expected)
+}
+
+func (c *remoteBlockOwnerClient) DeleteIfVersion(ctx context.Context, key string, expected uint64) error {
+	if !isRemoteBenchmarkBlock(key) {
+		return c.local.DeleteIfVersion(ctx, key, expected)
+	}
+	return c.CacheClient.DeleteIfVersion(ctx, key, expected)
+}
+
 func (c *remoteBlockOwnerClient) Get(ctx context.Context, key string) ([]byte, error) {
 	if !isRemoteBenchmarkBlock(key) {
 		return c.local.Get(ctx, key)
@@ -651,7 +674,7 @@ func (f *remoteBlockMissBenchmarkFixture) seedMeta(tb testing.TB, bucket, key st
 		StatusCode:    http.StatusOK,
 		BlockSize:     f.blockLen,
 	}
-	if wrote, err := f.cache.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+	if wrote, err := f.cache.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano(), cache.VersionAny); err != nil || !wrote {
 		tb.Fatalf("seed block metadata = (wrote=%t, err=%v)", wrote, err)
 	}
 	return meta

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -825,28 +825,33 @@ func (s *Service) serveFullObjectFromBlockCache(
 	// bound after an out-of-band overwrite) and guarantee a window where the meta outlives
 	// every block. Best-effort: a skipped or failed promotion only means the next full GET
 	// probes again.
-	if !meta.BlocksComplete {
-		if remaining := s.remainingMetaTTL(meta); remaining > 0 {
-			expectETag := meta.ETag
-			go func() {
-				pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
-				defer cancel()
-				// A promotion is a read-modify-write of live metadata, so it
-				// re-reads with the version and promotes THAT snapshot under a
-				// strict precondition: a concurrent overwrite's fresh entry can
-				// never be clobbered by a promoted copy of the old one. Any
-				// skip just means the next full GET probes again.
-				cur, version, found, gerr := s.cache.GetMetaWithVersion(pctx, bucket, key)
-				if gerr != nil || !found || cur == nil || cur.ETag != expectETag || cur.BlocksComplete {
-					return
-				}
-				promoted := *cur
-				promoted.BlocksComplete = true
-				if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, remaining, writeStartTime, version); perr != nil {
-					log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
-				}
-			}()
-		}
+	if !meta.BlocksComplete && s.remainingMetaTTL(meta) > 0 {
+		expectETag := meta.ETag
+		go func() {
+			pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
+			defer cancel()
+			// A promotion is a read-modify-write of live metadata, so it
+			// re-reads with the version and promotes THAT snapshot under a
+			// strict precondition: a concurrent overwrite's fresh entry can
+			// never be clobbered by a promoted copy of the old one. Any
+			// skip just means the next full GET probes again.
+			cur, version, found, gerr := s.cache.GetMetaWithVersion(pctx, bucket, key)
+			if gerr != nil || !found || cur == nil || cur.ETag != expectETag || cur.BlocksComplete {
+				return
+			}
+			// TTL from the RE-READ snapshot: the serve-path copy may have
+			// expired and been re-established since, and stamping the fresh
+			// row with the old copy's nearly-spent TTL would expire it early.
+			remaining := s.remainingMetaTTL(cur)
+			if remaining <= 0 {
+				return
+			}
+			promoted := *cur
+			promoted.BlocksComplete = true
+			if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, remaining, writeStartTime, version); perr != nil {
+				log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
+			}
+		}()
 	}
 
 	meta.WriteHeaders(w)

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -827,12 +827,22 @@ func (s *Service) serveFullObjectFromBlockCache(
 	// probes again.
 	if !meta.BlocksComplete {
 		if remaining := s.remainingMetaTTL(meta); remaining > 0 {
-			promoted := *meta
-			promoted.BlocksComplete = true
+			expectETag := meta.ETag
 			go func() {
 				pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
 				defer cancel()
-				if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, remaining, writeStartTime); perr != nil {
+				// A promotion is a read-modify-write of live metadata, so it
+				// re-reads with the version and promotes THAT snapshot under a
+				// strict precondition: a concurrent overwrite's fresh entry can
+				// never be clobbered by a promoted copy of the old one. Any
+				// skip just means the next full GET probes again.
+				cur, version, found, gerr := s.cache.GetMetaWithVersion(pctx, bucket, key)
+				if gerr != nil || !found || cur == nil || cur.ETag != expectETag || cur.BlocksComplete {
+					return
+				}
+				promoted := *cur
+				promoted.BlocksComplete = true
+				if _, perr := s.cache.PutMetaTombstoneAware(pctx, bucket, key, &promoted, remaining, writeStartTime, version); perr != nil {
 					log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
 				}
 			}()
@@ -1453,7 +1463,7 @@ func (s *Service) buildBlockMeta(bucket, key string, respHeader http.Header, tot
 // truncated bytes under a committed length (and poison a later range-path populate that trusts
 // existing blocks). fetchOneBlock validates block length the same way; this keeps the two block
 // writers consistent. A body longer than Content-Length is likewise rejected before the meta.
-func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, r io.Reader, ttl int, writeStartTime int64) (err error) {
+func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, r io.Reader, ttl int, writeStartTime int64, expected uint64) (err error) {
 	// On any early return, drain the rest of r. setupCacheListener feeds this from an io.Pipe; if
 	// we stop reading with bytes still queued (a mid-object PutBlockStream error, or an oversize
 	// body), the pipe writer goroutine blocks forever on Write, leaking it and never releasing the
@@ -1491,7 +1501,7 @@ func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, m
 	// Every block was just written, so stamp the meta complete: full-object serves can skip
 	// the per-block probe pass and stream optimistically.
 	meta.BlocksComplete = true
-	if _, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime); err != nil {
+	if _, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime, expected); err != nil {
 		return err
 	}
 	return nil
@@ -1544,7 +1554,11 @@ func (s *Service) finalizeBlockModeMeta(ctx context.Context, bucket, key string,
 		return
 	}
 	ttl := int(s.config.Cache.TTL.Seconds())
-	wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime)
+	// Put-if-absent: this establishment was decided right after the write's own
+	// invalidation cleared the entry. If a racer (a warm, another establish)
+	// repopulated first, its entry describes the same or a newer version — the
+	// lost precondition leaves it in place.
+	wrote, err := s.cache.PutMetaTombstoneAware(ctx, bucket, key, meta, ttl, writeStartTime, 0)
 	if err != nil || !wrote {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Bool("wrote", wrote).Msg("Block-mode meta not written (tombstone or error)")
 		return

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -888,7 +888,7 @@ func TestPutBlocksFromStream_ExactMultipleNoPhantomBlock(t *testing.T) {
 	meta := cache.MetaFromHTTPHeaders(wowBucket, wowKey, http.StatusOK, h)
 	meta.BlockSize = 4
 
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEFGH"), 60, time.Now().UnixNano()); err != nil {
+	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEFGH"), 60, time.Now().UnixNano(), cache.VersionAny); err != nil {
 		t.Fatalf("putBlocksFromStream: %v", err)
 	}
 	for i := int64(0); i <= 1; i++ {
@@ -918,7 +918,7 @@ func TestPutBlocksFromStream_MidStreamErrorLeavesMetaUnwritten(t *testing.T) {
 
 	// One full block, then a read error before the second.
 	r := &errAfterReader{data: []byte("ABCD")}
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, r, 60, time.Now().UnixNano()); err == nil {
+	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, r, 60, time.Now().UnixNano(), cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the mid-stream read failure")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
@@ -941,7 +941,7 @@ func TestPutBlocksFromStream_TruncatedStreamLeavesNoShortBlockOrMeta(t *testing.
 	meta.BlockSize = 4
 
 	// ...but the body carries only 6 bytes, ending cleanly (no read error).
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, time.Now().UnixNano()); err == nil {
+	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, time.Now().UnixNano(), cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the truncated body")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
@@ -966,7 +966,7 @@ func TestPutBlocksFromStream_OversizedStreamLeavesMetaUnwritten(t *testing.T) {
 	meta.BlockSize = 4
 
 	// ...but the body carries 6 bytes.
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, time.Now().UnixNano()); err == nil {
+	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, time.Now().UnixNano(), cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the oversized body")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {

--- a/proxy/block_cache_prefetch_test.go
+++ b/proxy/block_cache_prefetch_test.go
@@ -547,7 +547,7 @@ func TestBlockCache_PipelineConcurrentFillDoesNotExhaustInlineFetchCap(t *testin
 		StatusCode:    http.StatusOK,
 		BlockSize:     blockSize,
 	}
-	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano(), cache.VersionAny); err != nil || !wrote {
 		t.Fatalf("seed block metadata = (wrote=%t, err=%v)", wrote, err)
 	}
 

--- a/proxy/block_cache_remote_write_test.go
+++ b/proxy/block_cache_remote_write_test.go
@@ -161,7 +161,7 @@ func newGatedAssembledRangeService(t *testing.T, local bool) (*Service, *cache.C
 		StatusCode:    http.StatusOK,
 		BlockSize:     4,
 	}
-	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano()); err != nil || !wrote {
+	if wrote, err := store.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 60, time.Now().UnixNano(), cache.VersionAny); err != nil || !wrote {
 		t.Fatalf("seed block meta = (wrote=%t, err=%v)", wrote, err)
 	}
 	return svc, store, client, mock, meta, trace

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -250,11 +250,16 @@ func (s *Service) setupCacheListener(
 			// read-back. The whole-vs-block boundary is size, not access pattern (RFC 0001): both
 			// full and range paths converge on one representation per size class. Sub-block objects
 			// keep the single whole-body write.
+			// VersionAny: the miss path can legitimately run while metadata
+			// still exists (a forced-revalidation fall-through, an anonymous
+			// read of a non-public entry), and this populate IS the refresh —
+			// last-write-wins is the contract, version-stamped so the row
+			// stays CAS-meaningful.
 			if s.isBlockEligibleSize(meta.ContentLength) {
 				meta.BlockSize = s.config.Cache.BlockSize
-				cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime)
+				cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime, cache.VersionAny)
 			} else {
-				_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime)
+				_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, sigReader, ttl, writeStartTime, cache.VersionAny)
 			}
 			if cacheErr != nil {
 				log.Debug().Err(cacheErr).Str("bucket", bucket).Str("key", key).Msg("Cache write with metadata failed")
@@ -542,12 +547,15 @@ func (s *Service) fetchFullObjectToCache(
 		// Block-eligible full fetches retain the size-based representation used by the
 		// foreground miss path: blocks are written first and tombstone-aware metadata is
 		// published last. Smaller objects use the whole-body stream writer.
+		// Put-if-absent: background populates are triggered on a metadata miss,
+		// so their precondition is absence — a racer that re-established the
+		// entry first fetched the same-or-newer upstream state and wins.
 		if blockMode {
 			meta.BlockSize = s.config.Cache.BlockSize
-			cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, writeStartTime)
+			cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, writeStartTime, 0)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(
-				cacheCtx, bucket, key, meta, body, ttl, writeStartTime,
+				cacheCtx, bucket, key, meta, body, ttl, writeStartTime, 0,
 			)
 		}
 		cacheErrCh <- cacheErr

--- a/proxy/meta_on_write_measure_test.go
+++ b/proxy/meta_on_write_measure_test.go
@@ -123,7 +123,7 @@ func TestMeasure_FirstOpenUpstreamRoundTrips(t *testing.T) {
 // of this measurement produced "no improvement".
 func mustPrimeMeta(t *testing.T, c *cache.Cache, bucket, key string, meta *cache.CachedObjectMeta) {
 	t.Helper()
-	wrote, err := c.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 3600, time.Now().UnixNano())
+	wrote, err := c.PutMetaTombstoneAware(context.Background(), bucket, key, meta, 3600, time.Now().UnixNano(), cache.VersionAny)
 	if err != nil || !wrote {
 		t.Fatalf("prime meta: wrote=%v err=%v", wrote, err)
 	}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -221,10 +221,12 @@ func (s *Service) handleRevalidation200(
 		var cacheErr error
 		if s.isBlockEligibleSize(newMeta.ContentLength) {
 			newMeta.BlockSize = s.config.Cache.BlockSize
-			cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime)
+			// Put-if-absent: the guarded delete above cleared the stale entry;
+			// if a racer re-established one, it holds the fresh version and wins.
+			cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, 0)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(
-				context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime,
+				context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, 0,
 			)
 		}
 		if cacheErr != nil {

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -159,6 +159,33 @@ func (s *Service) handleRevalidation304(
 	return true, nil
 }
 
+// revalidationExpectedVersion picks the meta-write precondition for a
+// revalidation repopulate. The guarded delete that precedes the repopulate is
+// best-effort, so "expect absent" alone is wrong: a transiently failed delete
+// leaves the KNOWN-STALE row in place, and put-if-absent would then refuse the
+// replacement and keep serving stale data. Instead:
+//   - entry absent → 0 (put-if-absent);
+//   - the observed stale row still present → its version (the replacement
+//     overwrites exactly that row; if it moves first, the newer write wins);
+//   - anything else present → a racer already re-established a fresh entry →
+//     0, which is guaranteed to mismatch, skipping the write in its favor.
+//
+// A read failure returns 0 as well: refusing to overwrite is the safe
+// direction when the store cannot be consulted, and the entry converges via
+// the next revalidation or TTL.
+func (s *Service) revalidationExpectedVersion(bucket, key, staleETag string) uint64 {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cur, version, found, err := s.cache.GetMetaWithVersion(ctx, bucket, key)
+	if err != nil || !found || cur == nil {
+		return 0
+	}
+	if cur.ETag == staleETag {
+		return version
+	}
+	return 0
+}
+
 // handleRevalidation200 handles a 200 OK revalidation response (object changed).
 // Streams the new body to the client while simultaneously updating the cache.
 func (s *Service) handleRevalidation200(
@@ -216,17 +243,16 @@ func (s *Service) handleRevalidation200(
 	// blocks (size-only mode, RFC 0001) exactly as the read-miss/warm paths do — a revalidated
 	// whole-mode entry that grew into a block-eligible object must not be re-stored as one whole
 	// blob. Sub-block objects keep the whole-body write.
+	expected := s.revalidationExpectedVersion(bucket, key, staleETag)
 	cacheErrCh := make(chan error, 1)
 	go func() {
 		var cacheErr error
 		if s.isBlockEligibleSize(newMeta.ContentLength) {
 			newMeta.BlockSize = s.config.Cache.BlockSize
-			// Put-if-absent: the guarded delete above cleared the stale entry;
-			// if a racer re-established one, it holds the fresh version and wins.
-			cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, 0)
+			cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, expected)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(
-				context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, 0,
+				context.Background(), bucket, key, newMeta, pr, ttl, writeStartTime, expected,
 			)
 		}
 		if cacheErr != nil {

--- a/proxy/revalidation_cas_test.go
+++ b/proxy/revalidation_cas_test.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// failingDeleteClient fails the next DeleteIfVersion once — simulating the
+// transient backend failure that leaves a known-stale row in place after a
+// guarded delete.
+type failingDeleteClient struct {
+	cacheclient.CacheClient
+	failNext bool
+}
+
+func (f *failingDeleteClient) DeleteIfVersion(ctx context.Context, key string, expected uint64) error {
+	if f.failNext {
+		f.failNext = false
+		return errors.New("transient backend failure")
+	}
+	return f.CacheClient.DeleteIfVersion(ctx, key, expected)
+}
+
+// A successful revalidation must replace known-stale metadata even when the
+// preliminary guarded delete fails transiently. Put-if-absent alone would
+// refuse against the surviving stale row and keep serving it; the
+// revalidation precondition picker overwrites exactly that row instead.
+func TestRevalidation200_ReplacesStaleEntryAfterFailedDelete(t *testing.T) {
+	newBody := "fresh content"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(newBody)),
+			Header: http.Header{
+				"Content-Type":   []string{"text/plain"},
+				"Content-Length": []string{"13"},
+				"Etag":           []string{`"new"`},
+			},
+		},
+	}
+
+	wrapped := &failingDeleteClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	c := cache.NewCacheWithClient(wrapped, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	stale := &cache.CachedObjectMeta{
+		Bucket: bucket, Key: key, ETag: `"old"`,
+		ContentType: "text/plain", ContentLength: 5, StatusCode: http.StatusOK,
+	}
+	if err := c.PutWithMeta(ctx, bucket, key, stale, []byte("stale"), 0); err != nil {
+		t.Fatalf("seed stale entry: %v", err)
+	}
+
+	// The guarded delete inside the revalidation path fails once: the stale
+	// row survives it.
+	wrapped.failNext = true
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	if err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", stale, time.Now()); err != nil {
+		t.Fatalf("revalidateAndServe: %v", err)
+	}
+	if w.Body.String() != newBody {
+		t.Fatalf("client body = %q, want the fresh content", w.Body.String())
+	}
+
+	meta, found, err := c.GetMeta(ctx, bucket, key)
+	if err != nil || !found || meta == nil {
+		t.Fatalf("meta after revalidation: found=%v err=%v", found, err)
+	}
+	if meta.ETag != `"new"` {
+		t.Fatalf("meta ETag = %q: known-stale entry survived a successful revalidation", meta.ETag)
+	}
+}

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -259,7 +259,9 @@ func (s *Service) cacheTeedBodyFromHead(bucket, key, putETag string, body []byte
 	ttl := int(s.config.Cache.TTL.Seconds())
 	cacheCtx, cacheCancel := context.WithTimeout(context.Background(), cacheWriteTimeoutForSize(meta.ContentLength))
 	defer cacheCancel()
-	wrote, err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime)
+	// Put-if-absent: this tee follows the PUT's own invalidation; a racer that
+	// re-established the entry (a warm) caches the current version and wins.
+	wrote, err := s.cache.PutWithMetaStreamTombstoneAware(cacheCtx, bucket, key, meta, bytes.NewReader(body), ttl, writeStartTime, 0)
 	if err != nil {
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Write-through cache tee write failed")
 		return teeFallbackWarm

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -1141,7 +1141,7 @@ func TestBlockCache_ServeInteriorBlockRangeThroughHandler(t *testing.T) {
 		ContentLength: total, StatusCode: 200, BlockSize: blockSize,
 		LastModified: time.Now().Unix(),
 	}
-	wrote, err := env.Cache.PutMetaTombstoneAware(ctx, bucket, key, meta, 300, time.Now().UnixNano())
+	wrote, err := env.Cache.PutMetaTombstoneAware(ctx, bucket, key, meta, 300, time.Now().UnixNano(), cache.VersionAny)
 	require.NoError(t, err)
 	require.True(t, wrote, "block-mode meta write skipped")
 


### PR DESCRIPTION
PR 2 of the CAS adoption sequence (ocache#254 / v1.12.0; PR 1 was #210).

Every meta-key write now carries a version precondition via one choke point (`putMetaVersioned` in `cache/cache.go`): either a strict expectation, or `VersionAny` — last-write-wins preserved through a bounded CAS loop that keeps the row version-stamped. The package invariant this establishes: **no meta key is ever written with a plain Put**, because a plain Put resets the row to the storage legacy version and blinds `DeleteIfETag`'s guard.

Preconditions chosen by decision context:

- **Put-if-absent (expected 0)**: background populates (absent-gated triggers), the revalidation 200/206 repopulates (follow the guarded delete), the write-through tee (follows the PUT's own invalidation), and meta-on-write establishment. A racer that re-established the entry fetched same-or-newer upstream state and wins.
- **Last-write-wins (`VersionAny`)**: the foreground miss populate — it can legitimately run while metadata exists (forced-revalidation fall-through, anonymous read of a non-public entry) and the populate IS the refresh.
- **True read-modify-write**: the `BlocksComplete` promotion re-reads with the new `GetMetaWithVersion` and promotes that exact snapshot under its version — a concurrent overwrite's fresh entry can never be clobbered by a promoted copy of the old one.

Tombstone checks are retained alongside the preconditions (belt-and-braces; retirement is PR 3, after soak). Cost note: `VersionAny` adds one point-read per meta write (once per populate, after a full body transfer); strict sites add none.

**The PR-1 tripwire flips as designed**: `TestDeleteIfETag_PlainReplacementInsideWindowIsStillDeleted` becomes `...PopulateReplacementInsideWindowSurvives` — the delete guard is now exact against all of this package's writers, not only conditional ones.

Merge-order note: #203 (tiered mode) is not on main yet; on rebase its meta writers take the new parameter, and its identity guards can then adopt strict versions directly.

Tests: put-if-absent refusal, stale-version refusal, VersionAny version-bumping + last-write-wins, the flipped tripwire, and CAS routing added to the two handlers benchmark fixtures (meta stays on the local client, mirroring their Get/Put routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to cache populate, revalidation, and block promotion concurrency; correctness-critical but heavily tested and scoped to meta-write ordering rather than serve-path behavior.
> 
> **Overview**
> **All object metadata cache writes now go through `putMetaVersioned`** instead of plain `Put`, so every meta row stays version-stamped and `DeleteIfETag` stays effective against populate races.
> 
> Callers pass an **`expected` version**: **`0`** (put-if-absent) for background populates, write-through tee, and block-mode establishment; **`VersionAny`** (bounded CAS loop, last-write-wins) for foreground read-miss populates and unconditional paths like `PutWithMeta`; **observed version** for true read-modify-writes (`BlocksComplete` promotion re-reads via new **`GetMetaWithVersion`**; revalidation uses **`revalidationExpectedVersion`** so a failed guarded delete does not block replacing known-stale meta).
> 
> Tombstone gates are unchanged alongside these preconditions. Tests add versioned populate coverage, flip the prior `DeleteIfETag` plain-put limitation tripwire to assert populate replacements survive, and extend handler benchmark cache clients with CAS routing for meta keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f30478fc56d5cb7bd01239f0e7006b95f85a5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->