### PR TITLE
build: tolerate apt index-refresh failures in install-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,12 @@ ifeq ($(UNAME_S),Darwin)
 	brew install snappy lz4 zstd bzip2 zlib
 else
 	@echo "Detected Linux - using apt-get..."
-	sudo apt-get update
+	# A broken THIRD-PARTY repo (e.g. the CI runner image's Chrome repo serving a
+	# Hash Sum mismatch) fails apt-get update outright, though the compression libs
+	# below come from the main Ubuntu archive. Tolerate index-refresh failures and
+	# let install decide: it succeeds from existing/partial indexes, and still
+	# fails loudly if the packages genuinely cannot be resolved.
+	sudo apt-get update || echo "WARNING: apt-get update failed (broken unrelated repo?) - installing from existing indexes"
 	sudo apt-get install -y libsnappy-dev liblz4-dev libzstd-dev libbz2-dev zlib1g-dev
 endif
 	@echo "System dependencies installed successfully."


### PR DESCRIPTION
The v1.21.0 release run failed twice on `make install-deps`: the runner image's pre-installed Chrome repo served a Hash Sum mismatch, and the blanket `apt-get update` fails on any broken repo — including ones irrelevant to the five compression libs we install from the main Ubuntu archive. `apt-get update` failures now warn and fall through to `apt-get install`, which works from existing indexes and still fails loudly if the packages genuinely cannot resolve. Same hardening spirit as benchmark.yaml's apt-mirror repoint; covers the release, test, and nightly benchmark workflows, which all call this target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9