### PR TITLE
fix: background populates carry context-correct preconditions

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -104,6 +104,12 @@ func (c *Cache) putMetaVersioned(ctx context.Context, bucket, key, metaKey strin
 	if expected != VersionAny {
 		if _, err := c.client.PutIfVersion(ctx, metaKey, metaBytes, ttl, expected); err != nil {
 			if _, mismatch := cacheclient.IsVersionMismatch(err); mismatch {
+				// Debug + metric, per the repo's log policy: the counter is the
+				// rollout-visibility signal — a lost precondition replaces what
+				// was previously a SILENT lost update, so a low rate here is
+				// the feature working, and growth means a precondition was
+				// chosen wrong for its path.
+				metrics.RecordCacheOperation("meta_put", "precondition_lost")
 				log.Debug().Str("bucket", bucket).Str("key", key).Uint64("expected", expected).
 					Msg("Skipping meta write - version precondition lost to a newer write")
 				return false, nil

--- a/proxy/cache_background_benchmark_test.go
+++ b/proxy/cache_background_benchmark_test.go
@@ -30,6 +30,16 @@ func (c *benchmarkCompletionClient) Put(ctx context.Context, key string, data []
 	return err
 }
 
+// Metadata is committed through PutIfVersion since the populate paths became
+// version-preconditioned; the completion signal must observe it too.
+func (c *benchmarkCompletionClient) PutIfVersion(ctx context.Context, key string, data []byte, ttlSeconds int64, expected uint64) (uint64, error) {
+	version, err := c.CacheClient.PutIfVersion(ctx, key, data, ttlSeconds, expected)
+	if err == nil && strings.HasPrefix(key, c.metadataPrefix) {
+		c.completed <- struct{}{}
+	}
+	return version, err
+}
+
 type benchmarkWarmForwarder struct {
 	*mockForwarder
 	body []byte
@@ -123,7 +133,7 @@ func benchmarkBackgroundCachePopulate(b *testing.B, blockMode bool) {
 		started := make(chan struct{}, concurrency)
 		forwarder.setBatch(gate, started)
 		for _, key := range keys {
-			svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityReadMiss)
+			svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityReadMiss, 0)
 		}
 
 		for range keys {

--- a/proxy/cache_background_benchmark_test.go
+++ b/proxy/cache_background_benchmark_test.go
@@ -133,7 +133,7 @@ func benchmarkBackgroundCachePopulate(b *testing.B, blockMode bool) {
 		started := make(chan struct{}, concurrency)
 		forwarder.setBatch(gate, started)
 		for _, key := range keys {
-			svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityReadMiss, 0)
+			svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityReadMiss, cache.VersionAny)
 		}
 
 		for range keys {
@@ -159,7 +159,7 @@ func benchmarkBackgroundCachePopulate(b *testing.B, blockMode bool) {
 		for {
 			allGone := true
 			for _, key := range keys {
-				if _, loaded := svc.activeBackgroundFetches.Load("bg:" + bucket + "/" + key); loaded {
+				if _, loaded := svc.activeBackgroundFetches.Load(backgroundFetchKey(bucket, key, cache.VersionAny)); loaded {
 					allGone = false
 					break
 				}

--- a/proxy/cache_background_test.go
+++ b/proxy/cache_background_test.go
@@ -68,7 +68,7 @@ func TestFetchFullObjectToCache_DrainsUncacheableBody(t *testing.T) {
 		return resp
 	})
 
-	if err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "no-etag", "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "no-etag", "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 	if source == nil {
@@ -99,7 +99,7 @@ func TestFetchFullObjectToCache_DrainsBodyAfterCacheWriteFailure(t *testing.T) {
 	}
 	svc := NewService(forwarder, cacheStore, cfg)
 
-	if err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "partial-failure", "access", "secret", false, priorityReadMiss); err == nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "partial-failure", "access", "secret", false, priorityReadMiss, 0); err == nil {
 		t.Fatal("partial cache write failure was swallowed")
 	}
 	if source == nil {
@@ -129,7 +129,7 @@ func TestFetchFullObjectToCache_DrainsBodyWhenBlockScratchUnavailable(t *testing
 		return resp
 	})
 
-	err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "block-scratch-unavailable", "access", "secret", false, priorityReadMiss)
+	err := svc.fetchFullObjectToCache(context.Background(), "background-bucket", "block-scratch-unavailable", "access", "secret", false, priorityReadMiss, 0)
 	if !errors.Is(err, errCachePopulateDeclined) {
 		t.Fatalf("fetchFullObjectToCache error = %v, want errCachePopulateDeclined", err)
 	}
@@ -158,7 +158,7 @@ func TestFetchFullObjectToCache_WritesWholeBodyDirectly(t *testing.T) {
 		return cacheableGetResponse(body, etag)
 	})
 
-	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 
@@ -200,7 +200,7 @@ func TestFetchFullObjectToCache_SmallWholeObjectFitsWithoutBlockScratch(t *testi
 		return cacheableGetResponse(body, `"small-whole-etag"`)
 	})
 
-	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 	meta, found, err := cacheStore.GetMeta(context.Background(), bucket, key)
@@ -246,7 +246,7 @@ func TestFetchFullObjectToCache_WarmWaitsForBlockScratchWithoutHoldingCountSlot(
 
 	warmDone := make(chan error, 1)
 	go func() {
-		warmDone <- svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityWarmWrite)
+		warmDone <- svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityWarmWrite, 0)
 	}()
 	select {
 	case <-started:
@@ -308,7 +308,7 @@ func TestFetchFullObjectToCache_WritesBlockBodyDirectly(t *testing.T) {
 		return cacheableGetResponse(body, etag)
 	})
 
-	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 
@@ -353,7 +353,7 @@ func TestFetchFullObjectToCache_DetachedWriteSurvivesFetchCancellation(t *testin
 
 	ctx, cancelContext := context.WithCancel(context.Background())
 	cancel = cancelContext
-	if err := svc.fetchFullObjectToCache(ctx, bucket, key, "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(ctx, bucket, key, "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 	if _, found, err := cacheStore.GetMeta(context.Background(), bucket, key); err != nil || !found {
@@ -378,7 +378,7 @@ func TestFetchFullObjectToCache_TombstoneBlocksDirectWrite(t *testing.T) {
 		return cacheableGetResponse(body, `"stale-etag"`)
 	})
 
-	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss); err != nil {
+	if err := svc.fetchFullObjectToCache(context.Background(), bucket, key, "access", "secret", false, priorityReadMiss, 0); err != nil {
 		t.Fatalf("fetchFullObjectToCache: %v", err)
 	}
 	if _, found, err := cacheStore.GetMeta(context.Background(), bucket, key); err != nil {

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -388,6 +388,7 @@ func (s *Service) fetchFullObjectToCache(
 	bucket, key, accessKey, secretKey string,
 	anonymous bool,
 	prio populatePriority,
+	expected uint64, // meta-write precondition (see putMetaVersioned)
 ) error {
 	// This is a background fetch whose only purpose is to populate the cache, so
 	// reserve a cache-populate slot up front. If the concurrent-write limit is
@@ -547,15 +548,17 @@ func (s *Service) fetchFullObjectToCache(
 		// Block-eligible full fetches retain the size-based representation used by the
 		// foreground miss path: blocks are written first and tombstone-aware metadata is
 		// published last. Smaller objects use the whole-body stream writer.
-		// Put-if-absent: background populates are triggered on a metadata miss,
-		// so their precondition is absence — a racer that re-established the
-		// entry first fetched the same-or-newer upstream state and wins.
+		// The precondition comes from the trigger's context: 0 for the
+		// absent-gated re-warms, the stale row's version for a revalidation
+		// re-warm (so a FAILED guarded delete cannot leave known-stale state
+		// that put-if-absent then refuses to repair), VersionAny for the
+		// warm-after-write paths whose displaced version is unknown.
 		if blockMode {
 			meta.BlockSize = s.config.Cache.BlockSize
-			cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, writeStartTime, 0)
+			cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, writeStartTime, expected)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamTombstoneAware(
-				cacheCtx, bucket, key, meta, body, ttl, writeStartTime, 0,
+				cacheCtx, bucket, key, meta, body, ttl, writeStartTime, expected,
 			)
 		}
 		cacheErrCh <- cacheErr
@@ -593,7 +596,7 @@ func (s *Service) fetchFullObjectToCache(
 // cached as public-read (see fetchFullObjectToCache); accessKey/secretKey are then
 // ignored. Pass anonymous=true exactly when the triggering request was anonymous, so
 // public-read is only ever inferred from a confirmed anonymous read.
-func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool, prio populatePriority) {
+func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool, prio populatePriority, expected uint64) {
 	bcastKey := "bg:" + bucket + "/" + key
 
 	// Atomic check-and-set: if key exists, a fetch is already in progress
@@ -612,7 +615,7 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 		ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
 		defer cancel()
 
-		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, anonymous, prio)
+		err := s.fetchFullObjectToCache(ctx, bucket, key, accessKey, secretKey, anonymous, prio, expected)
 
 		switch {
 		case errors.Is(err, errCachePopulateDeclined):

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -597,11 +597,20 @@ func (s *Service) fetchFullObjectToCache(
 // ignored. Pass anonymous=true exactly when the triggering request was anonymous, so
 // public-read is only ever inferred from a confirmed anonymous read.
 func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey string, anonymous bool, prio populatePriority, expected uint64) {
-	bcastKey := "bg:" + bucket + "/" + key
+	// Coalesce only triggers with IDENTICAL commit semantics: the precondition
+	// is part of the dedup key. Keyed by bucket/key alone, a VersionAny write
+	// repair arriving while an absent-gated warm is in flight would be dropped
+	// WITH its precondition — the in-flight warm then loses to the write's
+	// newer tombstone (its stamp predates it) and the repair that would have
+	// fixed the surviving state never runs. Distinct-precondition fetches for
+	// one key are bounded by the distinct races that spawned them, and each is
+	// budget-gated like any populate; identical triggers (a read-miss stampede)
+	// still coalesce to one fetch.
+	bcastKey := fmt.Sprintf("bg:%s/%s|%d", bucket, key, expected)
 
-	// Atomic check-and-set: if key exists, a fetch is already in progress
+	// Atomic check-and-set: if key exists, an equivalent fetch is already in progress
 	if _, loaded := s.activeBackgroundFetches.LoadOrStore(bcastKey, struct{}{}); loaded {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Background fetch already in progress, coalescing")
+		log.Debug().Str("bucket", bucket).Str("key", key).Uint64("expected", expected).Msg("Equivalent background fetch already in progress, coalescing")
 		return
 	}
 

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -593,6 +593,14 @@ func (s *Service) fetchFullObjectToCache(
 // This avoids broadcast.Manager's "no late joiners" policy which incorrectly
 // allows multiple fetches when the first has already started streaming.
 // When anonymous is true the fetch is issued without credentials and, on success,
+// backgroundFetchKey is the coalescing key for one background fetch: bucket,
+// key, and the commit precondition. One definition, shared with the tests that
+// wait on in-flight markers, so a format change cannot silently break their
+// waits into instant misses.
+func backgroundFetchKey(bucket, key string, expected uint64) string {
+	return fmt.Sprintf("bg:%s/%s|%d", bucket, key, expected)
+}
+
 // cached as public-read (see fetchFullObjectToCache); accessKey/secretKey are then
 // ignored. Pass anonymous=true exactly when the triggering request was anonymous, so
 // public-read is only ever inferred from a confirmed anonymous read.
@@ -606,7 +614,7 @@ func (s *Service) triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey 
 	// one key are bounded by the distinct races that spawned them, and each is
 	// budget-gated like any populate; identical triggers (a read-miss stampede)
 	// still coalesce to one fetch.
-	bcastKey := fmt.Sprintf("bg:%s/%s|%d", bucket, key, expected)
+	bcastKey := backgroundFetchKey(bucket, key, expected)
 
 	// Atomic check-and-set: if key exists, an equivalent fetch is already in progress
 	if _, loaded := s.activeBackgroundFetches.LoadOrStore(bcastKey, struct{}{}); loaded {

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -353,7 +353,7 @@ func (s *Service) fetchAndBroadcast(
 		if upErr := broadcaster.Error(); upErr == nil ||
 			errors.Is(upErr, context.Canceled) || errors.Is(upErr, context.DeadlineExceeded) {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss, 0)
 			}
 		}
 	}
@@ -843,7 +843,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 	} else if cacheable {
 		defer func() {
 			if _, found, _ := s.cache.GetMeta(context.Background(), bucket, key); !found {
-				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
+				s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss, 0)
 			}
 		}()
 	}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -406,8 +406,12 @@ func (s *Service) handleRevalidation206Range(
 		totalSize <= s.config.Cache.SizeThreshold &&
 		s.cache.IsEnabled() &&
 		accessKey != "" && secretKey != "" {
-		// Revalidation re-warm is a read-triggered populate.
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss)
+		// Revalidation re-warm is a read-triggered populate. Its precondition
+		// comes from the same picker as the 200 path: the guarded delete above
+		// is best-effort, and if it failed the fetch must overwrite exactly
+		// the surviving known-stale row rather than being refused by
+		// put-if-absent.
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, hasNoAuthCredentials(r), priorityReadMiss, s.revalidationExpectedVersion(bucket, key, staleETag))
 	}
 
 	return copyErr

--- a/proxy/revalidation_cas_test.go
+++ b/proxy/revalidation_cas_test.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -151,6 +153,75 @@ func TestRevalidation206_BackgroundFetchReplacesStaleAfterFailedDelete(t *testin
 			meta, found, _ := c.GetMeta(ctx, bucket, key)
 			t.Fatalf("stale entry not replaced by the background fetch: found=%v meta=%+v", found, meta)
 		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// A VersionAny write repair must not be coalesced away behind an in-flight
+// absent-gated warm: the warm's commit loses to newer state by design, so
+// dropping the repair (with its precondition) leaves the wrong entry standing.
+func TestBackgroundFetchRepairNotCoalescedBehindWarm(t *testing.T) {
+	gate := make(chan struct{})
+	var calls atomic.Int64
+	mock := &mockForwarder{
+		doFullObjectFunc: func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+			n := calls.Add(1)
+			h := http.Header{}
+			h.Set("Content-Type", "text/plain")
+			if n == 1 {
+				// The absent-gated warm: held in flight until released.
+				<-gate
+				h.Set("ETag", `"old"`)
+				h.Set("Content-Length", "3")
+				return &http.Response{StatusCode: http.StatusOK, Header: h, ContentLength: 3, Body: io.NopCloser(strings.NewReader("old"))}, nil
+			}
+			h.Set("ETag", `"new"`)
+			h.Set("Content-Length", "3")
+			return &http.Response{StatusCode: http.StatusOK, Header: h, ContentLength: 3, Body: io.NopCloser(strings.NewReader("new"))}, nil
+		},
+	}
+	svc, c := newTestService(mock, true)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	// 1. Absent-gated warm starts and blocks in its upstream fetch.
+	svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityReadMiss, 0)
+	waitFor(t, func() bool { return calls.Load() == 1 })
+
+	// 2. A write repair triggers while the warm is in flight. It must run,
+	//    not coalesce: with the old bucket/key-only dedup it was dropped here.
+	svc.triggerBackgroundCacheFetch(bucket, key, "access", "secret", false, priorityWarmWrite, cache.VersionAny)
+	waitFor(t, func() bool {
+		meta, found, _ := c.GetMeta(ctx, bucket, key)
+		return found && meta != nil && meta.ETag == `"new"`
+	})
+
+	// 3. The released warm commits put-if-absent against the repaired entry
+	//    and must lose to it.
+	close(gate)
+	waitFor(t, func() bool {
+		if _, busy := svc.activeBackgroundFetches.Load(fmt.Sprintf("bg:%s/%s|%d", bucket, key, uint64(0))); busy {
+			return false
+		}
+		return true
+	})
+	meta, found, _ := c.GetMeta(ctx, bucket, key)
+	if !found || meta == nil || meta.ETag != `"new"` {
+		t.Fatalf("repair's entry lost to the stale warm: found=%v meta=%+v", found, meta)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("condition not reached within 3s")
+		case <-time.After(5 * time.Millisecond):
 		}
 	}
 }

--- a/proxy/revalidation_cas_test.go
+++ b/proxy/revalidation_cas_test.go
@@ -85,3 +85,72 @@ func TestRevalidation200_ReplacesStaleEntryAfterFailedDelete(t *testing.T) {
 		t.Fatalf("meta ETag = %q: known-stale entry survived a successful revalidation", meta.ETag)
 	}
 }
+
+// The 206 path's repair runs through the BACKGROUND fetch, and must replace
+// known-stale metadata even when the preliminary guarded delete failed — the
+// same contract as the 200 path, enforced through the trigger's precondition.
+func TestRevalidation206_BackgroundFetchReplacesStaleAfterFailedDelete(t *testing.T) {
+	freshBody := "fresh content!"
+	mock := &mockForwarder{
+		conditionalResp: &http.Response{
+			StatusCode: http.StatusPartialContent,
+			Body:       io.NopCloser(strings.NewReader("fres")),
+			Header: http.Header{
+				"Content-Type":  []string{"text/plain"},
+				"Content-Range": []string{"bytes 0-3/14"},
+				"Etag":          []string{`"new"`},
+			},
+		},
+		doFullObjectFunc: func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+			h := http.Header{}
+			h.Set("ETag", `"new"`)
+			h.Set("Content-Type", "text/plain")
+			h.Set("Content-Length", "14")
+			return &http.Response{StatusCode: http.StatusOK, Header: h, ContentLength: 14, Body: io.NopCloser(strings.NewReader(freshBody))}, nil
+		},
+	}
+
+	wrapped := &failingDeleteClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	c := cache.NewCacheWithClient(wrapped, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+	ctx := context.Background()
+	bucket, key := "b", "k"
+
+	stale := &cache.CachedObjectMeta{
+		Bucket: bucket, Key: key, ETag: `"old"`,
+		ContentType: "text/plain", ContentLength: 5, StatusCode: http.StatusOK,
+	}
+	if err := c.PutWithMeta(ctx, bucket, key, stale, []byte("stale"), 0); err != nil {
+		t.Fatalf("seed stale entry: %v", err)
+	}
+	wrapped.failNext = true
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/b/k", nil)
+	r.Header.Set("Range", "bytes=0-3")
+	r.Header.Set("Cache-Control", "no-cache")
+	// A credentialed request, so the background repair uses the signed fetch.
+	r.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=access/20260907/auto/s3/aws4_request")
+	if err := svc.revalidateAndServe(ctx, w, r, bucket, key, "access", "secret", stale, time.Now()); err != nil {
+		t.Fatalf("revalidateAndServe: %v", err)
+	}
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("client status = %d, want 206", w.Code)
+	}
+
+	// The repair is a background fetch: poll until the stale entry is replaced.
+	deadline := time.After(3 * time.Second)
+	for {
+		meta, found, _ := c.GetMeta(ctx, bucket, key)
+		if found && meta != nil && meta.ETag == `"new"` {
+			return
+		}
+		select {
+		case <-deadline:
+			meta, found, _ := c.GetMeta(ctx, bucket, key)
+			t.Fatalf("stale entry not replaced by the background fetch: found=%v meta=%+v", found, meta)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/proxy/revalidation_cas_test.go
+++ b/proxy/revalidation_cas_test.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -200,7 +199,7 @@ func TestBackgroundFetchRepairNotCoalescedBehindWarm(t *testing.T) {
 	//    and must lose to it.
 	close(gate)
 	waitFor(t, func() bool {
-		if _, busy := svc.activeBackgroundFetches.Load(fmt.Sprintf("bg:%s/%s|%d", bucket, key, uint64(0))); busy {
+		if _, busy := svc.activeBackgroundFetches.Load(backgroundFetchKey(bucket, key, 0)); busy {
 			return false
 		}
 		return true

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -886,7 +886,11 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 	// probe). See the doc comment: never infer public-read from a public write.
 	if hasNoAuthCredentials(r) {
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*anonymous*/, priorityWarmWrite)
+		// VersionAny: the warm follows this write's best-effort invalidation,
+		// and the displaced version's identity is unknown — the warm fetches
+		// the just-written current state, so last-write-wins is correct even
+		// over a survivor of a failed invalidation.
+		s.triggerBackgroundCacheFetch(bucket, key, "", "", true /*anonymous*/, priorityWarmWrite, cache.VersionAny)
 		return
 	}
 
@@ -895,7 +899,7 @@ func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 		return
 	}
 	metrics.WarmOnWriteTriggered.Inc()
-	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
+	s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite, cache.VersionAny)
 }
 
 // HandlePassthrough handles requests that are passed through without caching.

--- a/proxy/write_through.go
+++ b/proxy/write_through.go
@@ -193,7 +193,9 @@ func (s *Service) writeThroughCache(bucket, key string, ts *teeState) bool {
 		// only SPAWNS the fetch and returns, so this goroutine returns and its deferred release frees
 		// the slot, which the warm's (separate) blocking acquire then observes.
 		metrics.WarmOnWriteTriggered.Inc()
-		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite)
+		// VersionAny, like warmOnWrite: this warm follows the PUT's
+		// invalidation and must repair even a survivor of its failure.
+		s.triggerBackgroundCacheFetch(bucket, key, accessKey, secretKey, false /*anonymous*/, priorityWarmWrite, cache.VersionAny)
 	}()
 	return true
 }


### PR DESCRIPTION
Fixes the findings from the release PR's (#212) review — the same failed-delete-blocks-refresh class fixed for the 200 path in #211, which I missed on the paths that repair through the BACKGROUND populate:

- **206 re-warm**: precondition from the same picker as the 200 path (overwrite exactly the surviving stale row; put-if-absent when clear; guaranteed-mismatch when a fresh racer holds the key). Regression test drives the full 206 flow with a one-shot DeleteIfVersion failure and polls the background repair.
- **Warm-after-write (warmOnWrite + tee fallback)**: VersionAny — the displaced version's identity is unknown and the warm fetches the just-written current state, so last-write-wins repairs even a survivor of a failed invalidation.
- **Absent-gated re-warms** keep put-if-absent (their gate makes it exact).
- **Benchmark completion hook** observes PutIfVersion (metadata's commit path since #211); both background benchmarks complete in ms again instead of timing out.
- **Precondition losses get a metric**: `tag_cache_operations_total{operation="meta_put",result="precondition_lost"}` — per this repo's log policy (#150, discussed on four prior threads): per-request failure logging stays at Debug, the counter is the rollout-visibility signal. A low rate is the feature working (each count replaces a formerly-silent lost update); growth means a mis-chosen precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhPu9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache coalescing and versioned metadata commits on hot populate/revalidation paths; incorrect preconditions could leave stale entries or extra fetches, mitigated by new regression tests and a rollout metric.
> 
> **Overview**
> Background cache populates now thread an **`expected` meta-write precondition** from each trigger through `fetchFullObjectToCache`, instead of always using put-if-absent (`0`). **Absent-gated re-warms** still use `0`; **warm-on-write and tee fallback** use **`cache.VersionAny`** so repairs can overwrite state left behind by a failed invalidation; **206 revalidation re-warm** uses the same version picker as the 200 path (`revalidationExpectedVersion`) so a failed guarded delete does not block refresh.
> 
> **Dedup** keys in-flight background fetches by `backgroundFetchKey(bucket, key, expected)` so a `VersionAny` write repair is not dropped while an absent-gated warm is in flight.
> 
> **Observability:** lost version preconditions in `putMetaVersioned` increment **`meta_put` / `precondition_lost`** (debug log unchanged). Benchmark completion hooks **`PutIfVersion`** so metadata commits are detected again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9c6073bc0c56ebd2e7d97bd684e1ef8b10b42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->