### PR TITLE
fix: promotion commits under its pre-assembly token; legacy refuses expected=0

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -168,9 +168,11 @@ func (c *Cache) PutWithMeta(ctx context.Context, bucket, key string, meta *Cache
 // visible — refused atomically if the entry changed (including a fenced
 // delete) since the caller's token was read.
 //
-// The expected version is the meta write's precondition: 0 for legacy
-// unordered put-if-absent, a decision-time token (live version or absence
-// token) for an ordered populate, VersionAny for last-write-wins.
+// The expected version is the meta write's precondition: a decision-time
+// token (live version or absence token) for an ordered populate, VersionAny
+// for last-write-wins. 0 is unordered put-if-absent under the CAS
+// coordinator but is REFUSED by the legacy coordinator (nothing to order
+// against) — production callers always carry a nonzero token.
 //
 // Returns wrote=true only when the metadata was actually written (the entry
 // is now visible). It is false when the write was skipped without error — the

--- a/cache/coordinator.go
+++ b/cache/coordinator.go
@@ -256,6 +256,15 @@ func (c *legacyCoordinator) getMetaWithVersion(ctx context.Context, bucket, key 
 }
 
 func (c *legacyCoordinator) putMeta(ctx context.Context, bucket, key, metaKey string, metaBytes []byte, ttl int64, expected uint64) (bool, error) {
+	if expected == 0 {
+		// No decision-time token to order against. The CAS coordinator's
+		// expected==0 is unordered put-if-absent; that has no tombstone
+		// analogue, and writing here could resurrect an invalidated entry.
+		// Refuse — a skipped cache write is always safe. Production callers
+		// always carry a nonzero token (legacy stamps are wall-clock nanos).
+		metrics.RecordCacheOperation("meta_put", "precondition_lost")
+		return false, nil
+	}
 	if expected != VersionAny {
 		// Tombstone gate right before the visibility-granting meta write: an
 		// invalidation at or after the caller's decision-time stamp blocks the

--- a/cache/coordinator_test.go
+++ b/cache/coordinator_test.go
@@ -132,3 +132,22 @@ func TestLegacyCoordinator_NeverCallsCASAPI(t *testing.T) {
 	}
 	_ = time.Now()
 }
+
+// expected==0 carries no decision-time token, so the legacy coordinator must
+// refuse it outright — even on a virgin key with no tombstone anywhere.
+func TestLegacyCoordinator_ZeroExpectedRefused(t *testing.T) {
+	c, mem := newLegacyTestCache()
+	ctx := context.Background()
+
+	meta := &CachedObjectMeta{Bucket: "b", Key: "k", ETag: `"v1"`, StatusCode: 200}
+	wrote, err := c.PutMetaIfVersion(ctx, "b", "k", meta, 60, 0)
+	if err != nil {
+		t.Fatalf("PutMetaIfVersion(expected=0): %v", err)
+	}
+	if wrote {
+		t.Fatal("legacy coordinator accepted an unordered expected=0 write")
+	}
+	if data, err := mem.Get(ctx, MakeMetaKey("b", "k")); err == nil && data != nil {
+		t.Fatal("refused write still landed in the store")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/memberlist v0.3.1 // indirect
 	github.com/hashicorp/serf v0.9.7 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/linxGnu/grocksdb v1.10.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -784,6 +784,19 @@ func (s *Service) serveFullObjectFromBlockCache(
 		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Complete-serve buffer budget declined - serving via probe path")
 	}
 
+	// Decision-time token for the post-assembly promotion, read BEFORE assembly begins: the
+	// promotion's claim ("every block present") is decided by the assembly, so an invalidation
+	// landing DURING it must refuse the commit. A token read after assembly would postdate such
+	// an invalidation and let the promotion mark a concurrently re-established (possibly
+	// partial) same-ETag entry complete. A failed token read just skips the promotion.
+	var promoToken uint64
+	promoTokenOK := false
+	if !meta.BlocksComplete {
+		if _, tok, _, terr := s.cache.GetMetaWithVersion(ctx, bucket, key); terr == nil {
+			promoToken, promoTokenOK = tok, true
+		}
+	}
+
 	// A full GET must produce every block. bailIfMostlyMissing=true asks ensureBlocksCached to
 	// fall through (rather than assemble) when most blocks are absent — e.g. only a footer range
 	// was ever cached — since per-block assembly would be a large amplification versus one
@@ -813,25 +826,26 @@ func (s *Service) serveFullObjectFromBlockCache(
 		return false, ferr
 	}
 
-	// Every block is now present: promote the entry to complete (async, version-preconditioned with
-	// the pre-assembly timestamp, so a racing invalidation blocks the write) — later full GETs
-	// then take the probe-free path instead of re-probing every block. The rewrite carries the
-	// entry's REMAINING TTL, never a fresh one: promotion does not consult upstream, so
-	// extending the lifetime would reset the staleness clock (up to doubling the configured
-	// bound after an out-of-band overwrite) and guarantee a window where the meta outlives
-	// every block. Best-effort: a skipped or failed promotion only means the next full GET
-	// probes again.
-	if !meta.BlocksComplete && s.remainingMetaTTL(meta) > 0 {
+	// Every block is now present: promote the entry to complete (async, committed under the
+	// PRE-assembly token, so an invalidation racing the assembly refuses the write) — later
+	// full GETs then take the probe-free path instead of re-probing every block. The rewrite
+	// carries the entry's REMAINING TTL, never a fresh one: promotion does not consult
+	// upstream, so extending the lifetime would reset the staleness clock (up to doubling the
+	// configured bound after an out-of-band overwrite) and guarantee a window where the meta
+	// outlives every block. Best-effort: a skipped or failed promotion only means the next
+	// full GET probes again.
+	if !meta.BlocksComplete && promoTokenOK && s.remainingMetaTTL(meta) > 0 {
 		expectETag := meta.ETag
 		go func() {
 			pctx, cancel := context.WithTimeout(context.Background(), cacheWriteTimeout)
 			defer cancel()
-			// A promotion is a read-modify-write of live metadata, so it
-			// re-reads with the version and promotes THAT snapshot under a
-			// strict precondition: a concurrent overwrite's fresh entry can
-			// never be clobbered by a promoted copy of the old one. Any
-			// skip just means the next full GET probes again.
-			cur, version, found, gerr := s.cache.GetMetaWithVersion(pctx, bucket, key)
+			// Re-read for the CONTENT to promote (a promoted copy of a stale
+			// snapshot must never clobber a fresh entry) — but commit under
+			// the pre-assembly decision-time token: any invalidation or
+			// overwrite since that read, including one DURING the assembly,
+			// loses the precondition. Any skip just means the next full GET
+			// probes again.
+			cur, _, found, gerr := s.cache.GetMetaWithVersion(pctx, bucket, key)
 			if gerr != nil || !found || cur == nil || cur.ETag != expectETag || cur.BlocksComplete {
 				return
 			}
@@ -844,7 +858,7 @@ func (s *Service) serveFullObjectFromBlockCache(
 			}
 			promoted := *cur
 			promoted.BlocksComplete = true
-			if _, perr := s.cache.PutMetaIfVersion(pctx, bucket, key, &promoted, remaining, version); perr != nil {
+			if _, perr := s.cache.PutMetaIfVersion(pctx, bucket, key, &promoted, remaining, promoToken); perr != nil {
 				log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Blocks-complete promotion failed")
 			}
 		}()

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -788,11 +788,14 @@ func (s *Service) serveFullObjectFromBlockCache(
 	// promotion's claim ("every block present") is decided by the assembly, so an invalidation
 	// landing DURING it must refuse the commit. A token read after assembly would postdate such
 	// an invalidation and let the promotion mark a concurrently re-established (possibly
-	// partial) same-ETag entry complete. A failed token read just skips the promotion.
+	// partial) same-ETag entry complete. The token counts only with its OWN snapshot live and
+	// carrying the serve ETag — an absent or different-ETag entry means the serve-path copy is
+	// already displaced, and its token could order the commit against the wrong history. A
+	// failed or disqualified read just skips the promotion.
 	var promoToken uint64
 	promoTokenOK := false
 	if !meta.BlocksComplete {
-		if _, tok, _, terr := s.cache.GetMetaWithVersion(ctx, bucket, key); terr == nil {
+		if cur, tok, found, terr := s.cache.GetMetaWithVersion(ctx, bucket, key); terr == nil && found && cur != nil && cur.ETag == meta.ETag {
 			promoToken, promoTokenOK = tok, true
 		}
 	}

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -12,9 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	cacheclient "github.com/tigrisdata/ocache/client"
 	"github.com/tigrisdata/tag/cache"
 	"github.com/tigrisdata/tag/config"
+	"github.com/tigrisdata/tag/metrics"
 )
 
 // blockMockForwarder serves range GETs from a backing object, for both the initial
@@ -1896,6 +1898,12 @@ func TestBlockCache_PromotionRefusedWhenInvalidationRacesAssembly(t *testing.T) 
 		t.Fatal("meta not populated")
 	}
 
+	// The refused promotion is observable as a precondition_lost meta_put — the
+	// only such refusal in this flow (the hook's own re-establishment is checked
+	// to succeed), so waiting on it synchronizes with the fire-and-forget
+	// promotion goroutine instead of racing it with a fixed sleep.
+	lostBefore := testutil.ToFloat64(metrics.CacheOperations.WithLabelValues("meta_put", "precondition_lost"))
+
 	// Full GET assembles block 2 (firing the hook mid-assembly) and serves.
 	w2 := httptest.NewRecorder()
 	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
@@ -1908,13 +1916,20 @@ func TestBlockCache_PromotionRefusedWhenInvalidationRacesAssembly(t *testing.T) 
 		t.Fatal("hook never fired: assembly did not write the missing block")
 	}
 
-	// The re-established entry must never be promoted by the displaced assembly.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
+	// The displaced assembly's promotion must be attempted AND refused; the
+	// re-established entry stays !BlocksComplete throughout.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
 		m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
 		if found && m.BlocksComplete {
 			t.Fatal("promotion committed over a mid-assembly invalidation")
 		}
-		time.Sleep(10 * time.Millisecond)
+		if testutil.ToFloat64(metrics.CacheOperations.WithLabelValues("meta_put", "precondition_lost")) > lostBefore {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("promotion refusal never observed")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -1831,3 +1831,90 @@ func TestBlockCache_SequentialClientWriteFailureDoesNotFetchRemainder(t *testing
 
 // clientForwards reports how many client-range forwards have hit upstream.
 func (m *blockMockForwarder) clientForwards() int32 { return m.forwards.Load() }
+
+// blockPutHookClient fires hook once, synchronously, on the first PutStream of hookKey —
+// letting a test interleave an invalidation with a block assembly in progress.
+type blockPutHookClient struct {
+	cacheclient.CacheClient
+	hookKey string
+	fired   atomic.Bool
+	hook    func()
+}
+
+func (h *blockPutHookClient) PutStream(ctx context.Context, key string, r io.Reader, ttl int64) error {
+	if key == h.hookKey && h.fired.CompareAndSwap(false, true) {
+		h.hook()
+	}
+	return h.CacheClient.PutStream(ctx, key, r, ttl)
+}
+
+// An invalidation landing DURING the full-GET assembly must refuse the
+// blocks-complete promotion: the promotion's token is read before assembly, so
+// the mid-assembly delete + same-ETag re-establishment (whose blocks the
+// promotion knows nothing about) stays !BlocksComplete. Regression test for
+// the post-assembly token read, under the default legacy coordination.
+func TestBlockCache_PromotionRefusedWhenInvalidationRacesAssembly(t *testing.T) {
+	mock := newBlockMock([]byte("ABCDEFGHIJ"), `"v1"`)
+	hooked := &blockPutHookClient{
+		CacheClient: cacheclient.NewMemoryCache(),
+		hookKey:     cache.MakeBlockKey(wowBucket, wowKey, `"v1"`, 4, 2),
+	}
+	cfg := config.NewDefault()
+	cfg.Cache.SetBlockCachingEnabled(true)
+	cfg.Cache.BlockSize = 4
+	cfg.Cache.SizeThreshold = 1 << 20
+	c := cache.NewCacheWithClient(hooked, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// The moment assembly writes the missing block: invalidate, then
+	// re-establish the same-ETag entry (as a fresh partial populate would).
+	hooked.hook = func() {
+		ctx := context.Background()
+		prior, found, _ := c.GetMeta(ctx, wowBucket, wowKey)
+		if !found {
+			t.Error("hook: no meta to displace")
+			return
+		}
+		if err := c.DeleteWithMeta(ctx, wowBucket, wowKey); err != nil {
+			t.Errorf("hook: invalidation: %v", err)
+			return
+		}
+		_, tok, _, _ := c.GetMetaWithVersion(ctx, wowBucket, wowKey)
+		fresh := *prior
+		fresh.BlocksComplete = false
+		if wrote, err := c.PutMetaIfVersion(ctx, wowBucket, wowKey, &fresh, 60, tok); err != nil || !wrote {
+			t.Errorf("hook: re-establish: wrote=%v err=%v", wrote, err)
+		}
+	}
+
+	// Partial entry via a cold range miss (blocks 0,1 of 3).
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, blockGet(wowBucket, wowKey, "bytes=0-7")); err != nil {
+		t.Fatalf("cold range miss: %v", err)
+	}
+	if !metaCached(c, wowBucket, wowKey, 2*time.Second) {
+		t.Fatal("meta not populated")
+	}
+
+	// Full GET assembles block 2 (firing the hook mid-assembly) and serves.
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w2, fullGet(wowBucket, wowKey)); err != nil {
+		t.Fatalf("full GET: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Body.String() != "ABCDEFGHIJ" {
+		t.Fatalf("full GET: code=%d body=%q", w2.Code, w2.Body.String())
+	}
+	if !hooked.fired.Load() {
+		t.Fatal("hook never fired: assembly did not write the missing block")
+	}
+
+	// The re-established entry must never be promoted by the displaced assembly.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		m, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey)
+		if found && m.BlocksComplete {
+			t.Fatal("promotion committed over a mid-assembly invalidation")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Fixes the two Cursor findings from the release-PR review of the coordinator change:

- **Promotion token read too late** (`proxy/block_cache.go`): the blocks-complete promotion took its version token from a re-read AFTER assembly. Under legacy coordination that stamp postdates a tombstone written mid-assembly, so a delete + same-ETag re-establishment racing the assembly could get its (possibly partial) fresh entry marked `BlocksComplete`. The token is now read before assembly begins — the promotion's actual decision point — and the commit is refused by any invalidation or overwrite since, in both modes. Regression test interleaves an invalidation with the assembly via a block-write hook and fails against the old code.
- **`expected=0` silently no-ops in legacy** (`cache/coordinator.go`): the tombstone gate's `ts >= expected` refused 0 even on a virgin key, diverging silently from the CAS coordinator's documented put-if-absent. Now an explicit, documented refusal (counted as `precondition_lost`): legacy has no token to order 0 against, and writing could resurrect an invalidated entry. Production callers always carry a nonzero token; the public API doc states the per-mode behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes version-precondition semantics on block-cache promotion and legacy meta writes—correctness-critical cache paths, but scoped to edge races and documented refusal of expected=0 rather than broad behavior changes.
> 
> **Overview**
> Fixes two cache-coordination correctness gaps from the coordinator rollout.
> 
> **Block-cache promotion:** Full-object serves that assemble missing blocks no longer take the version token from a meta re-read after assembly. The token is captured **before** `ensureBlocksCached` runs, and the async `BlocksComplete` promotion commits with that pre-assembly token (content still comes from a guarded re-read). Invalidations or same-ETag re-establishments during assembly therefore lose the precondition instead of incorrectly promoting a possibly partial entry.
> 
> **Legacy coordinator:** `putMeta` with `expected == 0` is now an explicit no-op (`precondition_lost`), documented as distinct from the CAS coordinator’s unordered put-if-absent—avoiding silent divergence and unsafe writes that could resurrect invalidated metadata.
> 
> Adds unit/integration regression tests (zero-expected refusal; mid-assembly invalidation vs promotion) and clarifies `PutWithMetaStreamIfVersion` docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83726f7e12a1329bad3bcc7100c2305f40aac6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->