### PR TITLE
Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,12 @@ ifeq ($(UNAME_S),Darwin)
 	brew install snappy lz4 zstd bzip2 zlib
 else
 	@echo "Detected Linux - using apt-get..."
-	sudo apt-get update
+	# A broken THIRD-PARTY repo (e.g. the CI runner image's Chrome repo serving a
+	# Hash Sum mismatch) fails apt-get update outright, though the compression libs
+	# below come from the main Ubuntu archive. Tolerate index-refresh failures and
+	# let install decide: it succeeds from existing/partial indexes, and still
+	# fails loudly if the packages genuinely cannot be resolved.
+	sudo apt-get update || echo "WARNING: apt-get update failed (broken unrelated repo?) - installing from existing indexes"
 	sudo apt-get install -y libsnappy-dev liblz4-dev libzstd-dev libbz2-dev zlib1g-dev
 endif
 	@echo "System dependencies installed successfully."


### PR DESCRIPTION
Brings #220 (apt index-refresh tolerance in install-deps) into the release branch: the v1.21.0 release run failed three times on the runner's broken Chrome apt repo before the build/release jobs could start. Merging re-triggers the release workflow with the hardened Makefile; semantic release then cuts v1.21.0 with the full CAS line already on this branch (#210, #211, #213, #216, #218 — see #212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only change for Linux dependency install; package install still fails if libs are missing, with slightly more tolerance when apt indexes are stale.
> 
> **Overview**
> Hardens the Linux **`install-deps`** Makefile target so CI/release jobs are less likely to fail when **`apt-get update`** breaks because of an unrelated third-party apt repo (e.g. a Chrome repo hash mismatch on the runner).
> 
> Instead of aborting on a failed index refresh, **`apt-get update`** is allowed to fail with a warning while **`apt-get install`** for the RocksDB compression dev packages still runs from existing or partial indexes; installs still fail if those packages cannot be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd05ce9b0e5221a902e81882510eebe1e739abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->