### PR TITLE
Release

### DIFF
--- a/.github/workflows/s3-tests.yaml
+++ b/.github/workflows/s3-tests.yaml
@@ -28,15 +28,17 @@ jobs:
       contents: read
       packages: write
 
-    # Run the suite with the default (whole-object caching) config only. The blocks
-    # variant was dropped from CI to halve the duplicate compat runs; run it locally
-    # with `make s3-test-local-blocks` when touching block populate/assembly/range
-    # paths. The matrix form is kept so the job name (and any required-check
-    # reference to it) stays stable.
+    # default = the whole-object proxy config; tiered = TAG_MODE=tiered running the
+    # tiered PROFILE of the suite (the listings / server-side-copy / object-sub-
+    # resource classes are skipped — by-design limitations, see docs/tiered-mode.md
+    # and the class comments in run-tests.sh — so the job is a stable green-or-red
+    # signal for the paths tiered DOES implement). The blocks variant was dropped
+    # from CI to halve the duplicate compat runs; run it locally with
+    # `make s3-test-local-blocks` when touching block populate/assembly/range paths.
     strategy:
       fail-fast: false
       matrix:
-        cache_mode: [default]
+        cache_mode: [default, tiered]
 
     name: s3-compat-tests (${{ matrix.cache_mode }})
 
@@ -67,15 +69,19 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: make ${{ matrix.cache_mode == 'blocks' && 's3-test-local-blocks' || 's3-test-local' }}
+        run: make ${{ matrix.cache_mode == 'tiered' && 's3-test-local-tiered' || 's3-test-local' }}
 
       - name: Run S3 compatibility tests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3TEST_PROFILE: ${{ matrix.cache_mode == 'tiered' && 'tiered' || 'default' }}
         run: make s3-tests
 
       - name: Run SDK tests
+        # Default config only: the Go SDK suite has no tiered profile yet — it
+        # exercises listings and copies that tiered punts by design.
+        if: matrix.cache_mode == 'default'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,10 @@ run: build
 run-verbose: build
 	TAG_LOG_LEVEL=debug ./$(BINARY_NAME)
 
+.PHONY: run-tiered
+run-tiered: build
+	TAG_MODE=tiered ./$(BINARY_NAME)
+
 # Clean targets
 .PHONY: clean
 clean:
@@ -364,10 +368,12 @@ help:
 	@echo "Run targets:"
 	@echo "  run           - Run TAG with default options (use --help for CLI flags)"
 	@echo "  run-verbose   - Run TAG with debug logging (use --version for version info)"
+	@echo "  run-tiered    - Run TAG in tiered store mode (TAG_MODE=tiered)"
 	@echo ""
 	@echo "S3 compatibility test targets:"
 	@echo "  s3-test-local          - Start TAG locally with embedded cache"
 	@echo "  s3-test-local-blocks   - Start TAG locally with block-aligned caching on (small block_size)"
+	@echo "  s3-test-local-tiered   - Start TAG locally in tiered store mode (TAG_MODE=tiered)"
 	@echo "  s3-test-local-cluster  - Start TAG locally as a 2-node cluster"
 	@echo "  s3-test-local-cluster-blocks - Start a 2-node cluster with block-aligned caching on"
 	@echo "  s3-tests               - Run S3 compatibility tests (Python s3-tests)"
@@ -466,6 +472,18 @@ s3-test-local-blocks:
 	@TAG_CACHE_BLOCK_CACHING_ENABLED=true \
 		TAG_CACHE_BLOCK_SIZE=$(TAG_TEST_BLOCK_SIZE) \
 		$(MAKE) s3-test-local
+
+# Same single-node setup as s3-test-local but in tiered store mode (TAG_MODE=tiered): the
+# local metadata is authoritative, small objects are served entirely from the local tier,
+# large ones pass through with a marker. Tiered auto-selects CAS coordination and forces
+# block caching off. Expect BY-DESIGN failures from the ceph suite's multipart/copy
+# read-backs (v1 punts: no marker is stamped, so they read as authoritative misses) and
+# from request shapes the local engine answers 501 (see docs/tiered-mode.md). Stop it with
+# s3-test-local-down (same process, ports, and data dir).
+.PHONY: s3-test-local-tiered
+s3-test-local-tiered:
+	@echo "Starting TAG in tiered store mode..."
+	@TAG_MODE=tiered 		$(MAKE) s3-test-local
 
 # Local development: Run a 2-node TAG cluster on host with embedded cache
 # Uses non-default ports to avoid macOS conflicts (AirPlay uses 7000)

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -111,6 +111,34 @@ func (s *RequestSigner) SignRequest(ctx context.Context, method, path string,
 	// Set path (Go will properly encode special characters like % when converting to string)
 	baseURL.Path = pathPart
 	baseURL.RawQuery = queryPart
+	return s.signURL(ctx, method, &baseURL, body, bodyHash, accessKey, secretKey, headers)
+}
+
+// SignObjectRequest signs a synthetic single-object request built by TAG
+// itself (background fetches, revalidations, the tiered cross-tier cleanup
+// DELETE). Unlike SignRequest's combined path parameter, the KEY IS TAKEN
+// LITERALLY: it is never split on '?', so a key containing query-reserved
+// characters ('?' is legal in S3 keys) signs and routes to the exact object
+// instead of a truncated sibling — for a DELETE, a destructive request aimed
+// at the wrong key. The URL layer percent-encodes the path on the wire and
+// the canonical URI uses the same encoding, so signature and routing agree.
+func (s *RequestSigner) SignObjectRequest(ctx context.Context, method, bucket, key string,
+	body io.Reader, bodyHash string, accessKey, secretKey string, headers http.Header) (*http.Request, error) {
+
+	if s.endpointErr != nil {
+		return nil, fmt.Errorf("failed to parse endpoint: %w", s.endpointErr)
+	}
+	baseURL := *s.endpointURL
+	baseURL.Path = "/" + bucket + "/" + key
+	baseURL.RawQuery = ""
+	return s.signURL(ctx, method, &baseURL, body, bodyHash, accessKey, secretKey, headers)
+}
+
+// signURL finishes request construction and SigV4 signing for an already-built
+// URL (path and query set as their decoded forms).
+func (s *RequestSigner) signURL(ctx context.Context, method string, baseURL *url.URL,
+	body io.Reader, bodyHash string, accessKey, secretKey string, headers http.Header) (*http.Request, error) {
+
 	if baseURL.Opaque != "" {
 		// URL.String ignores Path for opaque URLs, so the old stringify-and-parse
 		// path returned an empty Path as well.
@@ -146,7 +174,7 @@ func (s *RequestSigner) SignRequest(ctx context.Context, method, path string,
 		// attach the completed URL directly rather than serializing and reparsing it.
 		req, err = http.NewRequestWithContext(ctx, method, "", body)
 		if err == nil {
-			req.URL = &baseURL
+			req.URL = baseURL
 			req.Host = baseURL.Host
 		}
 	}

--- a/auth/signer_request_test.go
+++ b/auth/signer_request_test.go
@@ -377,3 +377,36 @@ func TestRequestSignerSignRequestCopiesEndpointTemplate(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// SignObjectRequest takes the key LITERALLY: '?' is a legal S3 key character
+// and must never be read as a query separator — for the tiered cleanup DELETE
+// that split aimed a destructive request at a truncated sibling key.
+func TestSignObjectRequest_QueryCharsInKeyStayInPath(t *testing.T) {
+	signer := NewRequestSigner("https://s3.amazonaws.com", "us-east-1")
+	req, err := signer.SignObjectRequest(context.Background(), "DELETE", "b", "reports?2026.pq", nil, "", "AK", "SK", nil)
+	if err != nil {
+		t.Fatalf("SignObjectRequest: %v", err)
+	}
+	if req.URL.Path != "/b/reports?2026.pq" {
+		t.Fatalf("Path = %q, want the literal key", req.URL.Path)
+	}
+	if req.URL.RawQuery != "" {
+		t.Fatalf("RawQuery = %q, want empty (no split)", req.URL.RawQuery)
+	}
+	if got := req.URL.EscapedPath(); got != "/b/reports%3F2026.pq" {
+		t.Fatalf("EscapedPath = %q, want %%3F-encoded '?'", got)
+	}
+	if req.Header.Get("Authorization") == "" {
+		t.Fatal("request not signed")
+	}
+
+	// Contrast: SignRequest's combined-path parameter still splits — that is
+	// its contract for forwarded request targets.
+	req2, err := signer.SignRequest(context.Background(), "GET", "/b/reports?2026.pq", nil, "", "AK", "SK", nil)
+	if err != nil {
+		t.Fatalf("SignRequest: %v", err)
+	}
+	if req2.URL.Path != "/b/reports" || req2.URL.RawQuery != "2026.pq" {
+		t.Fatalf("SignRequest split = %q / %q, want /b/reports + 2026.pq", req2.URL.Path, req2.URL.RawQuery)
+	}
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -305,6 +305,34 @@ func (c *Cache) GetMeta(ctx context.Context, bucket, key string) (*CachedObjectM
 // Use this after GetMeta(), passing the meta's ETag so the body read resolves to
 // the exact version the metadata describes. Returns ErrNotFound if the body for
 // that version is not in cache.
+// PutBodyStream streams a whole-object body into the cache under the given
+// discriminator (an ETag for content-addressed entries, a NewBodyRef id for
+// the engine's streamed writes, where the ETag is unknown until EOF). Body
+// only — the entry becomes visible when its metadata commits; a body whose
+// meta never commits is an orphan that ages out by TTL, the same lifecycle
+// as a displaced version.
+func (c *Cache) PutBodyStream(ctx context.Context, bucket, key, discriminator string, r io.Reader, ttl int64) error {
+	if !c.IsEnabled() {
+		_, _ = io.Copy(io.Discard, r) // drain so a pipe producer never blocks
+		return nil
+	}
+	if ttl <= 0 {
+		ttl = c.defaultTTL
+	}
+	return c.client.PutStream(ctx, MakeBodyKey(bucket, key, discriminator), r, ttl)
+}
+
+// DeleteBody removes one staged or orphaned body by its discriminator. Used
+// by the engine's PUT abort paths (overrun, digest mismatch, refused
+// conditional) to reclaim a body whose metadata will never commit; TTL is
+// the backstop when this best-effort delete fails.
+func (c *Cache) DeleteBody(ctx context.Context, bucket, key, discriminator string) error {
+	if !c.IsEnabled() {
+		return nil
+	}
+	return c.client.Delete(ctx, MakeBodyKey(bucket, key, discriminator))
+}
+
 func (c *Cache) GetBodyStream(ctx context.Context, bucket, key, etag string, w io.Writer) error {
 	if !c.IsEnabled() {
 		return ErrCacheDisabled
@@ -381,6 +409,19 @@ func (c *Cache) Delete(ctx context.Context, bucket, key string) error {
 	}
 
 	return c.DeleteWithMeta(ctx, bucket, key)
+}
+
+// DeleteMetaIfVersion invalidates the object's metadata only while it still
+// carries the observed version token (from GetMetaWithVersion): the guard is
+// the exact snapshot the caller examined, so an entry replaced in between —
+// even by identical content reusing the same MD5 ETag — refuses the delete.
+// Returns (false, nil) when replaced or absent. CAS-coordinator strength; the
+// legacy coordinator refuses (see coordinator.go).
+func (c *Cache) DeleteMetaIfVersion(ctx context.Context, bucket, key string, version uint64) (bool, error) {
+	if !c.IsEnabled() {
+		return false, nil
+	}
+	return c.coord.deleteMetaIfVersion(ctx, bucket, key, version)
 }
 
 // DeleteIfETag invalidates the object's metadata only while it still carries
@@ -531,6 +572,23 @@ func (c *Cache) getRangeStreamByKey(ctx context.Context, cacheKey, bucket, key s
 		Int64("length", end-start+1).
 		Msg("Cache hit (range)")
 	return nil
+}
+
+// BodyExistsErr reports whether a whole-object body is present, with the same
+// error contract as BlockExistsErr: genuine absence is (false, nil), a transient
+// probe failure is (false, err). Same first-byte probe, on the body key.
+func (c *Cache) BodyExistsErr(ctx context.Context, bucket, key, etag string) (present bool, err error) {
+	if !c.IsEnabled() || etag == "" {
+		return false, nil
+	}
+	e := c.getRangeStreamByKey(ctx, MakeBodyKey(bucket, key, etag), bucket, key, 0, 0, io.Discard)
+	if e == nil {
+		return true, nil
+	}
+	if errors.Is(e, ErrNotFound) {
+		return false, nil // genuinely absent
+	}
+	return false, e // transient failure — not proof of absence
 }
 
 // BlockExists reports whether the given block of a block-mode object is present in cache.

--- a/cache/completion.go
+++ b/cache/completion.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// CompletionCacheTTL is the TTL for completion cache entries in seconds.
-	// tigris-os uses 1 second; we use 5 seconds for safety margin.
+	// Chosen with margin over the upstream implementation-observed window.
 	CompletionCacheTTL = 5
 
 	// completionKeyPrefix is the prefix for completion cache keys.

--- a/cache/coordinator.go
+++ b/cache/coordinator.go
@@ -58,6 +58,13 @@ type metaCoordinator interface {
 	// deleteMetaIfETag invalidates only while the entry still carries
 	// staleETag. Returns (false, nil) when absent, different, or replaced.
 	deleteMetaIfETag(ctx context.Context, bucket, key, staleETag string) (bool, error)
+	// deleteMetaIfVersion invalidates only while the entry still carries the
+	// caller's observed version token — a check-then-delete whose guard is
+	// exactly the check's snapshot, unlike deleteMetaIfETag's content ETag
+	// (which identical bytes can reuse across entries and tiers). CAS-
+	// coordinator strength: legacy coordination stores no versions to compare
+	// and refuses with (false, nil).
+	deleteMetaIfVersion(ctx context.Context, bucket, key string, version uint64) (bool, error)
 }
 
 // ============================================================================
@@ -190,6 +197,21 @@ func (c *casCoordinator) deleteMetaIfETag(ctx context.Context, bucket, key, stal
 			return false, nil
 		}
 		return false, fmt.Errorf("guarded meta delete: %w", derr)
+	}
+	return true, nil
+}
+
+func (c *casCoordinator) deleteMetaIfVersion(ctx context.Context, bucket, key string, version uint64) (bool, error) {
+	if derr := c.client.DeleteIfVersion(ctx, MakeMetaKey(bucket, key), version); derr != nil {
+		if _, mismatch := cacheclient.IsVersionMismatch(derr); mismatch {
+			// Replaced (or removed) since the caller's read: the newer state
+			// wins — exactly what the guard exists for.
+			return false, nil
+		}
+		if isNotFoundError(derr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("version-guarded meta delete: %w", derr)
 	}
 	return true, nil
 }
@@ -344,4 +366,13 @@ func (c *legacyCoordinator) tombstoneTimestamp(ctx context.Context, bucket, key 
 		return 0
 	}
 	return int64(binary.BigEndian.Uint64(data))
+}
+
+// deleteMetaIfVersion is a CAS-strength identity delete: legacy coordination
+// stores no versions (its tokens are wall-clock stamps never persisted with
+// the row), so there is nothing to compare the caller's token against and the
+// only safe answer is to refuse. Its sole caller (the tiered cleanup repair)
+// runs under CAS coordination by construction — tiered mode rejects legacy.
+func (c *legacyCoordinator) deleteMetaIfVersion(ctx context.Context, bucket, key string, version uint64) (bool, error) {
+	return false, nil
 }

--- a/cache/object.go
+++ b/cache/object.go
@@ -2,6 +2,8 @@
 package cache
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -43,6 +45,10 @@ type CachedObjectMeta struct {
 	PartsCount           string            `json:"parts_count,omitempty"`            // x-amz-mp-parts-count
 	UserMetadata         map[string]string `json:"user_metadata,omitempty"`          // x-amz-meta-*
 	StatusCode           int               `json:"status_code"`                      // Original HTTP status (200, etc.)
+	// BodyUpstream marks a tiered-mode entry whose body lives upstream (the large
+	// tier): this metadata is authoritative for existence, HEAD, and conditionals,
+	// while GET bodies are forwarded. False means the body is stored locally.
+	BodyUpstream bool `json:"body_upstream,omitempty"`
 	// BlockSize records the block granularity for a block-mode entry (RFC 0001). 0 means
 	// the body is stored as a single whole blob (MakeBodyKey); >0 means the body is stored
 	// as fixed-size blocks (MakeBlockKey) of this size. Captured at populate time so an
@@ -55,6 +61,26 @@ type CachedObjectMeta struct {
 	// hint, not an invariant: false (including on entries written before the field existed)
 	// only means the probe-first path is used.
 	BlocksComplete bool `json:"blocks_complete,omitempty"`
+	// BodyRef, when set, is the body key discriminator for this entry —
+	// a per-write unique id minted by the LOCAL-STORE ENGINE, which streams
+	// the body into the cache before its MD5 (the ETag) is known and so
+	// cannot key the body by content. Null on every proxy-written entry:
+	// proxy populates learn the ETag from upstream headers before the body
+	// streams and keep content-addressed keys (and their convergent
+	// double-write dedup). This is a WRITER-OWNERSHIP invariant, not a
+	// migration state — readers resolve through BodyDiscriminator and never
+	// care who wrote the entry.
+	BodyRef string `json:"body_ref,omitempty"`
+	// ContentLengthKnown records that ContentLength carries a real declared or
+	// measured length — including a genuine 0 for an empty object. Encode sets
+	// it automatically from ContentLength >= 0; DecodeMeta treats a row
+	// WITHOUT it whose ContentLength is 0 as UNKNOWN (-1): rows persisted
+	// before the -1 sentinel existed stored 0 for both "empty" and "unknown"
+	// (no Content-Length on the upstream response), and re-reading that
+	// ambiguous 0 as an affirmative zero length would serve non-empty cached
+	// objects as empty. Those legacy rows revert to their pre-upgrade
+	// omit-the-header behavior until TTL replaces them.
+	ContentLengthKnown bool `json:"content_length_known,omitempty"`
 	// CachedAt is the Unix time (seconds) this meta was built from a live upstream response.
 	// Rewrites of an existing meta that do NOT consult upstream (the blocks-complete
 	// promotion) use it to compute the entry's remaining TTL so they never extend its
@@ -86,9 +112,15 @@ func MetaFromHTTPHeaders(bucket, key string, statusCode int, headers http.Header
 		UserMetadata:         make(map[string]string),
 	}
 
-	// Parse Content-Length
+	// Parse Content-Length. Absent means UNKNOWN (a chunked upstream
+	// response), recorded as -1 — never 0, which is a real length (an empty
+	// object) that WriteHeaders must advertise. Producers that know the exact
+	// body length (the local-store engine, block populates) overwrite this
+	// with the measured value.
 	if cl := headers.Get("Content-Length"); cl != "" {
 		meta.ContentLength, _ = strconv.ParseInt(cl, 10, 64)
+	} else {
+		meta.ContentLength = -1
 	}
 
 	// Parse Last-Modified to Unix timestamp
@@ -133,7 +165,13 @@ func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter, opts ...WriteHead
 	if m.ContentType != "" {
 		w.Header().Set("Content-Type", m.ContentType)
 	}
-	if m.ContentLength > 0 {
+	if m.ContentLength >= 0 {
+		// Zero included: S3 sends Content-Length: 0 for an empty object, and a HEAD
+		// without it makes clients read the length as unknown rather than zero.
+		// Negative means genuinely unknown (a chunked upstream response,
+		// recorded as -1 by MetaFromHTTPHeaders) and the header is omitted —
+		// an affirmative 0 there would make clients read a non-empty object
+		// as zero bytes.
 		w.Header().Set("Content-Length", strconv.FormatInt(m.ContentLength, 10))
 	}
 	if m.LastModified > 0 {
@@ -172,8 +210,12 @@ func (m *CachedObjectMeta) WriteHeaders(w http.ResponseWriter, opts ...WriteHead
 	}
 	// Write user metadata with lowercase keys per S3 convention
 	for k, v := range m.UserMetadata {
+		// Written via the map directly so the wire name stays lowercase, as S3
+		// sends it. Header.Set would canonicalize to X-Amz-Meta-..., and botocore
+		// derives its Metadata keys from the case-preserved wire name — canonical
+		// casing turns the user's key "meta1" into "Meta1" on the client.
 		lk := strings.ToLower(k)
-		w.Header().Set(lk, v)
+		w.Header()[lk] = []string{v}
 	}
 
 	// Apply options (may override headers like Content-Length for range responses)
@@ -227,6 +269,44 @@ func (m *CachedObjectMeta) MatchesETag(etag string) bool {
 	return normalizeETag(etag) == normalizeETag(m.ETag)
 }
 
+// MatchesETagHeader evaluates a full If-Match / If-None-Match header value
+// against the object's ETag. RFC 7232 allows a comma-separated LIST of
+// entity-tags ("e1", "e2"), and matching the header as one opaque tag makes a
+// list that contains the live ETag never match — fatal on the authoritative
+// paths (origin-less and tiered), where there is no upstream to answer
+// correctly instead: legal conditional writes 412 and valid 304s are lost.
+// Splitting on ',' is exact here because ETags are quoted strings whose only
+// legal inner characters exclude ',' (RFC 7232 §2.3).
+//
+// strong selects the comparison function (RFC 7232 §2.3.2): If-Match REQUIRES
+// strong comparison — a W/ weak validator never matches, so a conditional
+// overwrite gated on one is refused — while If-None-Match uses weak
+// comparison, where W/"x" and "x" match.
+func (m *CachedObjectMeta) MatchesETagHeader(header string, strong bool) bool {
+	if header == "" || m.ETag == "" {
+		return false
+	}
+	if header == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" {
+			return true
+		}
+		if candidate == "" {
+			continue
+		}
+		if strong && (strings.HasPrefix(candidate, "W/") || strings.HasPrefix(m.ETag, "W/")) {
+			continue
+		}
+		if normalizeETag(candidate) == normalizeETag(m.ETag) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsModifiedSince returns true if the object was modified after the given time.
 // Used for If-Modified-Since conditional requests.
 func (m *CachedObjectMeta) IsModifiedSince(since time.Time) bool {
@@ -261,16 +341,26 @@ func etagKeyComponent(etag string) string {
 	return etag
 }
 
-// Encode serializes metadata to JSON bytes for cache storage.
+// Encode serializes metadata to JSON bytes for cache storage. It stamps
+// ContentLengthKnown from the length itself, so every producer — engine
+// writes, markers, block finalizes — gets the disambiguation without
+// having to remember the field exists.
 func (m *CachedObjectMeta) Encode() ([]byte, error) {
+	m.ContentLengthKnown = m.ContentLength >= 0
 	return json.Marshal(m)
 }
 
-// DecodeMeta deserializes JSON bytes to CachedObjectMeta.
+// DecodeMeta deserializes JSON bytes to CachedObjectMeta. A row without
+// ContentLengthKnown whose ContentLength is 0 predates the -1 unknown
+// sentinel, where 0 was ambiguous between "empty" and "unknown" — it decodes
+// as unknown so a non-empty cached object is never served as empty.
 func DecodeMeta(data []byte) (*CachedObjectMeta, error) {
 	var meta CachedObjectMeta
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return nil, err
+	}
+	if !meta.ContentLengthKnown && meta.ContentLength == 0 {
+		meta.ContentLength = -1
 	}
 	return &meta, nil
 }
@@ -293,6 +383,31 @@ func MakeMetaKey(bucket, key string) string {
 // resolved. The ETag is normalized with etagKeyComponent, which keeps the
 // weak/strong distinction so different validators never collide on one key. Objects
 // with no ETag fall back to the unversioned key (no version discriminator exists).
+// BodyDiscriminator returns the string this entry's body key is derived
+// from: BodyRef when set (engine-written entries, whose bodies are keyed by
+// a per-write id), else the ETag (proxy-written entries, content-addressed).
+// Every body read, probe, or targeted delete for an entry must resolve
+// through this — deriving from the ETag directly serves the wrong (absent)
+// key for engine entries.
+func (m *CachedObjectMeta) BodyDiscriminator() string {
+	if m.BodyRef != "" {
+		return m.BodyRef
+	}
+	return m.ETag
+}
+
+// NewBodyRef mints a per-write body key discriminator for entries whose
+// ETag is not known until the body has fully streamed (the local-store
+// engine's PUT). Uniqueness is what matters; the timestamp fallback keeps a
+// usable id even if the entropy source fails.
+func NewBodyRef() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "ref-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b[:])
+}
+
 func MakeBodyKey(bucket, key, etag string) string {
 	if etag == "" {
 		return bodyKeyPrefix + bucket + "|" + key

--- a/cache/object_test.go
+++ b/cache/object_test.go
@@ -96,8 +96,12 @@ func TestCachedObjectMeta_WriteHeaders(t *testing.T) {
 		t.Errorf("Cache-Control header = %q, want %q", w.Header().Get("Cache-Control"), "max-age=3600")
 	}
 
-	if w.Header().Get("X-Amz-Meta-Custom") != "custom-value" {
-		t.Errorf("X-Amz-Meta-Custom header = %q, want %q", w.Header().Get("X-Amz-Meta-Custom"), "custom-value")
+	// User metadata is written via the raw map so the WIRE name stays lowercase
+	// (S3's convention; botocore derives Metadata keys from the case-preserved
+	// wire name). Header.Get canonicalizes its lookup and cannot see raw keys, so
+	// assert the map directly — real clients re-canonicalize on their own side.
+	if got := w.Header()["x-amz-meta-custom"]; len(got) != 1 || got[0] != "custom-value" {
+		t.Errorf("x-amz-meta-custom = %v, want [custom-value]", got)
 	}
 }
 
@@ -320,13 +324,18 @@ func TestCachedObjectMeta_WriteHeaders_MetadataLowercase(t *testing.T) {
 	w := httptest.NewRecorder()
 	meta.WriteHeaders(w)
 
-	// Metadata headers should be written with lowercase keys
-	// http.Header.Get is case-insensitive, so it will find headers regardless of case
-	if w.Header().Get("x-amz-meta-custom") != "custom-value" {
-		t.Errorf("x-amz-meta-custom = %q, want %q", w.Header().Get("x-amz-meta-custom"), "custom-value")
+	// Metadata headers must land on the wire with LOWERCASE names — this test's
+	// original intent, now literal: the raw map is asserted because Header.Get
+	// canonicalizes its lookup and a canonical entry here would mean the wire
+	// carries X-Amz-Meta-..., which botocore surfaces as key "Custom" not "custom".
+	if got := w.Header()["x-amz-meta-custom"]; len(got) != 1 || got[0] != "custom-value" {
+		t.Errorf("x-amz-meta-custom = %v, want [custom-value]", got)
 	}
-	if w.Header().Get("x-amz-meta-foo") != "foo-value" {
-		t.Errorf("x-amz-meta-foo = %q, want %q", w.Header().Get("x-amz-meta-foo"), "foo-value")
+	if got := w.Header()["x-amz-meta-foo"]; len(got) != 1 || got[0] != "foo-value" {
+		t.Errorf("x-amz-meta-foo = %v, want [foo-value]", got)
+	}
+	if canonical := w.Header()["X-Amz-Meta-Custom"]; len(canonical) != 0 {
+		t.Errorf("canonical-cased duplicate present: %v", canonical)
 	}
 }
 

--- a/cmd/tag/cache_hit_benchmark_test.go
+++ b/cmd/tag/cache_hit_benchmark_test.go
@@ -44,6 +44,10 @@ func (embeddedCacheHitBenchmarkForwarder) DoFullObjectRequest(context.Context, s
 	return nil, errors.New("unexpected upstream full-object request")
 }
 
+func (embeddedCacheHitBenchmarkForwarder) DoObjectDeleteRequest(context.Context, string, string, string, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected upstream delete request")
+}
+
 func (embeddedCacheHitBenchmarkForwarder) DoAnonymousFullObjectRequest(context.Context, string, string) (*http.Response, error) {
 	return nil, errors.New("unexpected upstream anonymous request")
 }

--- a/cmd/tag/main.go
+++ b/cmd/tag/main.go
@@ -92,6 +92,9 @@ func main() {
 		cfg = config.NewDefault()
 	}
 
+	// Stamp the operating mode on the request metrics before anything serves.
+	metrics.SetMode(cfg.ResolvedMode())
+
 	// Override cache enabled from command line flag
 	if *disableCache {
 		cfg.Cache.SetEnabled(false)
@@ -148,7 +151,7 @@ func main() {
 			Str("endpoint", cfg.Upstream.Endpoint).
 			Str("region", cfg.Upstream.Region).
 			Int("max_idle_conns_per_host", cfg.Upstream.MaxIdleConnsPerHost).
-			Bool("transparent_proxy", cfg.Upstream.IsTransparentProxy()),
+			Str("mode", cfg.ResolvedMode()),
 		).
 		Dict("cache", zerolog.Dict().
 			Bool("enabled", cfg.Cache.IsEnabled()).
@@ -188,16 +191,17 @@ func main() {
 		log.Warn().Err(err).Msg("Failed to load credentials from environment")
 	}
 
-	// Initialize proxy signer if transparent proxy is enabled
+	// Initialize proxy signer unless running in signing mode. Transparent and
+	// tiered modes both forward with proxy headers and need TAG's own creds.
 	var proxySigner *auth.ProxySigner
-	if cfg.Upstream.IsTransparentProxy() {
+	if cfg.ResolvedMode() != config.ModeSigning {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 		if accessKey == "" || secretKey == "" {
-			log.Fatal().Msg("Transparent proxy requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
+			log.Fatal().Str("mode", cfg.ResolvedMode()).Msg("This mode requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
 		}
 		proxySigner = auth.NewProxySigner(accessKey, secretKey)
-		log.Info().Msg("Transparent proxy mode enabled")
+		log.Info().Str("mode", cfg.ResolvedMode()).Msg("Proxy mode enabled")
 	} else {
 		log.Info().Str("endpoint", cfg.Upstream.Endpoint).Msg("Signing mode enabled")
 		if !config.IsTigrisEndpoint(cfg.Upstream.Endpoint) {
@@ -206,7 +210,7 @@ func main() {
 		}
 	}
 
-	if credStore.Count() == 0 && !cfg.Upstream.IsTransparentProxy() {
+	if credStore.Count() == 0 && cfg.ResolvedMode() == config.ModeSigning {
 		log.Warn().Msg("No credentials loaded - TAG will reject all requests")
 	}
 
@@ -311,9 +315,9 @@ func main() {
 		objectCache = cache.NewDisabledCache()
 	}
 
-	// 3. Initialize local auth for transparent proxy
+	// 3. Initialize local auth (transparent and tiered modes)
 	var localAuth *proxy.LocalAuthConfig
-	if cfg.Upstream.IsTransparentProxy() {
+	if cfg.ResolvedMode() != config.ModeSigning {
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 		derivedKeyStore := auth.NewDerivedKeyStore(auth.DefaultDerivedKeyTTL)
 		keyUnwrapper, err := auth.NewKeyUnwrapper(secretKey)

--- a/config/config.go
+++ b/config/config.go
@@ -117,8 +117,21 @@ const (
 	DefaultWarmOnWriteReservedFraction = 0.5
 )
 
+// Operating modes. Mode selects how TAG relates to its upstream:
+// transparent forwards client signatures as-is with proxy headers (default),
+// signing validates client signatures and re-signs for upstream, and tiered
+// serves small objects entirely from the local cache — metadata is
+// authoritative, misses are answered locally — while large objects pass
+// through to upstream.
+const (
+	ModeTransparent = "transparent"
+	ModeSigning     = "signing"
+	ModeTiered      = "tiered"
+)
+
 // Config holds all configuration for TAG.
 type Config struct {
+	Mode        string            `yaml:"mode"` // transparent (default) | signing | tiered
 	Server      ServerConfig      `yaml:"server"`
 	Upstream    UpstreamConfig    `yaml:"upstream"`
 	Credentials CredentialsConfig `yaml:"credentials"`
@@ -146,6 +159,21 @@ type ServerConfig struct {
 func (s *ServerConfig) TLSEnabled() bool {
 	return s.TLSCertFile != "" && s.TLSKeyFile != ""
 }
+
+// ResolvedMode returns the operating mode, folding in the deprecated
+// upstream.transparent_proxy flag when mode is unset.
+func (c *Config) ResolvedMode() string {
+	if c.Mode != "" {
+		return c.Mode
+	}
+	if !c.Upstream.IsTransparentProxy() {
+		return ModeSigning
+	}
+	return ModeTransparent
+}
+
+// IsTiered returns whether TAG runs in tiered store mode.
+func (c *Config) IsTiered() bool { return c.ResolvedMode() == ModeTiered }
 
 // UpstreamConfig holds Tigris endpoint configuration.
 type UpstreamConfig struct {
@@ -269,7 +297,9 @@ type CacheConfig struct {
 	// EVERY node in the cluster runs a CAS-capable release, and flip via a
 	// brisk rolling restart (nodes in different modes order writes with
 	// different mechanisms during that window). Standalone nodes may flip
-	// immediately after upgrading.
+	// immediately after upgrading. Tiered mode requires CAS and selects it
+	// automatically when this is unset; an explicit true there is rejected
+	// at startup (see validateMode).
 	LegacyCoordination *bool `yaml:"legacy_coordination"`
 
 	// BlockCachingEnabled turns on block-aligned caching for large objects (RFC 0001):
@@ -401,6 +431,16 @@ func NewDefault() *Config {
 		panic(fmt.Sprintf("invalid default configuration: %v", err))
 	}
 	return cfg
+}
+
+// Validate runs the full configuration validation and applies mode-derived
+// defaults (tiered mode selects CAS coordination and disables block caching).
+// Load and NewDefault call it automatically; call it again after mutating a
+// Config programmatically — in particular after setting Mode — or the
+// mode-derived defaults silently do not apply and forbidden combinations
+// (tiered + legacy coordination, tiered + block caching) go undetected.
+func (c *Config) Validate() error {
+	return validate(c)
 }
 
 // applyDefaults sets default values for unset configuration fields.
@@ -737,7 +777,12 @@ func applyEnvOverrides(cfg *Config) {
 		cfg.Server.TLSKeyFile = keyFile
 	}
 
-	// Override transparent proxy from environment (enabled by default)
+	// Override operating mode from environment
+	if val := os.Getenv("TAG_MODE"); val != "" {
+		cfg.Mode = val
+	}
+
+	// Override transparent proxy from environment (deprecated: use TAG_MODE)
 	if val := os.Getenv("TAG_TRANSPARENT_PROXY"); val != "" {
 		enabled := val == "true" || val == "1"
 		cfg.Upstream.SetTransparentProxy(enabled)
@@ -753,7 +798,10 @@ func applyEnvOverrides(cfg *Config) {
 
 // validate checks that the final configuration is valid.
 func validate(cfg *Config) error {
-	if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint, cfg.Upstream.IsTransparentProxy()); err != nil {
+	if err := validateMode(cfg); err != nil {
+		return err
+	}
+	if err := validateUpstreamEndpoint(cfg.Upstream.Endpoint, cfg.ResolvedMode() != ModeSigning); err != nil {
 		return err
 	}
 	if err := validateTLS(&cfg.Server); err != nil {
@@ -761,6 +809,50 @@ func validate(cfg *Config) error {
 	}
 	if err := validateEvictionPolicy(cfg.Cache.EvictionPolicy); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateMode checks the operating mode and its interaction with the
+// deprecated transparent_proxy flag and with block caching. Tiered mode is
+// whole-object only (block caching would let individual blocks of a cached
+// object expire, which breaks authoritative local misses), so an explicit
+// block_caching_enabled=true is rejected and the block-caching default flips
+// to off.
+func validateMode(cfg *Config) error {
+	switch cfg.Mode {
+	case "", ModeTransparent, ModeSigning, ModeTiered:
+	default:
+		return fmt.Errorf("invalid mode %q: must be %q, %q, or %q", cfg.Mode, ModeTransparent, ModeSigning, ModeTiered)
+	}
+	if cfg.Mode != "" && cfg.Upstream.TransparentProxy != nil {
+		tp := *cfg.Upstream.TransparentProxy
+		if cfg.Mode == ModeTiered || (cfg.Mode == ModeTransparent) != tp {
+			return fmt.Errorf("mode %q conflicts with deprecated transparent_proxy=%v: remove transparent_proxy", cfg.Mode, tp)
+		}
+	}
+	if cfg.IsTiered() {
+		if cfg.Cache.BlockCachingEnabled != nil && *cfg.Cache.BlockCachingEnabled {
+			return fmt.Errorf("tiered mode requires whole-object caching: remove cache.block_caching_enabled")
+		}
+		cfg.Cache.SetBlockCachingEnabled(false)
+		if !cfg.Cache.IsEnabled() {
+			return fmt.Errorf("tiered mode requires the cache to be enabled")
+		}
+		// Tiered mode REQUIRES CAS-strength meta coordination: the cache is
+		// authoritative and the local tier holds the only copy, so an ordering
+		// race that would be transient staleness in proxy mode (legacy
+		// coordination's accepted write-vs-write window) is permanent data
+		// loss here — a re-tier or populate could overwrite an acknowledged
+		// write. Every node running tiered is CAS-capable by construction (the
+		// mode ships with the coordinator), so the legacy default's
+		// mixed-cluster rationale does not apply: unset selects CAS
+		// automatically, and an explicit legacy_coordination=true is a
+		// contradiction rejected like the other tiered conflicts above.
+		if cfg.Cache.LegacyCoordination != nil && *cfg.Cache.LegacyCoordination {
+			return fmt.Errorf("tiered mode requires CAS meta coordination: remove cache.legacy_coordination")
+		}
+		cfg.Cache.SetLegacyCoordination(false)
 	}
 	return nil
 }

--- a/config/mode_test.go
+++ b/config/mode_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeModeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMode_DefaultIsTransparent(t *testing.T) {
+	cfg := NewDefault()
+	if got := cfg.ResolvedMode(); got != ModeTransparent {
+		t.Fatalf("ResolvedMode() = %q, want %q", got, ModeTransparent)
+	}
+	if cfg.IsTiered() {
+		t.Fatal("IsTiered() = true for default config")
+	}
+}
+
+func TestMode_TransparentProxyFalseResolvesSigning(t *testing.T) {
+	cfg := NewDefault()
+	cfg.Upstream.SetTransparentProxy(false)
+	if got := cfg.ResolvedMode(); got != ModeSigning {
+		t.Fatalf("ResolvedMode() = %q, want %q", got, ModeSigning)
+	}
+}
+
+func TestMode_OverrideByEnv(t *testing.T) {
+	t.Setenv("TAG_MODE", ModeTiered)
+	var cfg Config
+	applyDefaults(&cfg)
+	applyEnvOverrides(&cfg)
+	if err := validate(&cfg); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !cfg.IsTiered() {
+		t.Fatal("IsTiered() = false with TAG_MODE=tiered")
+	}
+}
+
+func TestMode_InvalidRejected(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = "sideways"
+	if err := validate(&cfg); err == nil {
+		t.Fatal("validate accepted an invalid mode")
+	}
+}
+
+func TestMode_ContradictionWithTransparentProxyRejected(t *testing.T) {
+	cases := []struct {
+		mode string
+		tp   bool
+	}{
+		{ModeTransparent, false},
+		{ModeSigning, true},
+		{ModeTiered, true},
+		{ModeTiered, false},
+	}
+	for _, tc := range cases {
+		var cfg Config
+		applyDefaults(&cfg)
+		cfg.Mode = tc.mode
+		cfg.Upstream.SetTransparentProxy(tc.tp)
+		if err := validate(&cfg); err == nil {
+			t.Fatalf("validate accepted mode=%q with transparent_proxy=%v", tc.mode, tc.tp)
+		}
+	}
+}
+
+func TestMode_ConsistentTransparentProxyAllowed(t *testing.T) {
+	cases := []struct {
+		mode string
+		tp   bool
+	}{
+		{ModeTransparent, true},
+		{ModeSigning, false},
+	}
+	for _, tc := range cases {
+		var cfg Config
+		applyDefaults(&cfg)
+		cfg.Mode = tc.mode
+		cfg.Upstream.SetTransparentProxy(tc.tp)
+		if err := validate(&cfg); err != nil {
+			t.Fatalf("validate rejected consistent mode=%q transparent_proxy=%v: %v", tc.mode, tc.tp, err)
+		}
+	}
+}
+
+func TestMode_TieredRejectsBlockCaching(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(true)
+	if err := validate(&cfg); err == nil {
+		t.Fatal("validate accepted tiered mode with block caching enabled")
+	}
+}
+
+func TestMode_TieredDefaultsBlockCachingOff(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = ModeTiered
+	if err := validate(&cfg); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if cfg.Cache.IsBlockCachingEnabled() {
+		t.Fatal("block caching still enabled in tiered mode")
+	}
+}
+
+func TestMode_TieredSelectsCASCoordination(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = ModeTiered
+	if err := validate(&cfg); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if cfg.Cache.IsLegacyCoordination() {
+		t.Fatal("tiered mode did not auto-select CAS coordination")
+	}
+}
+
+func TestMode_TieredRejectsExplicitLegacyCoordination(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = ModeTiered
+	cfg.Cache.SetLegacyCoordination(true)
+	if err := validate(&cfg); err == nil {
+		t.Fatal("validate accepted tiered mode with legacy coordination forced on")
+	}
+}
+
+// The env override applies before validation, so forcing legacy coordination
+// through the environment is the same contradiction as forcing it in yaml.
+func TestMode_TieredRejectsLegacyCoordinationEnv(t *testing.T) {
+	t.Setenv("TAG_MODE", ModeTiered)
+	t.Setenv("TAG_CACHE_LEGACY_COORDINATION", "true")
+	path := writeModeConfig(t, `
+upstream:
+  endpoint: "https://t3.storage.dev"
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load accepted tiered mode with legacy coordination forced by env")
+	}
+}
+
+func TestMode_TieredRequiresCache(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	cfg.Mode = ModeTiered
+	disabled := false
+	cfg.Cache.Enabled = &disabled
+	if err := validate(&cfg); err == nil {
+		t.Fatal("validate accepted tiered mode with the cache disabled")
+	}
+}
+
+func TestMode_LoadFromYAML(t *testing.T) {
+	path := writeModeConfig(t, `
+mode: tiered
+upstream:
+  endpoint: "https://t3.storage.dev"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.IsTiered() {
+		t.Fatal("IsTiered() = false for mode: tiered YAML")
+	}
+	if cfg.Cache.IsBlockCachingEnabled() {
+		t.Fatal("block caching enabled in tiered mode")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,8 @@ TAG can be configured via a YAML configuration file and/or environment variables
 | `TAG_HTTP_PORT`                   | Port for the S3 API                                                             | `8080`                   |
 | `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
 | `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                 | `json`                   |
-| `TAG_TRANSPARENT_PROXY`           | Disable transparent proxy mode (`false` or `0`)                                 | `true`                   |
+| `TAG_MODE`                        | Operating mode: `transparent`, `signing`, or `tiered` (see [tiered-mode.md](tiered-mode.md)) | `transparent`            |
+| `TAG_TRANSPARENT_PROXY`           | **Deprecated** — use `TAG_MODE`. Disable transparent proxy mode (`false` or `0`); conflicts with an explicit `TAG_MODE` are startup-fatal | `true`                   |
 | `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                                       | (none)                   |
 | `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                                       | (none)                   |
 | `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
@@ -55,6 +56,13 @@ The configuration file uses YAML format. Specify the path with the `--config` fl
 ### Full Configuration Reference
 
 ```yaml
+# Operating mode: transparent (default), signing, or tiered.
+# transparent forwards client signatures as-is with proxy headers; signing
+# validates client signatures and re-signs for upstream; tiered serves small
+# objects entirely from the local cache with authoritative misses (see
+# tiered-mode.md). Supersedes upstream.transparent_proxy.
+mode: transparent
+
 # Server configuration
 server:
   # HTTP port for the S3 API
@@ -101,9 +109,10 @@ upstream:
   # Default: 100
   max_idle_conns_per_host: 100
 
-  # Enable transparent proxy mode
+  # Deprecated: use the top-level `mode` instead.
   # When true (default), client requests are forwarded as-is with proxy headers.
   # When false, TAG validates and re-signs requests (signing mode).
+  # Setting both this and `mode` inconsistently is a startup-fatal error.
   # Default: true
   transparent_proxy: true
 
@@ -321,7 +330,7 @@ Configures the connection to upstream Tigris storage.
 | `endpoint`                | string | `"https://t3.storage.dev"` | Tigris S3 endpoint URL                           |
 | `region`                  | string | `"auto"`                   | AWS region for request signing                   |
 | `max_idle_conns_per_host` | int    | `100`                      | HTTP connection pool size per host               |
-| `transparent_proxy`       | bool   | `true`                     | Forward client requests as-is with proxy headers |
+| `transparent_proxy`       | bool   | `true`                     | **Deprecated** — use top-level `mode`. Forward client requests as-is with proxy headers |
 
 **Endpoint Validation:**
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,6 +27,8 @@ Total number of requests processed by TAG.
 | ----------- | -------------------------------------------------------------------- |
 | `operation` | S3 operation: `GetObject`, `PutObject`, `DeleteObject`, `HeadObject` |
 | `status`    | Result: `success`, `error`, `auth_error`, `range_not_satisfiable`    |
+| `mode`      | The process's operating mode (`transparent`, `signing`, `tiered`) — one constant value per instance, for fleet-wide splits |
+| `source`    | Where the response was produced: `local` (TAG's own store or knowledge — cache hits, revalidated-304 serves, authoritative misses, auth errors) or `upstream` (proxied) |
 
 **Example queries:**
 
@@ -36,6 +38,9 @@ rate(tag_requests_total[5m])
 
 # Error rate
 sum(rate(tag_requests_total{status="error"}[5m])) / sum(rate(tag_requests_total[5m]))
+
+# Share of traffic answered without touching upstream (per mode)
+sum(rate(tag_requests_total{source="local"}[5m])) by (mode) / sum(rate(tag_requests_total[5m])) by (mode)
 
 # GetObject success rate
 rate(tag_requests_total{operation="GetObject",status="success"}[5m]) /
@@ -51,6 +56,8 @@ Request duration in seconds.
 | Label       | Description  |
 | ----------- | ------------ |
 | `operation` | S3 operation |
+| `mode`      | Operating mode (constant per instance) |
+| `source`    | `local` or `upstream` — where the response was produced |
 
 **Buckets:** 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10 (the default Prometheus buckets plus extra tail resolution at 1.5, 2, 3, 4 and 7.5 seconds)
 
@@ -448,6 +455,43 @@ rate(tag_cache_populate_skipped_total{source="warm_on_write"}[5m])
 # Total populate shed rate
 sum(rate(tag_cache_populate_skipped_total[5m]))
 ```
+
+#### tag_tiered_cleanup_total
+
+**Type:** Counter
+
+Tiered mode's cross-tier cleanup deletes (issued when a small local write
+displaces an upstream-tier version), by outcome — exactly one per cleanup.
+Cleanup is best-effort: anything other than `deleted` / `already_gone` /
+`replaced` / `marker_repaired` leaves an orphan for the upstream bucket's own
+expiry — failures are Debug-logged, so this counter is the rollout-visibility
+signal.
+
+| Label     | Description                                                              |
+| --------- | ------------------------------------------------------------------------ |
+| `outcome` | `deleted`, `already_gone` (404), `replaced` (412 — a newer version took the key, left alone), `rejected` (other upstream refusal), `error` (request failed), `no_etag` (no displaced ETag to bind to; skipped), `live_marker` (skipped: the key's current metadata is a live marker for this ETag — the body is authoritative again), `marker_repaired` (a same-ETag marker raced in during the delete; the repair removed it, converging on an authoritative miss the caller re-populates), `repair_failed` (the repair could not run or could not remove the raced-in marker — it may stay authoritative over a deleted body until TTL) |
+
+```promql
+# Orphan-producing cleanup rate (should be ~0)
+sum(rate(tag_tiered_cleanup_total{outcome=~"rejected|error|no_etag|repair_failed"}[5m]))
+```
+
+#### tag_tiered_retier_total
+
+**Type:** Counter
+
+Tiered mode's re-tier-on-read attempts: a validated GET that hits an
+upstream-tier marker whose size fits the local tier triggers a one-shot
+background move of the body into the local tier (healing objects mis-placed
+by, e.g., a cold-start PUT forwarded before its key was learned).
+
+| Label     | Description                                                              |
+| --------- | ------------------------------------------------------------------------ |
+| `outcome` | `retiered` (moved into the local tier), `shed` (populate budget refused the buffer), `changed` (object replaced/deleted mid-flight; its newer state wins), `canceled` (a concurrent write claimed the key — normal coordination), `error` (fetch or store failed) |
+
+A sustained `retiered` rate outside restart windows means writes keep landing
+in the wrong tier — check key learning. Per-key dedup skips are not counted.
+
 
 ### Revalidation Metrics
 

--- a/docs/tiered-mode.md
+++ b/docs/tiered-mode.md
@@ -1,0 +1,112 @@
+# Tiered Store Mode
+
+`mode: tiered` (or `TAG_MODE=tiered`) runs TAG as a two-tier cache in front of
+an upstream that is a cheap, capacity-priced store — not the system of record.
+The caller (typically another cache layer) treats TAG's 404 as "not cached" and
+falls back to its own authoritative store.
+
+## Semantics
+
+**Local metadata is authoritative for existence.** TAG keeps metadata for every
+object it holds, stamped with the tier the body lives in. A metadata miss
+answers `NoSuchKey` immediately — no upstream request, in either tier.
+
+**Small objects (declared size ≤ `cache.size_threshold`) are the local tier.**
+PUT STREAMS the object into the local cache — the body is never buffered in
+memory, so the threshold can be sized to the workload without a per-request
+memory cost. The MD5 ETag is computed over the decoded bytes as they stream;
+because the ETag cannot exist before the last byte, the body is keyed by a
+per-write id carried in the metadata (`BodyRef`), and the metadata commit is
+what makes the entry visible. `If-Match`/`If-None-Match` are honored; GET,
+HEAD, and DELETE are served entirely locally. Reads and writes of small
+objects generate zero upstream traffic.
+
+**Large objects are the upstream tier.** The PUT passes through to upstream and
+TAG stores a metadata marker locally. HEAD answers from the marker; GET
+forwards for the body — the mode's only body traffic. DELETE forwards and
+drops the marker.
+
+**Cross-tier overwrites clean up the displaced version.** A small write over an
+upstream-tier object deletes the upstream copy asynchronously (best-effort —
+a failure leaves an orphan for the upstream bucket's own expiry to collect).
+A large write over a local-tier object frees the local copy. With no prior
+metadata, nothing is cached and nothing is cleaned.
+
+**Population is by writes, plus one healing read-populate.** There is no
+write-through of large bodies and no general read-populate: every unique read
+costs at most one upstream GET, and never an upstream write. The one
+exception is **re-tier-on-read**: a validated GET that hits an upstream-tier
+marker whose size fits the local tier triggers a one-shot background move of
+the body into the local tier — streamed like the engine's PUT, so a heal
+costs fixed memory regardless of object size and the threshold is never
+budget-capped. This heals objects mis-placed by the cold-start
+window below, capping the damage at one extra upstream fetch per object
+instead of one body forward per read until TTL. The displaced upstream copy
+is left for the upstream bucket's own expiry.
+
+## Authentication
+
+The transparent-proxy flow, unchanged. Tiered semantics apply only to requests
+whose SigV4 signature TAG validated locally; a request it cannot validate yet
+(unknown key, anonymous) forwards to upstream exactly as in transparent mode,
+and keys are learned from those responses. Until keys are learned, reads
+behave like cache misses, and small writes land in the upstream tier (with a
+marker, so they stay readable) — the first such write's 2xx is itself what
+teaches the keys, and re-tier-on-read moves those objects into the local tier
+on their first validated read.
+
+**Credential requirement**: unlike proxy mode's read-only guidance (which
+targets customer buckets), tiered mode's upstream is the operator's own cache
+bucket, and TAG's `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` must have
+**delete** permission there — the cross-tier cleanup DELETE and the re-tier
+fetch are signed with TAG's own credentials. With read-only credentials every
+cleanup is rejected (visible as `tag_tiered_cleanup_total{outcome="rejected"}`)
+and displaced upstream copies accumulate until bucket expiry.
+
+## Configuration
+
+```yaml
+mode: tiered
+upstream:
+  endpoint: "https://t3.storage.dev"   # the cache bucket's endpoint
+cache:
+  size_threshold: 1073741824           # tier boundary (default 1GB)
+  ttl: 24h                             # applies to both tiers' metadata
+```
+
+Startup is fatal when tiered mode is combined with:
+
+- `cache.block_caching_enabled: true` — tiered mode is whole-object only
+  (individual blocks expiring would break authoritative local misses). Block
+  caching defaults to **off** in this mode.
+- `cache.enabled: false` — the local metadata store is the mode.
+- `cache.legacy_coordination: true` — tiered mode requires CAS-strength meta
+  coordination (the cache is authoritative and the local tier holds the only
+  copy, so ordering races that are transient staleness in proxy mode would be
+  data loss here). CAS coordination is selected **automatically** when the
+  setting is unset; every node running tiered is CAS-capable by construction,
+  so the proxy modes' legacy default has no upgrade population to protect in
+  this mode.
+- `upstream.transparent_proxy` set to anything — superseded by `mode`.
+
+## Not implemented (v1)
+
+Listings, multipart transfers, copies, tagging, and ACL operations pass
+through to upstream. A multipart **completion** stamps an upstream-tier
+marker — the assembled object is upstream-tier by construction — so
+multipart-written objects are immediately readable (HEAD from the marker,
+GET forwarded); the marker's metadata comes from an upstream HEAD when the
+completing request validated, and falls back to an ETag-only marker with
+unknown length otherwise. Objects created upstream without a marker-stamping
+operation (a server-side copy) read as misses through TAG until written
+again via a plain PUT. Client `Cache-Control` revalidation directives are
+not consulted — the cache is the store.
+
+A validated GET/HEAD carrying a query parameter the local engine does not
+implement (`versionId`, `partNumber`, `attributes`, presigned
+`response-content-*` overrides) answers 501 NotImplemented when the object is
+local-tier or uncached — the local store is authoritative there and cannot
+forward without breaking that authority. The same request against an
+upstream-tier object forwards normally. Sub-resource PUTs with no dedicated
+route (`retention`, `legal-hold`) forward to upstream without touching the
+object's local metadata.

--- a/handlers/block_cache_prefetch_benchmark_test.go
+++ b/handlers/block_cache_prefetch_benchmark_test.go
@@ -298,6 +298,10 @@ func (handlerPrefetchForwarder) DoFullObjectRequest(context.Context, string, str
 	return nil, errors.New("unexpected full object request")
 }
 
+func (handlerPrefetchForwarder) DoObjectDeleteRequest(context.Context, string, string, string, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected object delete request")
+}
+
 func (handlerPrefetchForwarder) DoAnonymousFullObjectRequest(context.Context, string, string) (*http.Response, error) {
 	return nil, errors.New("unexpected anonymous full object request")
 }

--- a/handlers/remote_block_miss_benchmark_test.go
+++ b/handlers/remote_block_miss_benchmark_test.go
@@ -524,6 +524,10 @@ func (*benchmarkRangeForwarder) DoFullObjectRequest(context.Context, string, str
 	return nil, errors.New("unexpected full object request")
 }
 
+func (*benchmarkRangeForwarder) DoObjectDeleteRequest(context.Context, string, string, string, string, string) (*http.Response, error) {
+	return nil, errors.New("unexpected object delete request")
+}
+
 func (*benchmarkRangeForwarder) DoAnonymousFullObjectRequest(context.Context, string, string) (*http.Response, error) {
 	return nil, errors.New("unexpected anonymous full object request")
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,13 +10,18 @@ import (
 )
 
 var (
-	// RequestsTotal counts total requests by operation and status.
+	// RequestsTotal counts total requests by operation and status; mode is
+	// the process's operating mode (one constant value per instance — it
+	// exists so fleet-wide queries can split traffic by mode) and source is
+	// where the RESPONSE was produced: "local" when TAG answered from its own
+	// store or knowledge (cache hits, revalidated-304 serves, authoritative
+	// misses, auth errors), "upstream" when the response was proxied.
 	RequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "tag_requests_total",
 			Help: "Total number of requests processed",
 		},
-		[]string{"operation", "status"},
+		[]string{"operation", "status", "mode", "source"},
 	)
 
 	// RequestDuration tracks request latency by operation.
@@ -29,7 +34,7 @@ var (
 			// tail investigations — quantiles interpolate across whole seconds.
 			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10},
 		},
-		[]string{"operation"},
+		[]string{"operation", "mode", "source"},
 	)
 
 	// CacheHits counts cache hits.
@@ -74,6 +79,34 @@ var (
 			Help: "Total number of upstream errors",
 		},
 		[]string{"method"},
+	)
+
+	// TieredCleanup counts tiered mode's cross-tier cleanup deletes by outcome:
+	// deleted, already_gone (404), replaced (412 — a newer version took the key),
+	// rejected (any other upstream refusal), error (request failed), and
+	// no_etag (marker had no ETag to bind the delete to, cleanup skipped).
+	// Failures are Debug-logged per the repo's log policy, so this counter is
+	// the rollout-visibility signal for orphaned upstream copies.
+	TieredCleanup = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tag_tiered_cleanup_total",
+			Help: "Tiered-mode cross-tier cleanup deletes by outcome",
+		},
+		[]string{"outcome"},
+	)
+
+	// TieredRetier counts tiered mode's re-tier-on-read attempts by outcome:
+	// retiered (moved into the local tier), shed (populate budget refused the
+	// buffer), changed (the object was replaced, deleted, or no longer the
+	// marker by commit time — its newer state wins), canceled (a concurrent
+	// write claimed the key — coordination, not failure), error (fetch or
+	// store failed). Per-key dedup and claim-refused skips are not counted.
+	TieredRetier = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tag_tiered_retier_total",
+			Help: "Tiered-mode re-tier-on-read attempts by outcome",
+		},
+		[]string{"outcome"},
 	)
 
 	// AuthFailures counts authentication/signature validation failures.
@@ -425,9 +458,28 @@ var (
 )
 
 // RecordRequest records a request with its duration and status.
-func RecordRequest(operation, status string, durationSeconds float64) {
-	RequestsTotal.WithLabelValues(operation, status).Inc()
-	RequestDuration.WithLabelValues(operation).Observe(durationSeconds)
+// Source label values for RecordRequest: where the response was produced.
+const (
+	SourceLocal    = "local"    // answered from TAG's own store or knowledge
+	SourceUpstream = "upstream" // proxied from upstream
+)
+
+// processMode is the operating mode stamped on every request metric. One
+// value per process, set once at startup (SetMode) before the server serves —
+// not synchronized, so it must not change while requests flow.
+var processMode = "unknown"
+
+// SetMode records the process's operating mode (transparent/signing/tiered)
+// for the request metrics' mode label. Call once at startup.
+func SetMode(mode string) {
+	if mode != "" {
+		processMode = mode
+	}
+}
+
+func RecordRequest(operation, status, source string, durationSeconds float64) {
+	RequestsTotal.WithLabelValues(operation, status, processMode, source).Inc()
+	RequestDuration.WithLabelValues(operation, processMode, source).Observe(durationSeconds)
 }
 
 // RecordCacheHit records a cache hit.
@@ -569,4 +621,35 @@ func SampleCacheSize(ctx context.Context, interval time.Duration, size func() in
 			CacheSizeBytes.Set(float64(size()))
 		}
 	}
+}
+
+// RecordTieredCleanup classifies a cross-tier cleanup delete's outcome from
+// its transport error or HTTP status and records it — classification lives
+// here, not at call sites. 404 means the displaced copy was already gone; 412
+// means the If-Match lost because a newer version took the key (left alone);
+// both are completed outcomes, not failures.
+func RecordTieredCleanup(status int, err error) {
+	outcome := "deleted"
+	switch {
+	case err != nil:
+		outcome = "error"
+	case status == 404:
+		outcome = "already_gone"
+	case status == 412:
+		outcome = "replaced"
+	case status >= 300:
+		outcome = "rejected"
+	}
+	TieredCleanup.WithLabelValues(outcome).Inc()
+}
+
+// RecordTieredCleanupSkipped records a cleanup that was never attempted
+// (e.g. no displaced ETag to bind the delete to).
+func RecordTieredCleanupSkipped(reason string) {
+	TieredCleanup.WithLabelValues(reason).Inc()
+}
+
+// RecordTieredRetier records a re-tier-on-read attempt's outcome.
+func RecordTieredRetier(outcome string) {
+	TieredRetier.WithLabelValues(outcome).Inc()
 }

--- a/proxy/block_cache.go
+++ b/proxy/block_cache.go
@@ -209,7 +209,7 @@ func (s *Service) serveRangeFromBlockCache(
 		return true, berr
 	}
 	metrics.RecordRangeFromCacheHit()
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(startTime).Seconds())
 	return true, nil
 }
 
@@ -374,7 +374,7 @@ func (s *Service) serveAssembledRange(
 		return true, werr
 	}
 	metrics.RecordRangeFromCacheHit()
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(startTime).Seconds())
 	// A parquet reader's trailer probe is a few bytes, so it is served here rather
 	// than by streamBlockRange — this, not the streaming path, is where the footer
 	// signal actually arrives for a reader opening a file.
@@ -874,7 +874,7 @@ func (s *Service) serveFullObjectFromBlockCache(
 	if _, berr := s.streamBlockRange(ctx, w, bucket, key, accessKey, secretKey, meta, 0, meta.ContentLength-1); berr != nil {
 		return true, berr
 	}
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(startTime).Seconds())
 	return true, nil
 }
 
@@ -964,7 +964,7 @@ func (s *Service) serveCompleteFromBlocks(
 	if berr != nil {
 		return true, berr
 	}
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(startTime).Seconds())
 	return true, nil
 }
 
@@ -1481,7 +1481,7 @@ func (s *Service) buildBlockMeta(bucket, key string, respHeader http.Header, tot
 // truncated bytes under a committed length (and poison a later range-path populate that trusts
 // existing blocks). fetchOneBlock validates block length the same way; this keeps the two block
 // writers consistent. A body longer than Content-Length is likewise rejected before the meta.
-func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, r io.Reader, ttl int, expected uint64) (err error) {
+func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta, r io.Reader, ttl int, expected uint64) (wrote bool, err error) {
 	// On any early return, drain the rest of r. setupCacheListener feeds this from an io.Pipe; if
 	// we stop reading with bytes still queued (a mid-object PutBlockStream error, or an oversize
 	// body), the pipe writer goroutine blocks forever on Write, leaking it and never releasing the
@@ -1502,10 +1502,10 @@ func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, m
 		bStart, bEnd := blockBounds(idx, meta.BlockSize, meta.ContentLength)
 		want := bEnd - bStart + 1
 		if _, err := io.ReadFull(r, buf[:want]); err != nil {
-			return fmt.Errorf("block split: block %d short read (%w) - upstream body shorter than Content-Length %d", idx, err, meta.ContentLength)
+			return false, fmt.Errorf("block split: block %d short read (%w) - upstream body shorter than Content-Length %d", idx, err, meta.ContentLength)
 		}
 		if perr := s.cache.PutBlockStream(ctx, bucket, key, meta.ETag, meta.BlockSize, idx, bytes.NewReader(buf[:want]), ttl); perr != nil {
-			return perr
+			return false, perr
 		}
 		metrics.CacheBlockPopulated.Inc()
 		metrics.CacheBlockBytesPopulated.Add(float64(want))
@@ -1514,15 +1514,15 @@ func (s *Service) putBlocksFromStream(ctx context.Context, bucket, key string, m
 	// before the meta so the entry can't claim a length its blocks overrun.
 	var probe [1]byte
 	if _, err := io.ReadFull(r, probe[:]); err != io.EOF {
-		return fmt.Errorf("block split: upstream body longer than Content-Length %d", meta.ContentLength)
+		return false, fmt.Errorf("block split: upstream body longer than Content-Length %d", meta.ContentLength)
 	}
 	// Every block was just written, so stamp the meta complete: full-object serves can skip
 	// the per-block probe pass and stream optimistically.
 	meta.BlocksComplete = true
-	if _, err := s.cache.PutMetaIfVersion(ctx, bucket, key, meta, ttl, expected); err != nil {
-		return err
-	}
-	return nil
+	// The store's verdict passes through: callers on conditional paths (the
+	// tiered engine's If-Match/If-None-Match PUTs) must distinguish a refused
+	// precondition from a written entry; populate paths ignore it.
+	return s.cache.PutMetaIfVersion(ctx, bucket, key, meta, ttl, expected)
 }
 
 // triggerBlockModePopulate populates a block-mode entry in the background after a cold range

--- a/proxy/block_cache_integration_test.go
+++ b/proxy/block_cache_integration_test.go
@@ -890,7 +890,7 @@ func TestPutBlocksFromStream_ExactMultipleNoPhantomBlock(t *testing.T) {
 	meta := cache.MetaFromHTTPHeaders(wowBucket, wowKey, http.StatusOK, h)
 	meta.BlockSize = 4
 
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEFGH"), 60, cache.VersionAny); err != nil {
+	if _, err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEFGH"), 60, cache.VersionAny); err != nil {
 		t.Fatalf("putBlocksFromStream: %v", err)
 	}
 	for i := int64(0); i <= 1; i++ {
@@ -920,7 +920,7 @@ func TestPutBlocksFromStream_MidStreamErrorLeavesMetaUnwritten(t *testing.T) {
 
 	// One full block, then a read error before the second.
 	r := &errAfterReader{data: []byte("ABCD")}
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, r, 60, cache.VersionAny); err == nil {
+	if _, err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, r, 60, cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the mid-stream read failure")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
@@ -943,7 +943,7 @@ func TestPutBlocksFromStream_TruncatedStreamLeavesNoShortBlockOrMeta(t *testing.
 	meta.BlockSize = 4
 
 	// ...but the body carries only 6 bytes, ending cleanly (no read error).
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, cache.VersionAny); err == nil {
+	if _, err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the truncated body")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {
@@ -968,7 +968,7 @@ func TestPutBlocksFromStream_OversizedStreamLeavesMetaUnwritten(t *testing.T) {
 	meta.BlockSize = 4
 
 	// ...but the body carries 6 bytes.
-	if err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, cache.VersionAny); err == nil {
+	if _, err := svc.putBlocksFromStream(context.Background(), wowBucket, wowKey, meta, strings.NewReader("ABCDEF"), 60, cache.VersionAny); err == nil {
 		t.Fatal("expected an error from the oversized body")
 	}
 	if _, found, _ := c.GetMeta(context.Background(), wowBucket, wowKey); found {

--- a/proxy/cache_hit_stream_test.go
+++ b/proxy/cache_hit_stream_test.go
@@ -195,7 +195,9 @@ func requestCount(t *testing.T, status string) float64 {
 	t.Helper()
 
 	var metric dto.Metric
-	if err := metrics.RequestsTotal.WithLabelValues("GetObject", status).Write(&metric); err != nil {
+	// mode defaults to "unknown" in tests (SetMode is a main.go concern); the
+	// cache-hit paths this test exercises record source=local.
+	if err := metrics.RequestsTotal.WithLabelValues("GetObject", status, "unknown", metrics.SourceLocal).Write(&metric); err != nil {
 		t.Fatalf("read %s request count: %v", status, err)
 	}
 	return metric.GetCounter().GetValue()

--- a/proxy/caching.go
+++ b/proxy/caching.go
@@ -258,7 +258,7 @@ func (s *Service) setupCacheListener(
 			// last-write-winning stale bytes over it.
 			if s.isBlockEligibleSize(meta.ContentLength) {
 				meta.BlockSize = s.config.Cache.BlockSize
-				cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, sigReader, ttl, expected)
+				_, cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, sigReader, ttl, expected)
 			} else {
 				_, cacheErr = s.cache.PutWithMetaStreamIfVersion(cacheCtx, bucket, key, meta, sigReader, ttl, expected)
 			}
@@ -555,7 +555,7 @@ func (s *Service) fetchFullObjectToCache(
 		// read a token does not fire.
 		if blockMode {
 			meta.BlockSize = s.config.Cache.BlockSize
-			cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, expected)
+			_, cacheErr = s.putBlocksFromStream(cacheCtx, bucket, key, meta, body, ttl, expected)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamIfVersion(
 				cacheCtx, bucket, key, meta, body, ttl, expected,

--- a/proxy/chunked_reader.go
+++ b/proxy/chunked_reader.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,10 +18,24 @@ const StreamingPayloadHash = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
 // AWS SDK v2 for unsigned chunked encoding with trailing checksums.
 const StreamingUnsignedTrailerHash = "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
 
+// streamingPayloadHashes is the full set of X-Amz-Content-Sha256 markers AWS
+// SDKs use for aws-chunked bodies: SigV4 and SigV4A (ECDSA) signed chunks, each
+// with and without trailing checksums, plus unsigned chunks with trailers. All
+// share the same chunk framing; missing one here would store the framing as
+// object bytes.
+var streamingPayloadHashes = map[string]bool{
+	StreamingPayloadHash:                               true,
+	StreamingPayloadHash + "-TRAILER":                  true,
+	StreamingUnsignedTrailerHash:                       true,
+	"STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD":         true,
+	"STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD-TRAILER": true,
+}
+
 // IsStreamingPayload returns true if the given body hash indicates
-// AWS chunked transfer encoding (either signed or unsigned variant).
+// AWS chunked transfer encoding (signed, signed-with-trailer, ECDSA,
+// or unsigned-with-trailer variants).
 func IsStreamingPayload(bodyHash string) bool {
-	return bodyHash == StreamingPayloadHash || bodyHash == StreamingUnsignedTrailerHash
+	return streamingPayloadHashes[bodyHash]
 }
 
 // awsChunkedReader decodes AWS S3 chunked transfer encoding.
@@ -48,9 +63,14 @@ type awsChunkedReader struct {
 	done      bool
 }
 
+// awsChunkedReaderBufSize is the decoder's internal bufio buffer. Named so
+// budget accounting (origin-less PUT admission) can reserve exactly what the
+// decoder allocates.
+const awsChunkedReaderBufSize = 64 * 1024
+
 func newAWSChunkedReader(r io.Reader) *awsChunkedReader {
 	return &awsChunkedReader{
-		reader: bufio.NewReaderSize(r, 64*1024),
+		reader: bufio.NewReaderSize(r, awsChunkedReaderBufSize),
 	}
 }
 
@@ -77,15 +97,27 @@ func (r *awsChunkedReader) Read(p []byte) (int, error) {
 
 	n, err := r.reader.Read(p[:toRead])
 	r.remaining -= n
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			// The body ended INSIDE a chunk's data. A bare io.EOF here would
+			// read as clean termination to callers — and one whose byte
+			// count happens to match the declared length would commit a
+			// never-terminated body. Clean EOF exists ONLY after the
+			// terminal 0-chunk (r.done above); every truncation shape
+			// surfaces as a wrapped, non-sentinel error.
+			return n, fmt.Errorf("aws-chunked body truncated mid-chunk: %w", io.ErrUnexpectedEOF)
+		}
+		return n, err
+	}
 
 	// When we've consumed the entire chunk, read the trailing \r\n.
-	if r.remaining == 0 && err == nil {
+	if r.remaining == 0 {
 		if err := r.readTrailingCRLF(); err != nil {
 			return n, err
 		}
 	}
 
-	return n, err
+	return n, nil
 }
 
 // maxChunkHeaderLen is the maximum allowed length of a chunk header line.
@@ -178,4 +210,19 @@ func decodeChunkedIfNeeded(r *http.Request) (body io.ReadCloser, bodyHash string
 
 	decoded := newAWSChunkedReader(r.Body)
 	return io.NopCloser(decoded), "UNSIGNED-PAYLOAD", contentLength, true
+}
+
+// stripAWSChunkedToken removes the aws-chunked token from a Content-Encoding
+// value, preserving any remaining encodings ("aws-chunked,gzip" → "gzip").
+// Content-coding tokens are case-insensitive (RFC 9110), and chunked decoding
+// keys off the streaming SHA-256 marker rather than this header's spelling, so
+// any casing of the token must be stripped once the framing is decoded.
+func stripAWSChunkedToken(ce string) string {
+	var remaining []string
+	for _, part := range strings.Split(ce, ",") {
+		if p := strings.TrimSpace(part); p != "" && !strings.EqualFold(p, "aws-chunked") {
+			remaining = append(remaining, p)
+		}
+	}
+	return strings.Join(remaining, ",")
 }

--- a/proxy/delete_objects.go
+++ b/proxy/delete_objects.go
@@ -96,12 +96,38 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	// requestedCounts tracks how many entries each key was requested under (the same
 	// key may appear multiple times with different version IDs).
 	var requestedCounts map[string]int
+	// Tiered: pre-forward tokens per key, so the post-success converge is
+	// ordered — see convergeTieredDelete.
+	type tieredPrior struct {
+		version uint64
+		known   bool
+	}
+	var tieredPriors map[string]tieredPrior
+	if s.config.IsTiered() {
+		tieredPriors = make(map[string]tieredPrior)
+	}
 	if s.cache.IsEnabled() {
 		var deleteReq deleteObjectsRequest
 		if xmlErr := xml.Unmarshal(bodyBytes, &deleteReq); xmlErr == nil {
 			requestedCounts = make(map[string]int)
 			for _, obj := range deleteReq.Objects {
-				s.invalidateObject(context.Background(), bucket, obj.Key)
+				// Proxy modes only — see preForwardInvalidate; in tiered
+				// mode a listed key may be a local-tier only-copy that a
+				// rejected bulk delete must leave intact (the per-key
+				// post-success converge below carries tiered).
+				s.preForwardInvalidate(context.Background(), bucket, obj.Key)
+				if tieredPriors != nil {
+					if _, seen := tieredPriors[obj.Key]; !seen {
+						// Claim before capturing the token, held for the whole
+						// bulk delete: cancels and excludes re-tiers so a heal
+						// cannot resurrect a deleted key past the ordered
+						// converge (see HandleDeleteObject).
+						s.claimRetierWrite(bucket, obj.Key)
+						defer s.releaseRetierWrite(bucket, obj.Key)
+						_, v, known := s.captureMarkerPrior(context.Background(), bucket, obj.Key)
+						tieredPriors[obj.Key] = tieredPrior{version: v, known: known}
+					}
+				}
 				requestedCounts[obj.Key]++
 				log.Debug().
 					Str("bucket", bucket).
@@ -133,7 +159,12 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 			if parsed && reqN <= erroredCounts[key] {
 				continue // every requested entry for this key errored — object still present
 			}
-			s.invalidateObject(context.Background(), bucket, key)
+			if tieredPriors != nil {
+				p := tieredPriors[key]
+				s.convergeTieredDelete(bucket, key, p.version, p.known)
+				continue
+			}
+			s.convergeInvalidation(context.Background(), bucket, key)
 		}
 	}
 
@@ -142,7 +173,7 @@ func (s *Service) HandleDeleteObjects(w http.ResponseWriter, r *http.Request) er
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("DeleteObjects", status, time.Since(start).Seconds())
+	metrics.RecordRequest("DeleteObjects", status, metrics.SourceUpstream, time.Since(start).Seconds())
 
 	return err
 }

--- a/proxy/forwarder.go
+++ b/proxy/forwarder.go
@@ -58,6 +58,14 @@ type RequestForwarder interface {
 	// Caller is responsible for closing the response body.
 	DoAnonymousFullObjectRequest(ctx context.Context, bucket, key string) (*http.Response, error)
 
+	// DoObjectDeleteRequest executes a synthetic DELETE for one object, signed with
+	// the given credentials. Used by tiered mode's cross-tier cleanup when a small
+	// (local) write replaces an object whose prior version lives upstream. A
+	// non-empty etag is sent as If-Match so the delete only removes the displaced
+	// version — never a newer object a concurrent write put in its place.
+	// Caller is responsible for closing the response body.
+	DoObjectDeleteRequest(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error)
+
 	// DoConditionalGetRequest executes a conditional GET for cache revalidation.
 	// Sends If-None-Match and/or If-Modified-Since headers.
 	// If rangeHeader is non-empty, includes a Range header (for range+revalidation).
@@ -326,10 +334,9 @@ func (b *baseForwarder) executeRequest(fwdReq *http.Request, inContentLength int
 // (from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY) are valid Tigris credentials
 // that can sign requests directly.
 func (b *baseForwarder) DoFullObjectRequest(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
-	path := "/" + bucket + "/" + key
-
-	// Create request without Range header - just a simple GET for the full object
-	fwdReq, err := b.signer.SignRequest(ctx, "GET", path, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, nil)
+	// SignObjectRequest takes the key literally: a key containing '?' must not
+	// be split into path + query (it would fetch a truncated sibling key).
+	fwdReq, err := b.signer.SignObjectRequest(ctx, "GET", bucket, key, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -373,6 +380,37 @@ func (b *baseForwarder) DoAnonymousFullObjectRequest(ctx context.Context, bucket
 	return resp, nil
 }
 
+// DoObjectDeleteRequest executes a synthetic DELETE for one object. Standard
+// SigV4 signing, like every TAG-initiated request. A non-empty etag becomes an
+// If-Match precondition: a 412 means the object was already replaced and must
+// be left alone. Tigris enforces If-Match on DELETE (conditional deletes are
+// ordered against the object's current version) — tiered mode is endpoint-
+// locked to Tigris, so this guard is contractual, not best-effort.
+func (b *baseForwarder) DoObjectDeleteRequest(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error) {
+	var extraHeaders http.Header
+	if etag != "" {
+		extraHeaders = http.Header{}
+		extraHeaders.Set("If-Match", etag)
+	}
+	// SignObjectRequest takes the key literally: splitting a '?'-bearing key
+	// into path + query would aim this DESTRUCTIVE request at a truncated
+	// sibling key.
+	fwdReq, err := b.signer.SignObjectRequest(ctx, http.MethodDelete, bucket, key, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamStart := time.Now()
+	resp, err := b.httpClient.Do(fwdReq)
+	metrics.RecordUpstreamRequest(http.MethodDelete, time.Since(upstreamStart).Seconds(), err)
+	if err != nil {
+		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cross-tier delete failed")
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 // DoConditionalGetRequest executes a conditional GET request to upstream.
 // Used for cache revalidation: sends If-None-Match and/or If-Modified-Since headers
 // to check if a cached object is still fresh.
@@ -395,8 +433,6 @@ func (b *baseForwarder) DoConditionalHeadRequest(ctx context.Context, bucket, ke
 // Sends If-None-Match and/or If-Modified-Since headers for cache revalidation.
 // Uses standard SigV4 signing because these are synthetic requests initiated by TAG.
 func (b *baseForwarder) doConditionalRequest(ctx context.Context, method, bucket, key, accessKey, secretKey, etag string, lastModified int64, rangeHeader string) (*http.Response, error) {
-	path := "/" + bucket + "/" + key
-
 	extraHeaders := http.Header{}
 	if etag != "" {
 		extraHeaders.Set("If-None-Match", etag)
@@ -409,7 +445,8 @@ func (b *baseForwarder) doConditionalRequest(ctx context.Context, method, bucket
 		extraHeaders.Set("Range", rangeHeader)
 	}
 
-	fwdReq, err := b.signer.SignRequest(ctx, method, path, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, extraHeaders)
+	// SignObjectRequest takes the key literally — see DoObjectDeleteRequest.
+	fwdReq, err := b.signer.SignObjectRequest(ctx, method, bucket, key, nil, "UNSIGNED-PAYLOAD", accessKey, secretKey, extraHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy/get_object.go
+++ b/proxy/get_object.go
@@ -85,6 +85,9 @@ func (cw *lazyCommitWriter) Write(p []byte) (int, error) {
 // Supports conditional requests (If-None-Match, If-Modified-Since).
 // Supports client-triggered cache revalidation via Cache-Control: no-cache/max-age=0.
 func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error {
+	if s.config.IsTiered() {
+		return s.handleTieredObject(w, r)
+	}
 	start := time.Now()
 	ctx := r.Context()
 	bucket, key := ParseBucketKey(r)
@@ -92,9 +95,9 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	bypassCache := shouldBypassCache(r)
 	rangeHeader := r.Header.Get("Range")
 
-	// Conditional request headers
+	// Conditional request headers (evaluated by writeNotModifiedFromCache on
+	// the hit path; logged here for request tracing)
 	ifNoneMatch := r.Header.Get("If-None-Match")
-	ifModifiedSince := r.Header.Get("If-Modified-Since")
 
 	log.Debug().
 		Str("bucket", bucket).
@@ -107,7 +110,7 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 	// 1. Validate credentials FIRST (before any broadcast operations)
 	result, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
 	if err != nil {
-		metrics.RecordRequest("GetObject", "auth_error", time.Since(start).Seconds())
+		metrics.RecordRequest("GetObject", "auth_error", metrics.SourceLocal, time.Since(start).Seconds())
 		return err
 	}
 
@@ -196,28 +199,14 @@ func (s *Service) HandleGetObject(w http.ResponseWriter, r *http.Request) error 
 					return s.handleRangeWithBackgroundCache(ctx, w, r, bucket, key, accessKey, secretKey, start, XCacheMiss)
 				}
 
-				// Check conditional request: If-None-Match
-				if ifNoneMatch != "" && meta.MatchesETag(ifNoneMatch) {
-					log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified")
-					writeCacheStatus(w, XCacheHit)
-					w.Header().Set("ETag", meta.ETag)
-					w.WriteHeader(http.StatusNotModified)
-					metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+				// Conditional 304s through the SHARED helper (its stated
+				// purpose): the inline version had drifted on RFC 7232 §3.3
+				// precedence — it fell through to If-Modified-Since when
+				// If-None-Match mismatched, answering 304 with stale bytes
+				// kept after a same-second overwrite; the helper ignores IMS
+				// whenever INM is present, and evaluates ETag LISTS.
+				if s.writeNotModifiedFromCache(w, r, meta, "GetObject", start) {
 					return nil
-				}
-
-				// Check conditional request: If-Modified-Since
-				if ifModifiedSince != "" {
-					if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
-						if !meta.IsModifiedSince(t) {
-							log.Debug().Str("bucket", bucket).Str("key", key).Msg("Cache hit - 304 Not Modified (time)")
-							writeCacheStatus(w, XCacheHit)
-							w.Header().Set("ETag", meta.ETag)
-							w.WriteHeader(http.StatusNotModified)
-							metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
-							return nil
-						}
-					}
 				}
 
 				// Serve full response from cache.
@@ -365,7 +354,7 @@ func (s *Service) fetchAndBroadcast(
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 	return err
 }
 
@@ -498,7 +487,7 @@ func (s *Service) receiveFromBroadcastListener(
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 	return err
 }
 
@@ -670,7 +659,7 @@ func writeRangeNotSatisfiable(w http.ResponseWriter, r *http.Request, meta *cach
 	w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", meta.ContentLength))
 	writeCacheStatus(w, XCacheHit)
 	s3err.WriteError(w, r, s3err.ErrInvalidRange)
-	metrics.RecordRequest("GetObject", "range_not_satisfiable", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "range_not_satisfiable", metrics.SourceLocal, time.Since(startTime).Seconds())
 }
 
 // It returns served=true when it has produced a complete client response (a range
@@ -711,7 +700,7 @@ func (s *Service) serveRangeFromCache(
 	// client cannot distinguish from a valid short read.
 	pr, pw := io.Pipe()
 	go func() {
-		streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.ETag, rng.start, rng.end, pw)
+		streamErr := s.cache.GetRangeStream(ctx, bucket, key, meta.BodyDiscriminator(), rng.start, rng.end, pw)
 		if streamErr != nil {
 			pw.CloseWithError(streamErr)
 		} else {
@@ -756,7 +745,7 @@ func (s *Service) serveRangeFromCache(
 	}
 
 	metrics.RecordRangeFromCacheHit()
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(startTime).Seconds())
 	return true, nil
 }
 
@@ -774,7 +763,7 @@ func (s *Service) handleRangeWithBackgroundCache(
 	// Forward the Range request directly to client (low latency)
 	resp, err := s.forwarder.DoRequestWithCreds(ctx, r, accessKey, secretKey)
 	if err != nil {
-		metrics.RecordRequest("GetObject", "error", time.Since(startTime).Seconds())
+		metrics.RecordRequest("GetObject", "error", metrics.SourceUpstream, time.Since(startTime).Seconds())
 		return err
 	}
 	defer resp.Body.Close()
@@ -870,7 +859,36 @@ func (s *Service) handleRangeWithBackgroundCache(
 		return err
 	}
 
-	metrics.RecordRequest("GetObject", "success", time.Since(startTime).Seconds())
+	metrics.RecordRequest("GetObject", "success", metrics.SourceUpstream, time.Since(startTime).Seconds())
 
 	return nil
+}
+
+// writeNotModifiedFromCache answers a conditional request with 304 when the
+// cached entry satisfies the request's validators. Per RFC 7232 §3.3, a
+// request carrying If-None-Match is judged by it ALONE — If-Modified-Since is
+// ignored, matching or not: LastModified is second-granular, so falling back
+// to it could 304 a client across a same-second overwrite it should see.
+// Returns true when it wrote the response. Shared by the proxying GET hit
+// path and the origin-less handler so the two cannot drift.
+func (s *Service) writeNotModifiedFromCache(w http.ResponseWriter, r *http.Request, meta *cache.CachedObjectMeta, operation string, start time.Time) bool {
+	if inm := r.Header.Get("If-None-Match"); inm != "" {
+		if !meta.MatchesETagHeader(inm, false) {
+			return false
+		}
+	} else {
+		ims := r.Header.Get("If-Modified-Since")
+		if ims == "" {
+			return false
+		}
+		t, parseErr := http.ParseTime(ims)
+		if parseErr != nil || meta.IsModifiedSince(t) {
+			return false
+		}
+	}
+	writeCacheStatus(w, XCacheHit)
+	w.Header().Set("ETag", meta.ETag)
+	w.WriteHeader(http.StatusNotModified)
+	metrics.RecordRequest(operation, "success", metrics.SourceLocal, time.Since(start).Seconds())
+	return true
 }

--- a/proxy/localstore.go
+++ b/proxy/localstore.go
@@ -1,0 +1,712 @@
+package proxy
+
+// The local-store engine: whole-object PUT/GET/HEAD/DELETE served entirely from
+// the cache with authoritative misses. In tiered mode this engine is the small
+// tier, and everything else forwards.
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+	"github.com/tigrisdata/tag/s3err"
+)
+
+// The local-store engine: TAG serving and storing on its own, with no
+// upstream involved. Its sole consumer is TIERED MODE's local tier — the
+// handlers keep their HandleOriginless names from the abandoned stand-alone
+// origin-less mode, whose branch is deleted; the engine itself is what
+// survived it.
+//
+// The engine is reached only through the tiered dispatch (handleTieredObject
+// / handleTieredPut / handleTieredDeleteLocal), so every path that assumes
+// an upstream — revalidation, broadcast coalescing, background fetch, the
+// proxy mutation handlers with their invalidate-before-forward ordering — is
+// unreachable by construction. Requests arrive already validated by the
+// tiered handlers (unvalidated requests forward upstream before the engine
+// is consulted).
+//
+// Reads:  GET/HEAD of one object from cache; a miss is NoSuchKey, the caller's
+//         cue to fall back to its authoritative store.
+// Writes: PUT stores the object in the local cache under cache.ttl; DELETE
+//         invalidates. This is how the tier is populated — by its callers,
+//         directly.
+// Everything else — listings, multipart, copies, tagging, ACLs — answers 501
+// or forwards at the tiered layer above.
+
+// HandleOriginlessObject serves GET and HEAD for a single object from cache
+// alone. A miss is the final answer: NoSuchKey — the caller's cue to fall back
+// to its authoritative store.
+func (s *Service) HandleOriginlessObject(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+
+	// Plain reads only: a query parameter (beyond the SDK's no-op x-id tag)
+	// selects a representation or operation this mode does not implement —
+	// ?versionId, ?partNumber, ?tagging — and serving the current full object for
+	// those would be silently wrong data.
+	if !originlessPlainObject(r) {
+		return s.HandleOriginlessUnsupported(w, r)
+	}
+
+	operation := "GetObject"
+	if r.Method == http.MethodHead {
+		operation = "HeadObject"
+	}
+
+	log.Debug().Str("bucket", bucket).Str("key", key).Str("op", operation).Msg("HandleOriginlessObject")
+
+	if !s.cache.IsEnabled() {
+		writeCacheStatus(w, XCacheDisabled)
+		s3err.WriteError(w, r, s3err.ErrNoSuchKey)
+		metrics.RecordRequest(operation, "success", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+
+	meta, metaVersion, found, cacheErr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+	if cacheErr != nil {
+		// A transient metadata failure is not absence: the miss below is
+		// authoritative, so it must never be minted from an error. 500-retry,
+		// matching the body-probe path below.
+		metrics.RecordRequest(operation, "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return cacheErr
+	}
+	if !found {
+		meta = nil
+	}
+	return s.serveOriginlessObject(w, r, operation, start, meta, metaVersion)
+}
+
+// serveOriginlessObject serves GET/HEAD from an ALREADY-READ metadata
+// snapshot (nil = authoritative miss). Tiered mode calls it with the meta its
+// tier decision was made from: re-reading here opened a window where a large
+// PUT committing its BodyUpstream marker between the two reads made the
+// engine treat the marker as a local-tier entry, probe the body under the NEW
+// upstream ETag, and answer an authoritative NoSuchKey for an object that
+// existed before, during, and after the overwrite. One read, one decision —
+// a read racing an overwrite serves the version its snapshot saw, the legal
+// atomic-replace answer (and the hottest path saves a doubled meta read).
+func (s *Service) serveOriginlessObject(w http.ResponseWriter, r *http.Request, operation string, start time.Time, meta *cache.CachedObjectMeta, metaVersion uint64) error {
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+
+	if meta == nil {
+		return s.originlessMiss(w, r, operation, start)
+	}
+
+	// ONE existence gate for the whole handler: an entry is visible only when its
+	// data is fully present — every block of a block-mode entry, the body of a
+	// whole-object one. Every answer below (304, HEAD 200, any serve) implies
+	// existence, and each of HEAD, conditionals, and the serve paths independently
+	// answering that question is exactly how three review rounds of
+	// existence-vs-serveability disagreements happened. An incomplete entry is
+	// simply invisible: metadata alone cannot be served, and claiming existence
+	// from it makes HEAD-as-existence callers — anything that skips re-population
+	// when a HEAD says the object exists — skip the healing that would make the
+	// entry servable again. A probe-to-serve race can still truncate a
+	// concurrent eviction; the gate narrows the window, nothing can close it.
+	servable, servErr := s.entryServable(ctx, bucket, key, meta)
+	if servErr != nil {
+		// A transient probe failure is not absence: 500-retry, never a false miss.
+		metrics.RecordRequest(operation, "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return servErr
+	}
+	if !servable {
+		return s.originlessMiss(w, r, operation, start)
+	}
+
+	// Conditional requests are answered from the cached metadata; there is no
+	// upstream for a client's Cache-Control to revalidate against, so no-cache and
+	// no-store are simply not consulted — the cached copy is the only copy.
+	if s.answerConditionalsFromMeta(w, r, meta, operation, start) {
+		return nil
+	}
+
+	if r.Method == http.MethodHead {
+		serveMetaHit(w, meta, operation, start)
+		return nil
+	}
+
+	// Whole-object serves only: this engine's modes force block caching off
+	// (tiered rejects it at validateMode), so every entry IT writes is a
+	// whole blob, and the serve helpers below fail before committing headers
+	// — a miss response is always still writable.
+	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
+		served, rangeErr := s.serveRangeFromCache(ctx, w, r, bucket, key, meta, rangeHeader, start)
+		if served {
+			return rangeErr
+		}
+		return s.finishServeBodyError(ctx, w, r, bucket, key, metaVersion, rangeErr, operation, start)
+	}
+
+	if bodyErr := s.serveFromCache(ctx, w, bucket, key, meta, start); bodyErr != nil {
+		// serveFromCache fails before committing headers, so a miss response is
+		// still writable.
+		return s.finishServeBodyError(ctx, w, r, bucket, key, metaVersion, bodyErr, operation, start)
+	}
+	return nil
+}
+
+// finishServeBodyError disposes of a pre-commit body-serve failure. It
+// distinguishes two cases the mode must not conflate:
+//   - The body is GENUINELY GONE (evicted under a live meta): an
+//     authoritative miss, and the orphaned meta is invalidated — but
+//     ETag-GUARDED (DeleteIfETag), never an unconditional delete, so a
+//     concurrent PUT's just-committed newer version is never wiped. The
+//     guard resolves against the served snapshot's discriminator identity;
+//     a different current entry keeps the key.
+//   - Anything else is TRANSIENT (a cluster-peer gRPC blip, a deadline):
+//     NOT absence. Minting an authoritative NoSuchKey here would tell the
+//     caller a live object does not exist — so it propagates as a retryable
+//     5xx, matching this handler's meta-read and probe legs.
+func (s *Service) finishServeBodyError(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket, key string, metaVersion uint64, serveErr error, operation string, start time.Time) error {
+	if !bodyGone(serveErr) {
+		metrics.RecordRequest(operation, "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return serveErr
+	}
+	// VERSION-guarded against the SERVED snapshot: a concurrent PUT's newer
+	// meta (even an identical-content one, which shares the ETag but not the
+	// version) is never wiped — only the exact orphaned entry this serve
+	// read is removed. The delete is best-effort cleanup anyway: entryServable
+	// already gates every subsequent read on body presence, so a surviving
+	// orphan reads as a miss regardless and ages out by TTL.
+	if _, derr := s.cache.DeleteMetaIfVersion(ctx, bucket, key, metaVersion); derr != nil {
+		log.Debug().Err(derr).Str("bucket", bucket).Str("key", key).Msg("Orphaned-meta invalidation failed; ages out by TTL")
+	}
+	return s.originlessMiss(w, r, operation, start)
+}
+
+// entryServable is the handler's single existence answer: all blocks present for
+// a block-mode entry, the body present for a whole-object one. Everything the
+// handler says — 304, HEAD 200, a served body — flows from this one predicate, so
+// existence and serveability cannot disagree.
+func (s *Service) entryServable(ctx context.Context, bucket, key string, meta *cache.CachedObjectMeta) (bool, error) {
+	// A zero-length object is vacuously servable: no byte can be missing, and the
+	// first-byte probe below cannot see one anyway — the embedded backend returns
+	// nil + zero bytes for a present-but-empty body and an absent one alike (the
+	// quirk countingWriter exists for). Serving from metadata alone is exact for an
+	// empty body, evicted or not.
+	if meta.ContentLength == 0 {
+		return true, nil
+	}
+	return s.cache.BodyExistsErr(ctx, bucket, key, meta.BodyDiscriminator())
+}
+
+// originlessMiss answers the one thing a miss can be in this mode.
+func (s *Service) originlessMiss(w http.ResponseWriter, r *http.Request, operation string, start time.Time) error {
+	writeCacheStatus(w, XCacheMiss)
+	s3err.WriteError(w, r, s3err.ErrNoSuchKey)
+	metrics.RecordRequest(operation, "success", metrics.SourceLocal, time.Since(start).Seconds())
+	return nil
+}
+
+// writePreconditionFailed answers the 412 preconditions (RFC 7232 order:
+// If-Match before If-Unmodified-Since) from cached metadata. Returns true when
+// it wrote the response. The 304 conditionals (If-None-Match/If-Modified-Since)
+// are evaluated separately, after these.
+func writePreconditionFailed(w http.ResponseWriter, r *http.Request, meta *cache.CachedObjectMeta) bool {
+	if im := r.Header.Get("If-Match"); im != "" {
+		if im != "*" && !meta.MatchesETagHeader(im, true) {
+			s3err.WriteError(w, r, s3err.ErrPreconditionFailed)
+			return true
+		}
+		// RFC 7232 §3.4: when If-Match is present, If-Unmodified-Since is ignored
+		// — a matching ETag with a stale date must serve, not 412.
+		return false
+	}
+	if ius := r.Header.Get("If-Unmodified-Since"); ius != "" {
+		if t, err := http.ParseTime(ius); err == nil && meta.IsModifiedSince(t) {
+			s3err.WriteError(w, r, s3err.ErrPreconditionFailed)
+			return true
+		}
+	}
+	return false
+}
+
+// originlessPutSize returns the number of body bytes a PUT declares. For a
+// streaming (aws-chunked) payload that is X-Amz-Decoded-Content-Length —
+// REQUIRED, and zero is valid (the SDK's empty-body default); sizing a framed
+// body by its wire Content-Length would reject valid uploads as IncompleteBody.
+// For a plain payload it is Content-Length, which Go reports as -1 when absent.
+func originlessPutSize(r *http.Request) (int64, bool) {
+	if IsStreamingPayload(r.Header.Get("X-Amz-Content-Sha256")) {
+		dcl := r.Header.Get("X-Amz-Decoded-Content-Length")
+		if dcl == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseInt(dcl, 10, 64)
+		return n, err == nil && n >= 0
+	}
+	if r.ContentLength < 0 {
+		return 0, false
+	}
+	return r.ContentLength, true
+}
+
+// originlessPlainObject reports whether the request is a plain single-object
+// operation: no query parameters beyond the SDK's no-op x-id tag, and no
+// copy-source header (server-side copy needs a source read this mode does not
+// implement as an operation).
+// originlessIgnoredParams are query parameters that select no operation or
+// representation: the SDK's no-op tag, and the auth parameters presigned URLs
+// attach (SigV4 and SigV2). Auth is ignored in this mode — the network is the
+// boundary — so a presigned request is served exactly like its header-signed
+// twin: the signature is stripped, not evaluated.
+var originlessIgnoredParams = []string{
+	"x-id",
+	"X-Amz-Algorithm", "X-Amz-Credential", "X-Amz-Date", "X-Amz-Expires",
+	"X-Amz-SignedHeaders", "X-Amz-Signature", "X-Amz-Security-Token",
+	"AWSAccessKeyId", "Signature", "Expires",
+}
+
+func originlessPlainObject(r *http.Request) bool {
+	if r.Header.Get("X-Amz-Copy-Source") != "" {
+		return false
+	}
+	if r.URL.RawQuery == "" {
+		return true
+	}
+	q := r.URL.Query()
+	for _, p := range originlessIgnoredParams {
+		q.Del(p)
+	}
+	return len(q) == 0
+}
+
+// HandleOriginlessPut stores an object directly into the local cache — the
+// population path for this tier. The body is buffered to compute the ETag
+// (bodies are keyed by ETag so each version is immutable), bounded by the cache
+// size threshold, and stored under cache.ttl. Overwrites follow the proxying
+// mode's semantics: new meta points at the new ETag-keyed body; the old body
+// ages out by TTL.
+func (s *Service) HandleOriginlessPut(w http.ResponseWriter, r *http.Request) error {
+	return s.handleOriginlessPut(w, r, nil)
+}
+
+// putPrior is a metadata snapshot the caller already read, threaded into the
+// engine PUT so a single GetMetaWithVersion serves both the caller's decision
+// and the engine's precondition/token — closing the double-read TOCTOU (a
+// marker committing between two reads) and the doubled hot-path meta read.
+type putPrior struct {
+	meta    *cache.CachedObjectMeta
+	version uint64
+	found   bool
+}
+
+func (s *Service) handleOriginlessPut(w http.ResponseWriter, r *http.Request, prior *putPrior) error {
+	start := time.Now()
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+
+	if !originlessPlainObject(r) {
+		return s.HandleOriginlessUnsupported(w, r)
+	}
+	if !s.cache.IsEnabled() {
+		s3err.WriteError(w, r, s3err.ErrNotImplemented)
+		metrics.RecordRequest("PutObject", "unsupported", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+
+	// EVERY store commits under a decision-time token read here, before the
+	// body is consumed: a DELETE (or competing PUT) that lands after this
+	// instant refuses the commit — the ordering the pre-coordinator engine got
+	// from stamping writeStartTime at handler start, now expressed as the
+	// opaque token the selected coordinator orders by (fenced version under
+	// CAS, wall-clock stamp under legacy). For an absent key the token is the
+	// nonzero absence token, never 0 (ocache v1.13 contract).
+	//
+	// Conditional writes additionally evaluate the precondition here and then
+	// ENFORCE it at the store: a concurrent write between check and store
+	// surfaces as a refused store (answered 412) instead of a silent lost
+	// update. That closure is CAS-coordinator strength; under legacy
+	// coordination the token orders against DELETEs only, and write-vs-write
+	// remains the check-then-store race the pre-CAS engine documented as
+	// accepted. Semantics follow the ceph suite: If-Match against a MISSING
+	// object answers NoSuchKey (there is nothing to match), a
+	// present-but-different ETag is the 412; If-None-Match refuses when the
+	// object exists.
+	var existing *cache.CachedObjectMeta
+	var expected uint64
+	var found bool
+	if prior != nil {
+		// The caller's snapshot IS the decision state: reuse it so the tier
+		// routing and this precondition evaluation cannot disagree across a
+		// racing marker commit, and the hot path reads meta once.
+		existing, expected, found = prior.meta, prior.version, prior.found
+	} else {
+		var merr error
+		existing, expected, found, merr = s.cache.GetMetaWithVersion(ctx, bucket, key)
+		if merr != nil {
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return merr
+		}
+	}
+	conditional := false
+	ifMatch := r.Header.Get("If-Match")
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	if ifMatch != "" || ifNoneMatch != "" {
+		conditional = true
+		// Existence means SERVABLE existence — the same gate every read uses. An
+		// incomplete entry (orphaned meta, missing blocks) is invisible on every
+		// request shape, so If-None-Match:* must store over it (that IS the
+		// healing put-if-absent) and If-Match must answer NoSuchKey, not 412.
+		// A probe ERROR aborts: read as "absent" it would let If-None-Match:*
+		// overwrite a live object during a transient blip.
+		exists := found && existing != nil
+		// A BodyUpstream tier marker IS an existing object — its body lives
+		// upstream, so the local-body servability probe below would read it
+		// as absent, letting If-None-Match:* overwrite a live object (and
+		// If-Match answer NoSuchKey for one). The steady-state tiered router
+		// forwards marker-prior conditionals upstream; this guard covers the
+		// race where a marker commits between the router's read and this one.
+		if exists && !existing.BodyUpstream {
+			var servErr error
+			exists, servErr = s.entryServable(ctx, bucket, key, existing)
+			if servErr != nil {
+				metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+				return servErr
+			}
+		}
+		// The store applies against exactly the state this evaluation saw: the
+		// token above is the observed row's version when present (an unservable
+		// row still occupies the meta key, and the healing overwrite must
+		// replace that exact orphan), and the absence token when not — either
+		// way, whatever appears between this evaluation and the store refuses
+		// the commit.
+		switch {
+		case ifMatch != "" && !exists:
+			s3err.WriteError(w, r, s3err.ErrNoSuchKey)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		case ifMatch != "" && ifMatch != "*" && !existing.MatchesETagHeader(ifMatch, true):
+			s3err.WriteError(w, r, s3err.ErrPreconditionFailed)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		case ifNoneMatch != "" && exists && (ifNoneMatch == "*" || existing.MatchesETagHeader(ifNoneMatch, false)):
+			s3err.WriteError(w, r, s3err.ErrPreconditionFailed)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		}
+	}
+
+	// Decoded size, not wire size: a streaming-signed SDK upload frames the body
+	// (aws-chunked) and declares the real length in X-Amz-Decoded-Content-Length.
+	// Judging the threshold by wire length would reject payloads that fit.
+	//
+	// The declared size is REQUIRED, as on real S3 (411 without one): the budget
+	// reservation below must equal the bytes this handler can actually hold, and
+	// with no declared size the only safe reservation would be the full threshold
+	// for every request. Zero is a valid declaration — an empty object is the AWS
+	// SDK's default for empty bodies and must not be sized by its wire framing.
+	declaredSize, ok := originlessPutSize(r)
+	if !ok {
+		s3err.WriteError(w, r, s3err.ErrMissingContentLength)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+	if declaredSize > s.config.Cache.SizeThreshold {
+		s3err.WriteError(w, r, s3err.ErrEntityTooLarge)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+
+	// STREAMING store — the body is never buffered. It streams through an MD5
+	// tee into the cache under a per-write BodyRef (the ETag IS the body's
+	// MD5, so it cannot exist before the last byte; the ref stands in as the
+	// body key discriminator, see cache.NewBodyRef), and the metadata that
+	// makes the entry visible commits afterwards carrying both. Memory per
+	// PUT is the fixed streaming buffers below regardless of object size, so
+	// admission is the write-count ceiling plus that fixed weight — the
+	// populate BYTE budget no longer carries PUT bodies at all.
+	//
+	// Admission is NON-BLOCKING (the read-miss path): a client-facing PUT
+	// must shed with a retryable SlowDown immediately, not park on the
+	// budget's condition variable.
+	streaming := IsStreamingPayload(r.Header.Get("X-Amz-Content-Sha256"))
+	weight := int64(originlessPutStreamWeight)
+	if streaming {
+		weight += awsChunkedReaderBufSize
+	}
+	if !s.acquireEnginePutSlot(ctx, weight) {
+		s3err.WriteError(w, r, s3err.ErrSlowDown)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+	defer s.releaseEnginePutSlot(weight)
+
+	// Content-MD5 FORMAT is validated before a byte is accepted — a malformed
+	// digest (bad base64, wrong length, present-but-empty; Values, not Get,
+	// because Get cannot distinguish empty from absent) rejects without
+	// paying for the upload. The VALUE is compared after the stream, when
+	// the digest exists. Malformed = InvalidDigest, wrong = BadDigest —
+	// S3's split; the engine IS the store, nothing upstream checks this.
+	var wantMD5 []byte
+	if md5Vals := r.Header.Values("Content-MD5"); len(md5Vals) > 0 {
+		want, decErr := base64.StdEncoding.DecodeString(md5Vals[0])
+		if decErr != nil || len(want) != md5.Size {
+			s3err.WriteError(w, r, s3err.ErrInvalidDigest)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		}
+		wantMD5 = want
+	}
+
+	// Unwrap AWS chunked framing so the stored bytes — and the ETag computed over
+	// them — are the object, not the wire encoding. Storing the framing serves
+	// corrupt bytes with a 200, which the caller cannot detect as a miss.
+	reader := r.Body
+	if streaming {
+		reader = io.NopCloser(newAWSChunkedReader(r.Body))
+	}
+
+	// The stream is limited to declared+1 bytes (the extra byte detects a
+	// body longer than declared), teed through the digest, and counted; the
+	// capture wrapper records a reader-side failure so a failed store can be
+	// attributed to the client's body rather than the cache. On ANY
+	// non-success below, the staged body is deleted best-effort — a body
+	// whose meta never commits is an orphan, and TTL is the backstop when
+	// the delete itself fails.
+	hasher := md5.New()
+	src := &captureReader{r: io.TeeReader(io.LimitReader(reader, declaredSize+1), hasher)}
+	ref := cache.NewBodyRef()
+	ttl := int(s.config.Cache.TTL.Seconds())
+	// ONE deferred, panic-safe reclamation for the staged body, in place of a
+	// discard call on every abort path (a forgotten call on a future path —
+	// or a panic between staging and commit — would leak a threshold-sized
+	// orphan until TTL). Two flags steer it:
+	//   committed — the meta commit landed; the body is referenced, keep it.
+	//   ambiguousCommit — a commit ATTEMPT errored without a definitive
+	//     verdict. In cluster mode PutMetaIfVersion is a non-idempotent
+	//     remote op: an error can mean the owner APPLIED the write and the
+	//     confirmation was lost, so deleting the staged body here could
+	//     destroy the object a now-visible meta references — erasing the
+	//     previously live version with it. Ambiguity keeps the body; a
+	//     genuinely uncommitted orphan is TTL's job (the documented
+	//     backstop). Only DEFINITIVE outcomes discard: refused conditional
+	//     (412), overrun, short body, digest mismatch, refused-retries
+	//     exhaustion (each refusal is the store answering "no").
+	committed := false
+	ambiguousCommit := false
+	defer func() {
+		if committed || ambiguousCommit {
+			return
+		}
+		dctx, dcancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer dcancel()
+		if derr := s.cache.DeleteBody(dctx, bucket, key, ref); derr != nil {
+			log.Debug().Err(derr).Str("bucket", bucket).Str("key", key).Msg("Staged body delete failed; orphan ages out by TTL")
+		}
+	}()
+	if putErr := s.cache.PutBodyStream(ctx, bucket, key, ref, src, int64(ttl)); putErr != nil {
+		// ANY recorded reader error is the client's transfer: the capture
+		// wrapper sits over nothing but the request-body chain (net/http
+		// body, optionally the chunk decoder — whose truncations are all
+		// wrapped, never bare EOFs), so truncations, malformed framing,
+		// resets, and read-deadline expiries mid-body all classify as the
+		// client misdescribing or abandoning the request: 400
+		// IncompleteBody, never a retryable 500 (and never a server-error
+		// metric for a client fault). Only a cache-side write failure —
+		// putErr with no reader error — propagates.
+		if src.err != nil {
+			s3err.WriteError(w, r, s3err.ErrIncompleteBody)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		}
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		if src.err != nil {
+			return src.err
+		}
+		return putErr
+	}
+	switch {
+	case src.n == declaredSize+1:
+		// The limit filled: the body is longer than declared.
+		s3err.WriteError(w, r, s3err.ErrIncompleteBody)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	case src.n != declaredSize:
+		// Clean EOF before the declared size: the client misdescribed the
+		// request; not data to store under a wrong ETag.
+		s3err.WriteError(w, r, s3err.ErrIncompleteBody)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+
+	sum := hasher.Sum(nil)
+	etag := `"` + hex.EncodeToString(sum) + `"`
+	if wantMD5 != nil && !bytes.Equal(wantMD5, sum) {
+		s3err.WriteError(w, r, s3err.ErrBadDigest)
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return nil
+	}
+
+	// Same header→meta mapping as the proxying populate path, then override
+	// what a terminal store owns: the ETag is computed (never client-supplied),
+	// ContentLength is the decoded body (the wire length counts chunk framing),
+	// Content-Encoding drops the aws-chunked token (that layer was decoded above;
+	// dropping the header entirely would serve gzip bytes read as the raw
+	// object), and LastModified is the write time, not a client header.
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, r.Header)
+	meta.ETag = etag
+	meta.BodyRef = ref
+	meta.ContentLength = declaredSize
+	// Values, not Get: repeated Content-Encoding field lines are legal HTTP and
+	// equivalent to one comma-joined list ("aws-chunked" + "gzip" ≡
+	// "aws-chunked,gzip"); Get would keep only the first and lose the rest.
+	meta.ContentEncoding = strings.Join(r.Header.Values("Content-Encoding"), ",")
+	if streaming {
+		// Strip only what was actually decoded: the aws-chunked layer is
+		// removed above only for streaming-marked bodies, and advertising a
+		// non-streaming body as decoded would mislabel stored bytes.
+		meta.ContentEncoding = stripAWSChunkedToken(meta.ContentEncoding)
+	}
+	meta.LastModified = time.Now().Unix()
+
+	// The body is already durable under its ref, so the commit — and every
+	// retry — is METADATA ONLY: the store closure is one PutMetaIfVersion,
+	// never a body re-stream. A refused commit is detected, never silent:
+	// conditional writes answer the 412 their precondition earned (and
+	// reclaim the staged body), unconditional writes retry under a fresh
+	// token so the client's 200 always means the entry is visible.
+	store := func(token uint64) (bool, error) {
+		return s.cache.PutMetaIfVersion(ctx, bucket, key, meta, ttl, token)
+	}
+	var wrote bool
+	wrote, err := store(expected)
+	if err != nil {
+		ambiguousCommit = true
+		metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return err
+	}
+	if !wrote {
+		if conditional {
+			// The conditional's precondition raced away between evaluation and
+			// store. The honest answer is the 412 the client would have gotten
+			// had the racer arrived a moment earlier; the staged body will
+			// never be referenced.
+			s3err.WriteError(w, r, s3err.ErrPreconditionFailed)
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return nil
+		}
+		// A refused UNCONDITIONAL client write is retried under a fresh token,
+		// never acked without storing: the racer that bumped the version may be
+		// TAG's OWN re-tier heal committing the PRE-PUT version (the write
+		// claim is process-local, so a re-tier on another node — or one whose
+		// cancellation landed after its last context check — can slip in), and
+		// treating that as "the racer's state keeps the key" would silently
+		// revert an acknowledged client write in the mode's authoritative
+		// store. A client write is by definition the newest state for the key;
+		// re-reading and retrying serializes it after whatever won the round.
+		// A genuine concurrent client racer (PUT or DELETE) just loses the
+		// last-writer race to this PUT — a legal S3 serialization either way.
+		// Bounded: exhaustion or an error answers retryably (500), so the
+		// client never holds a 200 for bytes that were not stored.
+		for attempt := 0; attempt < 8 && !wrote; attempt++ {
+			if cerr := ctx.Err(); cerr != nil {
+				metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+				return cerr
+			}
+			_, retryToken, _, terr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+			if terr != nil {
+				metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+				return terr
+			}
+			wrote, err = store(retryToken)
+			if err != nil {
+				ambiguousCommit = true
+				metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+				return err
+			}
+		}
+		if !wrote {
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return fmt.Errorf("put %s/%s: store refused %d retries under fresh tokens", bucket, key, 8)
+		}
+	}
+
+	committed = true
+	w.Header().Set("ETag", etag)
+	w.WriteHeader(http.StatusOK)
+	metrics.RecordRequest("PutObject", "success", metrics.SourceLocal, time.Since(start).Seconds())
+	return nil
+}
+
+// HandleOriginlessDelete invalidates the object. Deletion is not required for
+// correctness — entries lapse by cache.ttl — but a caller that expires objects
+// explicitly (a caller expiring objects on its own schedule) gets prompt removal.
+func (s *Service) HandleOriginlessDelete(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	bucket, key := ParseBucketKey(r)
+
+	if !originlessPlainObject(r) {
+		return s.HandleOriginlessUnsupported(w, r)
+	}
+	// The cache is the only store: an acked-but-failed delete would keep
+	// serving the object until TTL with no signal to retry on. 500, not 204.
+	if err := s.invalidateObject(r.Context(), bucket, key); err != nil {
+		metrics.RecordRequest("DeleteObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	metrics.RecordRequest("DeleteObject", "success", metrics.SourceLocal, time.Since(start).Seconds())
+	return nil
+}
+
+// HandleOriginlessUnsupported rejects every operation this mode does not
+// implement — listings, mutations, multipart, tagging, ACLs. Recorded under a
+// distinct status so a client persistently writing to an origin-less tier (a
+// misconfigured caller, for instance) is visible on the dashboard instead of
+// blending into the success rate.
+func (s *Service) HandleOriginlessUnsupported(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	s3err.WriteError(w, r, s3err.ErrNotImplemented)
+	metrics.RecordRequest("Unsupported", "unsupported", metrics.SourceLocal, time.Since(start).Seconds())
+	return nil
+}
+
+// originlessPutStreamWeight is the fixed byte-budget weight of one streaming
+// engine PUT — the store's pinned stream buffering, not the body (the body
+// never lives in TAG's memory). ocache's PutStream holds a ~64 KiB
+// first-chunk buffer plus a 1 MiB pooled copy buffer for the stream's whole
+// (client-paced) duration, and the cluster remote path pins a further 1 MiB
+// gRPC send buffer — mirrored here as a literal (like the storage defaults
+// in config) since TAG imports only the ocache client. Sized for the
+// cluster worst case; undercounting this is the unaccounted-margin class
+// that has OOM-killed pods before.
+const originlessPutStreamWeight = 2*1024*1024 + 128*1024
+
+// captureReader counts the bytes read through it and records the first
+// non-EOF error its inner reader returns, so a failed store can be
+// attributed to the client's body (truncated, malformed chunk framing)
+// rather than the cache write.
+type captureReader struct {
+	r   io.Reader
+	n   int64
+	err error
+}
+
+func (c *captureReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	// The io.EOF SENTINEL (equality, not errors.Is) is clean termination and
+	// is never recorded. A WRAPPED EOF is different: the chunked decoder
+	// wraps its errors ("reading chunk header: %w"), so a body truncated
+	// mid-frame surfaces as a wrapped io.EOF that must be attributed to the
+	// client — errors.Is would swallow it and turn IncompleteBody into a 500.
+	if err != nil && err != io.EOF && c.err == nil {
+		c.err = err
+	}
+	return n, err
+}

--- a/proxy/meta_on_write.go
+++ b/proxy/meta_on_write.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"encoding/xml"
 	"net/http"
-
-	"github.com/rs/zerolog/log"
-
-	"github.com/tigrisdata/tag/cache"
 )
 
 // Metadata caching on write (prototype).
@@ -78,26 +74,14 @@ func (s *Service) establishBlockMetaFromHead(bucket, key, accessKey, secretKey, 
 		return
 	}
 
-	resp, err := s.forwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, "", 0)
-	if err != nil {
-		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Meta-on-write - HEAD failed")
+	// Shared HEAD-and-verify: ok only when upstream answers 200 for exactly
+	// the ETag this write produced — a concurrent overwrite's meta would
+	// describe an object whose blocks a later read fetches under a different
+	// version, the torn-pair hazard write_through guards against.
+	meta, ok := s.headObjectMeta(ctx, bucket, key, accessKey, secretKey, writtenETag)
+	if !ok {
 		return
 	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return
-	}
-
-	// Only establish the version we actually wrote. A concurrent overwrite returns a
-	// different ETag, and caching that meta would describe an object whose blocks a
-	// later read would fetch under a different version — the same torn-pair hazard
-	// write_through guards against.
-	if resp.Header.Get("ETag") != writtenETag {
-		log.Debug().Str("bucket", bucket).Str("key", key).Msg("Meta-on-write skipped - superseded by a concurrent overwrite")
-		return
-	}
-
-	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
 	if !meta.IsCacheable(s.config.Cache.SizeThreshold) {
 		return
 	}

--- a/proxy/revalidation.go
+++ b/proxy/revalidation.go
@@ -124,7 +124,7 @@ func (s *Service) forwardAfterCacheMiss(ctx context.Context, w http.ResponseWrit
 	if forwardErr != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 	return forwardErr
 }
 
@@ -248,7 +248,7 @@ func (s *Service) handleRevalidation200(
 		if copyErr != nil {
 			status = "error"
 		}
-		metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+		metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 		return copyErr
 	}
 
@@ -265,7 +265,7 @@ func (s *Service) handleRevalidation200(
 		var cacheErr error
 		if s.isBlockEligibleSize(newMeta.ContentLength) {
 			newMeta.BlockSize = s.config.Cache.BlockSize
-			cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, expected)
+			_, cacheErr = s.putBlocksFromStream(context.Background(), bucket, key, newMeta, pr, ttl, expected)
 		} else {
 			_, cacheErr = s.cache.PutWithMetaStreamIfVersion(
 				context.Background(), bucket, key, newMeta, pr, ttl, expected,
@@ -307,7 +307,7 @@ func (s *Service) handleRevalidation200(
 	if copyErr != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 	return copyErr
 }
 
@@ -322,10 +322,7 @@ func (s *Service) serveFromCache(
 ) error {
 	// Zero-byte objects: no body to serve
 	if meta.ContentLength == 0 {
-		meta.WriteHeaders(w)
-		writeCacheStatus(w, XCacheHit)
-		w.WriteHeader(meta.StatusCode)
-		metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+		serveMetaHit(w, meta, "GetObject", start)
 		return nil
 	}
 
@@ -334,14 +331,14 @@ func (s *Service) serveFromCache(
 		bodyBuf := bufferPool.Get().(*bytes.Buffer)
 		bodyBuf.Reset()
 
-		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, bodyBuf)
+		bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.BodyDiscriminator(), bodyBuf)
 		if bodyErr == nil && bodyBuf.Len() > 0 {
 			meta.WriteHeaders(w)
 			writeCacheStatus(w, XCacheHit)
 			w.WriteHeader(meta.StatusCode)
 			n, _ := w.Write(bodyBuf.Bytes())
 			metrics.BytesTransferred.WithLabelValues("out").Add(float64(n))
-			metrics.RecordRequest("GetObject", "success", time.Since(start).Seconds())
+			metrics.RecordRequest("GetObject", "success", metrics.SourceLocal, time.Since(start).Seconds())
 			putBuffer(bodyBuf)
 			return nil
 		}
@@ -358,7 +355,7 @@ func (s *Service) serveFromCache(
 	// fallback for an absent or empty body without staging the stream through a
 	// pipe and a second copy.
 	cw := &lazyCommitWriter{w: w, meta: meta}
-	bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.ETag, cw)
+	bodyErr := s.cache.GetBodyStream(ctx, bucket, key, meta.BodyDiscriminator(), cw)
 	status := "success"
 	if bodyErr != nil {
 		if !cw.committed {
@@ -377,7 +374,7 @@ func (s *Service) serveFromCache(
 	}
 
 	metrics.BytesTransferred.WithLabelValues("out").Add(float64(cw.written))
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceLocal, time.Since(start).Seconds())
 	return nil
 }
 
@@ -415,7 +412,7 @@ func (s *Service) handleRevalidation206Range(
 	if copyErr != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("GetObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("GetObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 
 	// Trigger background full-object fetch to repopulate cache
 	if totalSize > 0 &&
@@ -464,6 +461,7 @@ func (s *Service) serveStaleFromCache(
 func (s *Service) revalidateAndServeHead(
 	ctx context.Context,
 	w http.ResponseWriter,
+	r *http.Request,
 	bucket, key, accessKey, secretKey string,
 	meta *cache.CachedObjectMeta,
 	start time.Time,
@@ -486,7 +484,9 @@ func (s *Service) revalidateAndServeHead(
 		copyHeaders(w.Header(), resp.Header)
 		writeCacheStatus(w, XCacheRevalidated)
 		w.WriteHeader(resp.StatusCode)
-		metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+		// The response headers came from upstream's 200 — this is an upstream
+		// answer, unlike the 304 path below that serves the cached metadata.
+		metrics.RecordRequest("HeadObject", "success", metrics.SourceUpstream, time.Since(start).Seconds())
 		return nil
 	}
 
@@ -508,10 +508,14 @@ func (s *Service) revalidateAndServeHead(
 		}
 	}
 
-	meta.WriteHeaders(w)
-	writeCacheStatus(w, XCacheHit)
-	w.WriteHeader(meta.StatusCode)
-	metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+	// The client's own conditionals still apply to the served headers — a
+	// matching If-None-Match is a 304, not a 200 (the same 304-only rule as
+	// the non-revalidate HEAD hit path; the upstream revalidation validated
+	// TAG's cached ETag, not the client's request).
+	if s.writeNotModifiedFromCache(w, r, meta, "HeadObject", start) {
+		return nil
+	}
+	serveMetaHit(w, meta, "HeadObject", start)
 	return nil
 }
 

--- a/proxy/revalidation_test.go
+++ b/proxy/revalidation_test.go
@@ -32,6 +32,7 @@ type mockForwarder struct {
 	doFullObjectFunc func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error)
 	// Optional DoAnonymousFullObjectRequest implementation for anonymous-warm tests
 	doAnonymousFullObjectFunc func(ctx context.Context, bucket, key string) (*http.Response, error)
+	doObjectDeleteFunc        func(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error)
 	// Optional ValidateAndGetCredentials implementation (e.g. to simulate an
 	// anonymous/unvalidated request that yields no credentials).
 	validateFunc func(r *http.Request) (AuthResult, string, string, error)
@@ -70,6 +71,13 @@ func (m *mockForwarder) DoFullObjectRequest(ctx context.Context, bucket, key, ac
 		return m.doFullObjectFunc(ctx, bucket, key, accessKey, secretKey)
 	}
 	return nil, errors.New("mock: DoFullObjectRequest not implemented")
+}
+
+func (m *mockForwarder) DoObjectDeleteRequest(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error) {
+	if m.doObjectDeleteFunc != nil {
+		return m.doObjectDeleteFunc(ctx, bucket, key, etag, accessKey, secretKey)
+	}
+	return nil, errors.New("mock: DoObjectDeleteRequest not implemented")
 }
 
 func (m *mockForwarder) DoAnonymousFullObjectRequest(ctx context.Context, bucket, key string) (*http.Response, error) {
@@ -377,7 +385,7 @@ func TestRevalidateAndServeHead_304(t *testing.T) {
 	_ = c.PutWithMeta(ctx, bucket, key, meta, make([]byte, 100), 0)
 
 	w := httptest.NewRecorder()
-	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	err := svc.revalidateAndServeHead(ctx, w, httptest.NewRequest(http.MethodHead, "/"+bucket+"/"+key, nil), bucket, key, "access", "secret", meta, time.Now())
 	if err != nil {
 		t.Fatalf("revalidateAndServeHead() error = %v", err)
 	}
@@ -422,7 +430,7 @@ func TestRevalidateAndServeHead_200(t *testing.T) {
 	_ = c.PutWithMeta(ctx, bucket, key, meta, make([]byte, 100), 0)
 
 	w := httptest.NewRecorder()
-	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	err := svc.revalidateAndServeHead(ctx, w, httptest.NewRequest(http.MethodHead, "/"+bucket+"/"+key, nil), bucket, key, "access", "secret", meta, time.Now())
 	if err != nil {
 		t.Fatalf("revalidateAndServeHead() error = %v", err)
 	}
@@ -464,7 +472,7 @@ func TestRevalidateAndServeHead_Error_ServesStale(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	err := svc.revalidateAndServeHead(ctx, w, bucket, key, "access", "secret", meta, time.Now())
+	err := svc.revalidateAndServeHead(ctx, w, httptest.NewRequest(http.MethodHead, "/"+bucket+"/"+key, nil), bucket, key, "access", "secret", meta, time.Now())
 	if err != nil {
 		t.Fatalf("revalidateAndServeHead() error = %v", err)
 	}
@@ -823,5 +831,42 @@ func TestRevalidation304_CacheBodyUnavailable_FallsThrough(t *testing.T) {
 	}
 	if w.Body.String() != freshBody {
 		t.Errorf("body = %q, want %q", w.Body.String(), freshBody)
+	}
+}
+
+// A conditional HEAD answered from cache must evaluate the client's
+// conditionals: If-None-Match carrying the cached ETag is a 304, a stale one
+// a 200 — the same RFC 7232 answers the GET hit path and the origin-less
+// engine give from identical metadata. This path used to serve an
+// unconditional 200 header set.
+func TestHeadCacheHit_EvaluatesClientConditionals(t *testing.T) {
+	mock := &mockForwarder{}
+	svc, c := newTestService(mock, true)
+
+	meta := &cache.CachedObjectMeta{
+		Bucket: "b", Key: "k", ETag: `"v1"`, ContentLength: 2, StatusCode: 200,
+	}
+	if err := c.PutWithMeta(context.Background(), "b", "k", meta, []byte("hi"), 60); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodHead, "/b/k", nil)
+	req.Header.Set("If-None-Match", `"v1"`)
+	w := httptest.NewRecorder()
+	if err := svc.HandleHeadObject(w, req); err != nil {
+		t.Fatalf("HEAD: %v", err)
+	}
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("matching If-None-Match HEAD = %d, want 304", w.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodHead, "/b/k", nil)
+	req2.Header.Set("If-None-Match", `"stale"`)
+	w2 := httptest.NewRecorder()
+	if err := svc.HandleHeadObject(w2, req2); err != nil {
+		t.Fatalf("HEAD: %v", err)
+	}
+	if w2.Code != http.StatusOK || w2.Header().Get("ETag") != `"v1"` {
+		t.Fatalf("mismatched If-None-Match HEAD = %d ETag %q, want 200 with the cached ETag", w2.Code, w2.Header().Get("ETag"))
 	}
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -47,6 +47,30 @@ func writeCacheStatus(w http.ResponseWriter, status string) {
 	}
 }
 
+// serveMetaHit commits a metadata-only cache-hit response: the entry's
+// headers, the HIT status, the original status code, and the success metric.
+// The one shape for every "answer from metadata" site — HEADs, marker serves,
+// empty bodies — so a header added to one is added to all.
+func serveMetaHit(w http.ResponseWriter, meta *cache.CachedObjectMeta, operation string, start time.Time) {
+	meta.WriteHeaders(w)
+	writeCacheStatus(w, XCacheHit)
+	w.WriteHeader(meta.StatusCode)
+	metrics.RecordRequest(operation, "success", metrics.SourceLocal, time.Since(start).Seconds())
+}
+
+// answerConditionalsFromMeta evaluates the client's conditional headers
+// against cached metadata in RFC 7232 order — the 412 preconditions
+// (If-Match / If-Unmodified-Since) before the 304 conditionals
+// (If-None-Match / If-Modified-Since) — and writes the response when one
+// decides. Returns true when it wrote; the caller serves normally otherwise.
+func (s *Service) answerConditionalsFromMeta(w http.ResponseWriter, r *http.Request, meta *cache.CachedObjectMeta, operation string, start time.Time) bool {
+	if writePreconditionFailed(w, r, meta) {
+		metrics.RecordRequest(operation, "success", metrics.SourceLocal, time.Since(start).Seconds())
+		return true
+	}
+	return s.writeNotModifiedFromCache(w, r, meta, operation, start)
+}
+
 // cacheMissStatus returns the X-Cache status for a request not served from cache:
 // DISABLED when caching is off, BYPASS when the client opted out (Cache-Control:
 // no-store), otherwise MISS. Only MISS counts as a cache miss.
@@ -66,14 +90,35 @@ type Service struct {
 	forwarder                   RequestForwarder
 	cache                       *cache.Cache
 	config                      *config.Config
-	cacheSemaphore              chan struct{}               // Count ceiling on concurrent cache-populate ops (nil = unlimited)
-	populateBudget              *byteBudget                 // Byte budget bounding all cache buffering — populate + block-serve staging (nil = unlimited)
-	perPopulateCap              int64                       // Max bytes a foreground broadcast populate can buffer
-	backgroundPopulateWriterCap int64                       // Bytes reserved for direct writer buffers before response inspection
-	broadcastManager            *broadcast.Manager          // For streaming request coalescing
-	activeBackgroundFetches     sync.Map                    // Dedup for background full-object fetches (range caching)
-	blockFetchMu                sync.Mutex                  // Guards blockFetches
-	blockFetches                map[string]*blockFetchState // Coalesce block fetches while a detached remote write is pending
+	cacheSemaphore              chan struct{}      // Count ceiling on concurrent cache-populate ops (nil = unlimited)
+	populateBudget              *byteBudget        // Byte budget bounding all cache buffering — populate + block-serve staging (nil = unlimited)
+	perPopulateCap              int64              // Max bytes a foreground broadcast populate can buffer
+	backgroundPopulateWriterCap int64              // Bytes reserved for direct writer buffers before response inspection
+	broadcastManager            *broadcast.Manager // For streaming request coalescing
+	activeBackgroundFetches     sync.Map           // Dedup for background full-object fetches (range caching)
+	// retier coordinates tiered-mode re-tier-on-read populates with writes:
+	// claims[key] counts PUTs in flight (a claim cancels and excludes re-tiers
+	// for the key), inflight[key] is the running re-tier's cancel func. One
+	// mutex serializes claim/registration, so the PUT-vs-re-tier handshake is
+	// ordering-free: a re-tier either registers before the claim (and is
+	// canceled by it) or sees the claim and refuses to start.
+	retierMu       sync.Mutex
+	retierClaims   map[string]int
+	retierInflight map[string]context.CancelFunc
+	// retierRecentMismatch backs off re-tier attempts for a marker version
+	// whose upstream fetch came back changed or gone: without it a marker
+	// that is persistently stale versus the upstream object re-downloads and
+	// discards the full body on EVERY validated GET for the marker's TTL.
+	retierRecentMismatch *expirable.LRU[string, struct{}]
+	// enginePutSlots bounds concurrent local-store engine PUTs, SEPARATE
+	// from cacheSemaphore: engine PUTs are client-paced (a trickle upload
+	// holds its slot for the transfer's whole duration), and before this
+	// split 256 slow large uploads could pin every shared cache-write slot,
+	// shedding all read-miss populates and collapsing the hit rate. Same
+	// size as the shared pool — the point is isolation, not a lower count.
+	enginePutSlots chan struct{}
+	blockFetchMu   sync.Mutex                  // Guards blockFetches
+	blockFetches   map[string]*blockFetchState // Coalesce block fetches while a detached remote write is pending
 	// recentFooterWork suppresses repeat footer scans for an object version that was
 	// already examined. Without it every tail read of a fully-warmed object re-probes
 	// its metadata blocks, which in cluster mode are mostly remote.
@@ -99,6 +144,10 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 	var cacheSem chan struct{}
 	if cfg.Cache.MaxConcurrentWrites > 0 {
 		cacheSem = make(chan struct{}, cfg.Cache.MaxConcurrentWrites)
+	}
+	var enginePutSlots chan struct{}
+	if cfg.IsTiered() && cfg.Cache.MaxConcurrentWrites > 0 {
+		enginePutSlots = make(chan struct{}, cfg.Cache.MaxConcurrentWrites)
 	}
 
 	perPopulateCap := perPopulateBufferBytes(cfg)
@@ -157,15 +206,21 @@ func NewService(forwarder RequestForwarder, cache *cache.Cache, cfg *config.Conf
 		cache:                       cache,
 		config:                      cfg,
 		cacheSemaphore:              cacheSem,
+		enginePutSlots:              enginePutSlots,
 		populateBudget:              populateBudget,
 		perPopulateCap:              perPopulateCap,
 		backgroundPopulateWriterCap: backgroundPopulateWriterCap,
 		broadcastManager:            broadcast.NewManager(channelBuf),
 		blockFetches:                make(map[string]*blockFetchState),
+		retierClaims:                make(map[string]int),
+		retierInflight:              make(map[string]context.CancelFunc),
 	}
 	// Allocated only when the feature that uses it is on.
 	if cfg.Cache.ParquetOptimization {
 		svc.recentFooterWork = expirable.NewLRU[string, struct{}](maxFooterWorkTracking, nil, footerWorkCooldown)
+	}
+	if cfg.IsTiered() {
+		svc.retierRecentMismatch = expirable.NewLRU[string, struct{}](maxRetierMismatchTracking, nil, retierMismatchCooldown)
 	}
 	return svc
 }
@@ -512,6 +567,36 @@ func (s *Service) tryAcquireCacheBytes(weight int64, prio populatePriority) bool
 	return s.populateBudget.tryAcquireReadMiss(weight)
 }
 
+// acquireEnginePutSlot admits one local-store engine PUT: a slot from the
+// engine's OWN pool (never the shared populate semaphore — see the field
+// comment) plus the fixed streaming weight against the byte budget.
+// Non-blocking: a client-facing PUT sheds with a retryable SlowDown.
+func (s *Service) acquireEnginePutSlot(ctx context.Context, weight int64) bool {
+	if s.enginePutSlots != nil {
+		select {
+		case s.enginePutSlots <- struct{}{}:
+		default:
+			return false
+		}
+	}
+	if !s.acquireCacheBytes(ctx, weight, priorityReadMiss) {
+		if s.enginePutSlots != nil {
+			<-s.enginePutSlots
+		}
+		return false
+	}
+	return true
+}
+
+func (s *Service) releaseEnginePutSlot(weight int64) {
+	if s.populateBudget != nil {
+		s.populateBudget.release(weight)
+	}
+	if s.enginePutSlots != nil {
+		<-s.enginePutSlots
+	}
+}
+
 // acquireCacheSlot tries to reserve a cache-populate slot without blocking,
 // reserving `weight` bytes against the memory budget. It returns true (and must be
 // paired with releaseCacheSlot passing the SAME weight) when both the count slot
@@ -612,14 +697,21 @@ func (rec *statusRecorder) wroteSuccess() bool {
 // HandlePutObject handles PUT requests for objects.
 // Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error {
+	if s.config.IsTiered() {
+		return s.handleTieredPut(w, r)
+	}
 	start := time.Now()
 	bucket, key := ParseBucketKey(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandlePutObject")
 
-	// Invalidate cache BEFORE forwarding to ensure consistency
-	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
-	s.invalidateObject(context.Background(), bucket, key)
+	// Invalidate cache BEFORE forwarding to ensure consistency: it prevents
+	// stale data from being served if forwarding succeeds but cache
+	// invalidation fails. Proxy modes only — see preForwardInvalidate; in
+	// tiered mode the key may hold a local-tier only-copy or a live marker
+	// that a rejected forward must leave intact (tiered relies on the
+	// post-success invalidation below).
+	s.preForwardInvalidate(context.Background(), bucket, key)
 
 	// Forward to Tigris, recording the upstream status. When eligible, forwardPutMaybeTee
 	// tees the decoded body so we can populate the cache directly (write-through) instead of
@@ -639,7 +731,7 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	// Routed through invalidateObject (like the pre-forward call) so a failure of this
 	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
-		s.invalidateObject(context.Background(), bucket, key)
+		s.convergeInvalidation(context.Background(), bucket, key)
 		teeHandled := requestRejectsCache
 		if teed != nil {
 			// writeThroughCache takes ownership of the reserved populate budget.
@@ -663,7 +755,7 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("PutObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("PutObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 
 	return err
 }
@@ -671,14 +763,52 @@ func (s *Service) HandlePutObject(w http.ResponseWriter, r *http.Request) error 
 // HandleDeleteObject handles DELETE requests for objects.
 // Invalidates cache BEFORE forwarding to ensure consistency.
 func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) error {
+	// Tiered mode: a local-tier object is deleted without touching upstream.
+	// Anything else (upstream tier, no metadata, unvalidated caller) falls
+	// through to the ordinary invalidate-and-forward below, which also clears
+	// the local metadata marker.
+	if s.config.IsTiered() {
+		// Claim the key for the DELETE's whole duration, exactly as a PUT
+		// does: a re-tier heals the object being deleted, and its commit
+		// rides a context this cancels — so an in-flight heal cannot
+		// resurrect the object after the version-guarded converge (which
+		// only removes the pre-forward version) declines to out-delete the
+		// heal's newer commit. New re-tiers are excluded until release.
+		bucket, key := ParseBucketKey(r)
+		s.claimRetierWrite(bucket, key)
+		defer s.releaseRetierWrite(bucket, key)
+		if handled, err := s.handleTieredDeleteLocal(w, r); handled {
+			return err
+		}
+	}
 	start := time.Now()
 	bucket, key := ParseBucketKey(r)
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleDeleteObject")
 
-	// Invalidate cache BEFORE forwarding to ensure consistency
-	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
-	s.invalidateObject(context.Background(), bucket, key)
+	// Invalidate cache BEFORE forwarding to ensure consistency: it prevents
+	// stale data from being served if forwarding succeeds but cache
+	// invalidation fails. Proxy modes only — see preForwardInvalidate; in
+	// tiered mode the key may hold a local-tier only-copy or a live marker
+	// that a rejected forward must leave intact (tiered relies on the
+	// post-success converge below).
+	s.preForwardInvalidate(context.Background(), bucket, key)
+
+	// Tiered: the post-success converge must be ORDERED. The unconditional
+	// coordinator delete deliberately out-deletes racing writers — correct
+	// for a proxy cache, but here a small PUT acked during the forward is
+	// the local tier's only copy, and out-deleting it is data loss. Capture
+	// the pre-forward token; the converge below removes exactly the state
+	// this DELETE displaced, and anything newer keeps the key.
+	var (
+		delPrior      *cache.CachedObjectMeta
+		delPriorVer   uint64
+		delPriorKnown bool
+	)
+	if s.config.IsTiered() {
+		delPrior, delPriorVer, delPriorKnown = s.captureMarkerPrior(r.Context(), bucket, key)
+		_ = delPrior
+	}
 
 	// Forward to upstream, recording the upstream status.
 	rec := &statusRecorder{ResponseWriter: w}
@@ -690,17 +820,19 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 	// fence bump blocks that stale repopulation.
 	// Gated on a 2xx: a rejected DELETE leaves the object present, so re-invalidating
 	// would only discard a valid racing refill and cause an unnecessary later miss.
-	// Routed through invalidateObject (like the pre-forward call) so a failure of this
-	// read-after-write-critical invalidation is recorded and logged, not discarded.
 	if err == nil && rec.wroteSuccess() && s.cache.IsEnabled() {
-		s.invalidateObject(context.Background(), bucket, key)
+		if s.config.IsTiered() {
+			s.convergeTieredDelete(bucket, key, delPriorVer, delPriorKnown)
+		} else {
+			s.convergeInvalidation(context.Background(), bucket, key)
+		}
 	}
 
 	status := "success"
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("DeleteObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("DeleteObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 
 	return err
 }
@@ -709,6 +841,9 @@ func (s *Service) HandleDeleteObject(w http.ResponseWriter, r *http.Request) err
 // Serves from cached metadata when available (no body fetch needed).
 // Supports cache revalidation via Cache-Control: no-cache/max-age=0.
 func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error {
+	if s.config.IsTiered() {
+		return s.handleTieredObject(w, r)
+	}
 	start := time.Now()
 	ctx := r.Context()
 	bucket, key := ParseBucketKey(r)
@@ -720,7 +855,7 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 	// Validate credentials before serving from cache
 	result, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
 	if err != nil {
-		metrics.RecordRequest("HeadObject", "auth_error", time.Since(start).Seconds())
+		metrics.RecordRequest("HeadObject", "auth_error", metrics.SourceLocal, time.Since(start).Seconds())
 		return err
 	}
 
@@ -739,15 +874,23 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 			// Client-triggered revalidation: Cache-Control: no-cache/max-age=0
 			if forceRevalidate && meta.ETag != "" {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD cache hit requires revalidation (client-triggered)")
-				return s.revalidateAndServeHead(ctx, w, bucket, key, accessKey, secretKey, meta, start)
+				return s.revalidateAndServeHead(ctx, w, r, bucket, key, accessKey, secretKey, meta, start)
 			}
 
 			if !forceRevalidate {
 				log.Debug().Str("bucket", bucket).Str("key", key).Msg("HEAD served from cache")
-				meta.WriteHeaders(w)
-				writeCacheStatus(w, XCacheHit)
-				w.WriteHeader(meta.StatusCode)
-				metrics.RecordRequest("HeadObject", "success", time.Since(start).Seconds())
+				// 304 conditionals only, exactly like the proxy GET hit path
+				// (writeNotModifiedFromCache): the 412 PRECONDITIONS
+				// (If-Match/If-Unmodified-Since) are origin-state questions
+				// RFC 9110 forbids answering from a possibly-stale cached
+				// response — a mixed-writer overwrite would make TAG return a
+				// hard 412 for an object whose live version matches. Those
+				// belong only where TAG is authoritative (tiered/origin-less),
+				// via answerConditionalsFromMeta.
+				if s.writeNotModifiedFromCache(w, r, meta, "HeadObject", start) {
+					return nil
+				}
+				serveMetaHit(w, meta, "HeadObject", start)
 				return nil
 			}
 			// forceRevalidate but no ETag — fall through to upstream
@@ -769,7 +912,7 @@ func (s *Service) HandleHeadObject(w http.ResponseWriter, r *http.Request) error
 	if err != nil {
 		status = "error"
 	}
-	metrics.RecordRequest("HeadObject", status, time.Since(start).Seconds())
+	metrics.RecordRequest("HeadObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
 	return err
 }
 
@@ -780,10 +923,13 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 
 	log.Debug().Str("bucket", bucket).Str("key", key).Msg("HandleCopyObject")
 
-	// Invalidate cache for destination object BEFORE forwarding to ensure consistency
-	// This prevents stale data from being served if forwarding succeeds but cache invalidation fails
+	// Invalidate cache for destination object BEFORE forwarding to ensure
+	// consistency: it prevents stale data from being served if forwarding
+	// succeeds but cache invalidation fails. Proxy modes only — see
+	// preForwardInvalidate; in tiered mode the destination may be a
+	// local-tier only-copy that a failed copy must leave intact.
 	if s.cache.IsEnabled() {
-		s.invalidateObject(context.Background(), bucket, key)
+		s.preForwardInvalidate(context.Background(), bucket, key)
 	}
 
 	// Forward to upstream, capturing the response so we can confirm the copy
@@ -799,7 +945,7 @@ func (s *Service) HandleCopyObject(w http.ResponseWriter, r *http.Request) error
 	// Gated on a confirmed-successful copy: a rejected copy leaves the destination
 	// unchanged, so re-invalidating would only discard a valid racing refill.
 	if err == nil && s3WriteSucceeded(capture) && s.cache.IsEnabled() {
-		s.invalidateObject(context.Background(), bucket, key)
+		s.convergeInvalidation(context.Background(), bucket, key)
 		s.warmOnWrite(r, bucket, key)
 		s.warmParquetFooterOnWrite(r, bucket, key)
 	}
@@ -832,25 +978,88 @@ func s3WriteSucceeded(capture *ResponseCapture) bool {
 // as an error rather than success: a false-green delete metric would hide the very
 // read-after-write hazard the invalidation exists to prevent, since the stale entry
 // is still in place. It is a no-op when the cache is disabled.
-func (s *Service) invalidateObject(ctx context.Context, bucket, key string) {
-	if !s.cache.IsEnabled() {
+// The error return matters only to origin-less callers, where the cache is the
+// only store and an acked-but-failed delete keeps serving until TTL. Proxy-mode
+// callers ignore it: there the origin is authoritative and the upstream DELETE
+// already succeeded, so a failed local invalidation is a stale-cache blip.
+// preForwardInvalidate is the proxy-mode "invalidate BEFORE forwarding"
+// consistency step, shared by the mutating handlers (DELETE, CopyObject,
+// CompleteMultipartUpload, bulk DeleteObjects). In proxy mode dropping a
+// cache entry is always safe, and doing it up front means a forward that
+// succeeds but whose post-invalidation fails cannot leave stale data served.
+// In TIERED mode it is the opposite of safe: the cache is authoritative and a
+// local-tier entry is the ONLY copy, so destroying it before upstream has
+// authorized and confirmed the operation turns a rejected request into data
+// loss (and drops a live marker on a failed upstream-tier op). Tiered relies
+// solely on the post-success invalidation these handlers already perform.
+// convergeInvalidation is the POST-SUCCESS invalidation of the mutating
+// handlers. By the time it runs the client already holds its 2xx, and in
+// tiered mode it is the ONLY invalidation (preForwardInvalidate is a no-op
+// there), so a transient failure leaves a deleted or overwritten local-tier
+// object — or a stale marker — serving authoritatively until TTL with no
+// retry signal. One immediate retry absorbs the transient class cheaply; a
+// repeat failure stays visible as tag_cache_operations_total{operation=
+// "delete",result="error"} (the dashboard's invalidation-errors panel),
+// since the acked response cannot be recalled.
+func (s *Service) convergeInvalidation(ctx context.Context, bucket, key string) {
+	if s.invalidateObject(ctx, bucket, key) == nil {
 		return
+	}
+	_ = s.invalidateObject(ctx, bucket, key)
+}
+
+// convergeTieredDelete is the tiered post-success invalidation for the
+// forwarded DELETE paths: it removes exactly the state the DELETE displaced
+// (the pre-forward token), so a small PUT acked during the forward — the
+// local tier's only copy — is never out-deleted the way the proxy-mode
+// unconditional converge deliberately does. A refused removal means a newer
+// write owns the key, which is the correct outcome. With the prior unknown
+// (its read failed) nothing is removed: the possibly-stale marker serves
+// until TTL — an availability inconsistency, chosen over unguarded deletion
+// in the mode where the cache is the store.
+func (s *Service) convergeTieredDelete(bucket, key string, priorVersion uint64, priorKnown bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if !priorKnown {
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Tiered DELETE converge skipped - prior unknown; possibly-stale metadata serves until TTL")
+		return
+	}
+	if _, err := s.cache.DeleteMetaIfVersion(ctx, bucket, key, priorVersion); err != nil {
+		metrics.RecordCacheOperation("delete", "error")
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Tiered DELETE converge failed; stale metadata may serve until TTL")
+		return
+	}
+	metrics.RecordCacheOperation("delete", "success")
+}
+
+func (s *Service) preForwardInvalidate(ctx context.Context, bucket, key string) {
+	if s.config.IsTiered() {
+		return
+	}
+	s.invalidateObject(ctx, bucket, key)
+}
+
+func (s *Service) invalidateObject(ctx context.Context, bucket, key string) error {
+
+	if !s.cache.IsEnabled() {
+		return nil
 	}
 	if err := s.cache.Delete(ctx, bucket, key); err != nil {
 		metrics.RecordCacheOperation("delete", "error")
 		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cache invalidation failed")
-		return
+		return err
 	}
 	metrics.RecordCacheOperation("delete", "success")
+	return nil
 }
 
 // warmOnWrite repopulates the cache after a successful write by triggering a
 // background full-object fetch, so a read soon after the write hits cache
 // (cache-warm-on-write; see cache.warm_on_write). It is best-effort and fully
 // detached: triggerBackgroundCacheFetch deduplicates concurrent warms, sheds under
-// the populate byte budget, and stamps its own writeStartTime before the GET so an
-// invalidation racing the warm is provably newer and blocks it. Safe to call on
-// every successful write.
+// the populate byte budget, and reads its own decision-time token before the GET
+// so an invalidation racing the warm refuses the commit. Safe to call on every
+// successful write.
 //
 // Credentials and public-read handling depend on how the write was authenticated,
 // because a write proves nothing about who may READ the object:
@@ -879,6 +1088,14 @@ func (s *Service) invalidateObject(ctx context.Context, bucket, key string) {
 // populate is the read-after-write guard.
 func (s *Service) warmOnWrite(r *http.Request, bucket, key string) {
 	if !s.config.Cache.WarmOnWrite || !s.cache.IsEnabled() {
+		return
+	}
+	// Never in tiered mode: a warm is a populate with none of tiered's guards
+	// (no write claim, no tier decision), and it would establish a local-tier
+	// entry for an object the mode documents as read-as-miss (copies,
+	// multipart completions). The re-tier is tiered's one read-triggered
+	// populate.
+	if s.config.IsTiered() {
 		return
 	}
 
@@ -958,7 +1175,32 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 	// upload overwrites the object, so any previously cached version is now stale;
 	// like PutObject/DeleteObject/CopyObject, invalidate up front so a forward that
 	// succeeds but whose post-invalidation fails can't leave stale data served.
-	s.invalidateObject(context.Background(), bucket, key)
+	// Proxy modes only — see preForwardInvalidate; in tiered mode the key may
+	// hold a local-tier only-copy that a failed completion must leave intact.
+	s.preForwardInvalidate(context.Background(), bucket, key)
+
+	// Tiered: the completed object assembles UPSTREAM, so on success it gets a
+	// BodyUpstream marker — like a large PUT — instead of the old read-as-miss
+	// punt. Same discipline as handleTieredPut: the key is claimed for the
+	// handler's duration (cancels and excludes re-tiers), and the prior + its
+	// decision token are captured BEFORE the forward so the marker commit is
+	// ordered against anything racing the completion. Credentials (when the
+	// request validates) let the marker be built from an upstream HEAD with a
+	// real Content-Length.
+	var (
+		mpPrior      *cache.CachedObjectMeta
+		mpPriorVer   uint64
+		mpPriorKnown bool
+		mpAK, mpSK   string
+	)
+	if s.config.IsTiered() {
+		s.claimRetierWrite(bucket, key)
+		defer s.releaseRetierWrite(bucket, key)
+		mpPrior, mpPriorVer, mpPriorKnown = s.captureMarkerPrior(ctx, bucket, key)
+		if result, ak, sk, aerr := s.forwarder.ValidateAndGetCredentials(r); aerr == nil && result == AuthValidated {
+			mpAK, mpSK = ak, sk
+		}
+	}
 
 	// Forward to upstream with response capture
 	capture, err := s.forwarder.ForwardWithCapture(ctx, w, r)
@@ -974,17 +1216,25 @@ func (s *Service) HandleCompleteMultipartUpload(w http.ResponseWriter, r *http.R
 	// object unchanged, doesn't discard a valid racing refill.
 	completed := s3WriteSucceeded(capture)
 	if completed && s.cache.IsEnabled() {
-		s.invalidateObject(context.Background(), bucket, key)
-		// Warm-on-write is the only way to make a multipart-completed object hot:
-		// TAG never sees its assembled body, so a write-through tee is impossible.
-		s.warmOnWrite(r, bucket, key)
-		// The path that matters for parquet: ingestors write via multipart, so this
-		// is where a freshly written file's metadata gets warmed (RFC 0002).
-		s.warmParquetFooterOnWrite(r, bucket, key)
-		// Prototype: establish the metadata entry so the first read does not pay an
-		// upstream round trip to discover it. Multipart is the gap — write-through
-		// cannot tee a body TAG never sees.
-		s.cacheBlockMetaOnWrite(r, bucket, key, completedMultipartETag(capture))
+		if s.config.IsTiered() {
+			// The marker IS the post-completion cache state: stamping it under
+			// the pre-forward token replaces the proxy-mode invalidate (which
+			// would bump the version and refuse the marker), and the object is
+			// immediately readable — HEAD from the marker, GET forwarded.
+			s.stampUpstreamMarkerAfterCompletion(bucket, key, completedMultipartETag(capture), mpAK, mpSK, mpPrior, mpPriorVer, mpPriorKnown)
+		} else {
+			s.convergeInvalidation(context.Background(), bucket, key)
+			// Warm-on-write is the only way to make a multipart-completed object hot:
+			// TAG never sees its assembled body, so a write-through tee is impossible.
+			s.warmOnWrite(r, bucket, key)
+			// The path that matters for parquet: ingestors write via multipart, so this
+			// is where a freshly written file's metadata gets warmed (RFC 0002).
+			s.warmParquetFooterOnWrite(r, bucket, key)
+			// Prototype: establish the metadata entry so the first read does not pay an
+			// upstream round trip to discover it. Multipart is the gap — write-through
+			// cannot tee a body TAG never sees.
+			s.cacheBlockMetaOnWrite(r, bucket, key, completedMultipartETag(capture))
+		}
 	}
 
 	// Cache successful completions in ocache for idempotent replays. Only cache a

--- a/proxy/tiered.go
+++ b/proxy/tiered.go
@@ -1,0 +1,922 @@
+package proxy
+
+// Tiered store mode (issue #201): TAG in front of an upstream that is a cheap,
+// capacity-priced store — a cache bucket — rather than the system of record.
+//
+// The metadata for EVERY object TAG holds lives locally, stamped with the tier
+// its body lives in (BodyUpstream). That makes the local metadata authoritative
+// for existence: a metadata miss answers NoSuchKey without touching upstream,
+// in both tiers — TAG is a cache, and "not cached" is a complete answer. The
+// caller treats it as its cue to fall back to the system of record and
+// re-populate by writing back through TAG.
+//
+// Small objects (declared size ≤ cache.size_threshold) are the LOCAL tier:
+// stored whole by the local-store engine (localstore.go), served and deleted
+// without any upstream request — reads of cached objects cost zero upstream
+// rate limit and zero upstream writes. Large objects are the UPSTREAM tier:
+// the PUT passes through, a metadata marker is stored locally, HEADs answer
+// from the marker, and a GET body forward is the mode's only body traffic.
+//
+// The tier boundary is enforced on reads as well as writes: a validated GET
+// that hits an upstream-tier marker whose size fits the local tier triggers a
+// one-shot background re-tier (maybeRetierOnRead), healing objects that were
+// mis-placed — e.g. a small PUT forwarded before its key was learned. Damage
+// from mis-placement is thereby capped at one extra upstream fetch per object
+// instead of one body forward per read until TTL.
+//
+// Cross-tier overwrites clean up the displaced version: a small write over an
+// upstream-tier object deletes the upstream copy asynchronously; a large write
+// over a local-tier object frees the local copy via the ordinary
+// invalidate-before-forward. No prior metadata means nothing is cached — there
+// is nothing to clean.
+//
+// Authentication is the transparent-proxy flow, unchanged: tiered semantics
+// apply only to requests whose signature TAG validated locally. A request it
+// cannot validate (unknown key, anonymous) forwards to upstream — the auth
+// authority — exactly as in transparent mode; keys are learned from those
+// responses, and the window before learning behaves like a cache miss.
+//
+// Deliberately NOT reimplemented here (v1): listings, multipart transfers,
+// copies, tagging, ACLs all pass through to upstream. A multipart COMPLETION
+// does stamp a BodyUpstream marker (the assembled object is upstream-tier by
+// construction — see HandleCompleteMultipartUpload), so multipart-written
+// objects exist in the authoritative view; objects created upstream without
+// any marker-stamping op (a server-side copy) still read as misses through
+// TAG until written again.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/metrics"
+)
+
+// tieredCleanupTimeout bounds the background cross-tier DELETE.
+const tieredCleanupTimeout = 30 * time.Second
+
+// forwardStatus maps a Forward result to the request-metric status label.
+func forwardStatus(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "success"
+}
+
+// handleTieredObject serves GET and HEAD in tiered mode.
+func (s *Service) handleTieredObject(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+
+	operation := "GetObject"
+	if r.Method == http.MethodHead {
+		operation = "HeadObject"
+	}
+
+	result, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil {
+		metrics.RecordRequest(operation, "auth_error", metrics.SourceLocal, time.Since(start).Seconds())
+		return err
+	}
+	if result != AuthValidated {
+		// Unvalidated requests forward to upstream (the auth authority) — an
+		// upstream-sourced response, recorded like every sibling path so the
+		// mode's traffic is visible in tag_requests_total.
+		ferr := s.forwarder.Forward(ctx, w, r)
+		metrics.RecordRequest(operation, forwardStatus(ferr), metrics.SourceUpstream, time.Since(start).Seconds())
+		return ferr
+	}
+
+	meta, metaVersion, found, cacheErr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+	if cacheErr != nil {
+		// A transient metadata failure is not absence. The miss below is
+		// authoritative — served for an existing object it would make the caller
+		// drop its cached copy — so this must surface as a retryable error.
+		metrics.RecordRequest(operation, "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return cacheErr
+	}
+	if found && meta != nil && meta.BodyUpstream {
+		// Upstream tier: the local metadata answers everything except a GET body.
+		if r.Method == http.MethodHead && originlessPlainObject(r) {
+			// Same conditional-then-serve shape as the engine's HEAD path,
+			// minus its servability probe: a marker has no local body to
+			// probe, and the metadata alone is the authoritative answer.
+			if s.answerConditionalsFromMeta(w, r, meta, operation, start) {
+				return nil
+			}
+			serveMetaHit(w, meta, operation, start)
+			return nil
+		}
+		// The mode's one body forward. The forward itself never populates;
+		// a mis-tiered small object is healed by the background re-tier, which
+		// carries its own guards (see maybeRetierOnRead).
+		// Plain-object GETs only: a sub-resource GET (?tagging, ?acl, …)
+		// forwards through this branch too, and healing on it would launch a
+		// full-body download the triggering request never serves.
+		if r.Method == http.MethodGet && originlessPlainObject(r) {
+			s.maybeRetierOnRead(bucket, key, accessKey, secretKey, meta)
+		}
+		// The mode's principal body traffic — record it (upstream-sourced),
+		// or a forward-heavy tiered node reads as ~100% local.
+		ferr := s.forwarder.Forward(ctx, w, r)
+		metrics.RecordRequest(operation, forwardStatus(ferr), metrics.SourceUpstream, time.Since(start).Seconds())
+		return ferr
+	}
+
+	// Local tier, or no metadata at all: the engine serves it, and its miss is
+	// the authoritative NoSuchKey. The metadata read ABOVE — the one the tier
+	// decision was made from — is threaded through: a second read here could
+	// see a large PUT's marker committed in between and mint a false
+	// authoritative miss from a mid-overwrite snapshot.
+	if !originlessPlainObject(r) {
+		return s.HandleOriginlessUnsupported(w, r)
+	}
+	if !found {
+		meta = nil
+	}
+	return s.serveOriginlessObject(w, r, operation, start, meta, metaVersion)
+}
+
+// handleTieredPut routes a PUT to its tier by declared size.
+func (s *Service) handleTieredPut(w http.ResponseWriter, r *http.Request) error {
+	start := time.Now()
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+
+	// A write claims the key for its whole duration: any in-flight re-tier is
+	// canceled and no new one can start until the claim is released (see
+	// maybeRetierOnRead's guards).
+	s.claimRetierWrite(bucket, key)
+	defer s.releaseRetierWrite(bucket, key)
+
+	result, accessKey, secretKey, err := s.forwarder.ValidateAndGetCredentials(r)
+	if err != nil {
+		metrics.RecordRequest("PutObject", "auth_error", metrics.SourceLocal, time.Since(start).Seconds())
+		return err
+	}
+
+	declaredSize, sized := originlessPutSize(r)
+
+	// Local-tier eligibility, before any metadata lookup: a validated caller
+	// (the engine serves from cache with no upstream auth check), a plain
+	// object PUT, and a declared size within the threshold. Everything else
+	// forwards and never needs the prior version — a metadata failure must not
+	// block a PUT that goes upstream anyway (including the unknown-key writes
+	// that bootstrap credential learning).
+	if result == AuthValidated && originlessPlainObject(r) && sized && declaredSize <= s.config.Cache.SizeThreshold {
+		// The prior version's tier decides what an overwrite must clean up and
+		// where a conditional write is evaluated, so a failed lookup cannot be
+		// read as "no prior". Fail retryably instead.
+		priorMeta, priorVersion, found, cacheErr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+		if cacheErr != nil {
+			metrics.RecordRequest("PutObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+			return cacheErr
+		}
+		var prior *cache.CachedObjectMeta
+		if found {
+			prior = priorMeta
+		}
+		conditional := r.Header.Get("If-Match") != "" || r.Header.Get("If-None-Match") != ""
+
+		// A conditional write against an upstream-tier prior forwards: the
+		// engine can only evaluate preconditions against a local body, and
+		// upstream owns that object's version.
+		if !(conditional && prior != nil && prior.BodyUpstream) {
+			rec := &statusRecorder{ResponseWriter: w}
+			// Thread the SAME snapshot into the engine: the tier decision
+			// above and the engine's precondition/token now share one read,
+			// so a marker committing in between cannot make them disagree.
+			err := s.handleOriginlessPut(rec, r, &putPrior{meta: priorMeta, version: priorVersion, found: found})
+			if err == nil && rec.wroteSuccess() && prior != nil && prior.BodyUpstream {
+				// Small write displaced an upstream-tier version: remove the
+				// upstream copy so it doesn't linger as an orphan. Bound to the
+				// displaced ETag so it can never remove a newer object that a
+				// concurrent large write put in its place.
+				s.deleteUpstreamObjectAsync(bucket, key, prior.ETag, accessKey, secretKey)
+			}
+			return err
+		}
+	}
+
+	// Upstream tier: pass the PUT through, then stamp the local metadata marker
+	// that makes this object exist in TAG's authoritative view.
+	//
+	// No pre-forward invalidation, unlike HandlePutObject: for a local-tier
+	// prior the cache holds the ONLY copy, and a failed forward must leave it
+	// intact — S3 semantics say a rejected PUT changes nothing. Reads racing
+	// the in-flight PUT serve the prior version, which is the atomic-replace
+	// behavior clients expect. The one read-triggered populate in this mode —
+	// the re-tier — cannot be ordered against this path's writes here (it
+	// performs none pre-forward); it defends itself with a claim plus its own
+	// pre-fetch decision token instead (see maybeRetierOnRead).
+	// No post-success invalidation either: the marker overwrites the prior
+	// metadata directly (a displaced local body ages out by TTL, the engine's
+	// own overwrite semantics), which lets the marker commit under the
+	// PRE-FORWARD decision token — see putUpstreamMarker for why that closes
+	// the concurrent-DELETE resurrection race.
+	// Capture the displaced prior before forwarding — tolerated, never blocking:
+	// it only arms the identity guard of the failure sweep in putUpstreamMarker.
+	// A failed lookup leaves the prior unknown, and the sweep then refuses to
+	// delete anything rather than guess.
+	// Only a PLAIN object PUT writes the object and therefore owns the marker.
+	// A sub-resource PUT with no dedicated route (?retention, ?legal-hold, …)
+	// reaches this path too, but it does not create a new object version: it
+	// must forward untouched — stamping a marker from its request headers
+	// would replace the real metadata with the sub-resource call's shape, and
+	// a 2xx response without an ETag would sweep the object's live metadata
+	// into an authoritative miss.
+	markerOwning := originlessPlainObject(r)
+
+	var prior *cache.CachedObjectMeta
+	var priorVersion uint64
+	priorKnown := false
+	if markerOwning {
+		prior, priorVersion, priorKnown = s.captureMarkerPrior(ctx, bucket, key)
+	}
+
+	rec := &statusRecorder{ResponseWriter: w}
+	err = s.forwarder.Forward(ctx, rec, r)
+
+	if err == nil && rec.wroteSuccess() && markerOwning && s.cache.IsEnabled() {
+		s.putUpstreamMarker(r, w.Header().Get("ETag"), bucket, key, prior, priorVersion, priorKnown)
+	}
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.RecordRequest("PutObject", status, metrics.SourceUpstream, time.Since(start).Seconds())
+	return err
+}
+
+// putUpstreamMarker stores the metadata-only entry for an object whose body
+// was just written upstream, replacing whatever metadata the displaced version
+// left. Headers come from the PUT request (the same mapping as every populate
+// path); the ETag comes from upstream's response.
+//
+// The store's expectation is the PRE-FORWARD decision token (read before the
+// forward began). Any DELETE that runs concurrently with — or after — this
+// PUT enters the store after that token, so the versioned write refuses the
+// marker and a deleted object can never be resurrected as metadata. The
+// forward path performs no meta writes of its own between the token read and
+// here, so only a genuine racer can suppress the marker.
+//
+// When the marker cannot be established (no response ETag, store failure, or
+// tombstone suppression), the entry converges on an authoritative miss via
+// invalidateDisplacedTieredMeta: the displaced prior is invalidated so a
+// stale version cannot keep serving, while a newer write that raced in keeps
+// the key. The client's 200 stands (the object IS stored upstream), and the
+// caller's ordinary miss handling re-populates on the next read. Failures log
+// at Warn (flood-safe: only successful 2xx PUTs reach here).
+// captureMarkerPrior reads the displaced prior and its decision-time token
+// BEFORE a marker-stamping forward (large PUT, multipart completion). A
+// failed lookup leaves the prior unknown — the marker is then not written and
+// the sweep refuses to delete anything rather than guess (see
+// commitUpstreamMarker). Tolerated, never blocking.
+func (s *Service) captureMarkerPrior(ctx context.Context, bucket, key string) (prior *cache.CachedObjectMeta, priorVersion uint64, priorKnown bool) {
+	if !s.cache.IsEnabled() {
+		return nil, 0, false
+	}
+	if m, version, found, cacheErr := s.cache.GetMetaWithVersion(ctx, bucket, key); cacheErr == nil {
+		priorKnown = true
+		priorVersion = version
+		if found {
+			prior = m
+		}
+	}
+	return prior, priorVersion, priorKnown
+}
+
+func (s *Service) putUpstreamMarker(r *http.Request, etag, bucket, key string, prior *cache.CachedObjectMeta, priorVersion uint64, priorKnown bool) {
+	if etag == "" {
+		s.invalidateDisplacedTieredMeta(bucket, key, prior, priorVersion, priorKnown)
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Upstream PUT response had no ETag - no tier marker; object reads as a miss until re-put")
+		return
+	}
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, r.Header)
+	meta.ETag = etag
+	meta.BodyUpstream = true
+	meta.LastModified = time.Now().Unix()
+	if declaredSize, ok := originlessPutSize(r); ok {
+		meta.ContentLength = declaredSize
+	} else {
+		// No decoded size declared (a streaming-signed PUT without
+		// X-Amz-Decoded-Content-Length): MetaFromHTTPHeaders copied the
+		// request's WIRE Content-Length, which counts aws-chunked framing.
+		// Advertising it would misreport HEADs, and an inflated-but-under-
+		// threshold value would send every validated GET into a re-tier whose
+		// fetch can never match the length. Unknown is the honest value; the
+		// re-tier skips unknown-length markers.
+		meta.ContentLength = -1
+	}
+	// Mirror the engine's PUT: upstream stores the decoded object, so a
+	// streaming-signed upload's aws-chunked token is wire framing, not the
+	// stored object's encoding — a HEAD advertising it would mislabel the
+	// bytes a forwarded GET returns.
+	meta.ContentEncoding = strings.Join(r.Header.Values("Content-Encoding"), ",")
+	if IsStreamingPayload(r.Header.Get("X-Amz-Content-Sha256")) {
+		meta.ContentEncoding = stripAWSChunkedToken(meta.ContentEncoding)
+	}
+
+	s.commitUpstreamMarker(bucket, key, meta, prior, priorVersion, priorKnown)
+}
+
+// commitUpstreamMarker commits a BodyUpstream marker under the caller's
+// PRE-FORWARD decision token — shared by the large-PUT path and the multipart
+// completion. The marker replaces exactly the displaced prior: the token (the
+// prior's live version, or the absence token when nothing predated the write)
+// is the store's expectation, so a DELETE or write that raced in during the
+// forward wins the key and the marker is refused into the convergence sweep.
+// With the prior unknown (its lookup failed) there is no token to order by,
+// and an unordered marker could resurrect over a DELETE that ran during the
+// forward — so no marker is written: the object reads as a miss until re-put,
+// on a path that already requires the metadata store to be failing.
+func (s *Service) commitUpstreamMarker(bucket, key string, meta *cache.CachedObjectMeta, prior *cache.CachedObjectMeta, priorVersion uint64, priorKnown bool) {
+	ttl := int(s.config.Cache.TTL.Seconds())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if !priorKnown {
+		s.invalidateDisplacedTieredMeta(bucket, key, prior, priorVersion, priorKnown)
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Prior lookup failed - no tier marker; object reads as a miss until re-put")
+		return
+	}
+	wrote, err := s.cache.PutMetaIfVersion(ctx, bucket, key, meta, ttl, priorVersion)
+	if err != nil {
+		s.invalidateDisplacedTieredMeta(bucket, key, prior, priorVersion, priorKnown)
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Failed to write upstream tier marker; object reads as a miss until re-put")
+		return
+	}
+	if !wrote {
+		// A racer entered the store after the pre-forward token was read — a
+		// DELETE (whose own invalidation normally removes the prior metadata)
+		// or a newer write. The guarded sweep covers the case where a DELETE's
+		// removal failed after it won, so the stale prior cannot outlive it;
+		// a newer write keeps the key through the sweep's identity guard.
+		s.invalidateDisplacedTieredMeta(bucket, key, prior, priorVersion, priorKnown)
+	}
+}
+
+// stampUpstreamMarkerAfterCompletion makes a multipart-completed object exist
+// in TAG's authoritative view: completion assembles the body UPSTREAM, so the
+// object is upstream-tier by construction, and without a marker it would read
+// as an authoritative miss until re-put (the old v1 punt). Metadata comes
+// from a HEAD to upstream when the caller's request validated (TAG's
+// credentials work on the cache bucket, and the HEAD's Content-Length keeps
+// range-reading callers honest); an ETag-only marker with unknown length is
+// the fallback — GETs forward regardless, HEAD just omits the length, and
+// the re-tier skips unknown-length markers. Commit and sweep are the
+// large-PUT path's, under the same pre-forward token.
+func (s *Service) stampUpstreamMarkerAfterCompletion(bucket, key, etag, accessKey, secretKey string, prior *cache.CachedObjectMeta, priorVersion uint64, priorKnown bool) {
+	if etag == "" {
+		s.invalidateDisplacedTieredMeta(bucket, key, prior, priorVersion, priorKnown)
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Multipart completion carried no ETag - no tier marker; object reads as a miss until re-put")
+		return
+	}
+	// TWO PHASES, because the client already holds its 200: the ETag-only
+	// marker commits IMMEDIATELY (one local cache op), so a read-after-write
+	// never sees an authoritative NoSuchKey while an upstream HEAD is in
+	// flight. The HEAD then runs in the background and upgrades the marker
+	// with real metadata (Content-Length above all, for range-reading
+	// callers) under an identity guard — GETs forward regardless, and the
+	// re-tier skips unknown-length markers, so the window is HEAD-omits-
+	// length, never wrong data.
+	meta := &cache.CachedObjectMeta{
+		Bucket: bucket, Key: key, ETag: etag, BodyUpstream: true,
+		StatusCode: http.StatusOK, CachedAt: time.Now().Unix(),
+		LastModified: time.Now().Unix(), ContentLength: -1,
+	}
+	s.commitUpstreamMarker(bucket, key, meta, prior, priorVersion, priorKnown)
+	if accessKey == "" || secretKey == "" {
+		return
+	}
+	go func() {
+		hctx, hcancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer hcancel()
+		full, ok := s.headObjectMeta(hctx, bucket, key, accessKey, secretKey, etag)
+		if !ok {
+			// Gone or replaced already; whatever state won the key stands.
+			return
+		}
+		// Identity-guarded upgrade: only the just-stamped unknown-length
+		// marker for THIS ETag is upgraded, under its observed version — a
+		// racing write refuses the commit and keeps the key.
+		cur, curVersion, found, gerr := s.cache.GetMetaWithVersion(hctx, bucket, key)
+		if gerr != nil || !found || cur == nil || !cur.BodyUpstream || cur.ETag != etag || cur.ContentLength >= 0 {
+			return
+		}
+		full.BodyUpstream = true
+		if full.LastModified == 0 {
+			// A HEAD without Last-Modified must not zero the phase-1 write
+			// stamp: If-Unmodified-Since fails closed on 0 and HEAD would
+			// omit the header.
+			full.LastModified = cur.LastModified
+		}
+		ttl := int(s.config.Cache.TTL.Seconds())
+		if _, perr := s.cache.PutMetaIfVersion(hctx, bucket, key, full, ttl, curVersion); perr != nil {
+			log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Completion marker upgrade failed; unknown-length marker serves until TTL")
+		}
+	}()
+}
+
+// headObjectMeta HEADs the object with TAG-signed credentials and builds its
+// metadata, returning ok only when upstream answered 200 for EXACTLY the
+// expected ETag — a mismatch means a concurrent overwrite superseded the
+// caller's version, and describing the newer object under the older identity
+// is the torn-pair hazard the write paths guard against. Shared by the
+// completion-marker upgrade and meta-on-write (establishBlockMetaFromHead);
+// each caller applies its mode-specific fields and commit discipline.
+func (s *Service) headObjectMeta(ctx context.Context, bucket, key, accessKey, secretKey, expectETag string) (*cache.CachedObjectMeta, bool) {
+	resp, err := s.forwarder.DoConditionalHeadRequest(ctx, bucket, key, accessKey, secretKey, "", 0)
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Marker HEAD failed")
+		return nil, false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("ETag") != expectETag {
+		return nil, false
+	}
+	meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
+	meta.ETag = expectETag
+	return meta, true
+}
+
+// invalidateDisplacedTieredMeta converges a key on an authoritative miss
+// after a marker could not be established, without either destroying a newer
+// racing write or deleting blind: cache.DeleteIfETag removes the entry only
+// while it still IS the displaced prior — the compare and the delete are one
+// CAS, so the compare-then-delete window the pre-CAS helper documented is
+// gone. Anything else present is a newer write and keeps the key; this PUT's
+// upstream copy is left as an orphan for the upstream bucket's expiry.
+//
+// No identity, no delete: when the prior is unknown (its pre-forward lookup
+// failed) nothing is removed and the possibly-stale prior serves until TTL —
+// that path requires the metadata store to be failing already, and an
+// unguarded delete there would trade a bounded staleness window for the
+// unbounded loss of a racing local write that has no upstream copy.
+func (s *Service) invalidateDisplacedTieredMeta(bucket, key string, prior *cache.CachedObjectMeta, priorVersion uint64, priorKnown bool) {
+	if !priorKnown {
+		log.Warn().Str("bucket", bucket).Str("key", key).Msg("Tier marker failed with unknown prior; possibly-stale metadata serves until TTL")
+		return
+	}
+	if prior == nil {
+		// Nothing predated this PUT: anything present now is a newer write.
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// VERSION-guarded, not ETag-guarded: MD5 ETags collide on identical
+	// bytes, so an ETag guard could delete a same-content successor write
+	// that won the race (an idempotent client re-PUT) — an acked local-tier
+	// only-copy. The observed version is exactly the snapshot this sweep is
+	// entitled to remove; anything newer keeps the key.
+	if _, err := s.cache.DeleteMetaIfVersion(ctx, bucket, key, priorVersion); err != nil {
+		log.Warn().Err(err).Str("bucket", bucket).Str("key", key).Msg("Tier marker failed and displaced prior could not be invalidated; possibly-stale metadata serves until TTL")
+	}
+}
+
+// retierFetchTimeout bounds the background re-tier fetch and store.
+const retierFetchTimeout = 60 * time.Second
+
+// A marker version whose re-tier fetch found upstream changed/gone is not
+// retried for this long — the next attempt costs a full discarded download.
+const (
+	maxRetierMismatchTracking = 4096
+	retierMismatchCooldown    = 5 * time.Minute
+)
+
+// maybeRetierOnRead heals a mis-tiered object: a validated GET hit an
+// upstream-tier marker whose size fits the local tier — typically a small PUT
+// that was forwarded before its key was learned. A background fetch moves the
+// body into the local tier so subsequent reads stop paying a body forward.
+//
+// Guards, in order:
+//   - dedup: one re-tier in flight per key, others ride the existing marker;
+//   - budget: STREAMED like the engine's PUT — the body goes straight into
+//     the cache under a BodyRef, so the reservation is the fixed stream
+//     weight, never the object; shed non-blocking;
+//   - version: the fetched ETag must match the marker's — anything else means
+//     a concurrent write replaced the object, whose state must be left alone;
+//   - identity commit: the entry is re-written only if it still IS the marker
+//     (same ETag, still upstream-tier);
+//   - write claim: PUTs write no tombstones, so a concurrent PUT could land
+//     between the identity check and the commit and be overwritten by the
+//     older version — a local-tier PUT's ONLY copy, in the worst case. Every
+//     tiered PUT therefore holds a per-key claim for its whole duration
+//     (claimRetierWrite): taking it cancels the running re-tier, and while
+//     held no new re-tier can register — a GET mid-PUT sees the old marker
+//     but cannot start a heal against it. Claim and registration share one
+//     mutex, so every interleaving lands on cancel-or-refuse. What remains is
+//     two truly concurrent commits racing in the store — the same unordered
+//     outcome S3 itself gives two concurrent writers;
+//   - decision tokens: the commit's token is read BEFORE the fetch, so a
+//     DELETE racing the re-tier enters the store provably after it and the
+//     commit is refused (DELETEs need no cancellation — the coordinator's
+//     ordering already covers them).
+//
+// The upstream copy is left as an orphan for the upstream bucket's expiry —
+// deleting it here could race a concurrent write of the same key.
+func (s *Service) maybeRetierOnRead(bucket, key, accessKey, secretKey string, marker *cache.CachedObjectMeta) {
+	if marker.ContentLength < 0 || marker.ContentLength > s.config.Cache.SizeThreshold {
+		return
+	}
+	if accessKey == "" || secretKey == "" || !s.cache.IsEnabled() {
+		return
+	}
+	// Backoff, not an outcome: a recent attempt for this exact marker version
+	// already found upstream changed or gone (recorded then as "changed"), so
+	// repeating the full-body fetch within the cooldown only burns bandwidth.
+	if s.retierRecentMismatch != nil {
+		if _, recent := s.retierRecentMismatch.Get(bucket + "|" + key + "|" + marker.ETag); recent {
+			return
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), retierFetchTimeout)
+	if !s.tryRegisterRetier(bucket, key, cancel) {
+		cancel()
+		return
+	}
+
+	// STREAMING heal: the body goes straight from the upstream response into
+	// the cache under a per-write BodyRef (the engine PUT's pattern), so the
+	// weight is the fixed stream buffering, never the object — a threshold
+	// sized above the populate budget no longer makes markers unhealable.
+	weight := int64(originlessPutStreamWeight)
+	if !s.acquireCacheSlot(context.Background(), weight, priorityReadMiss) {
+		s.unregisterRetier(bucket, key)
+		cancel()
+		metrics.RecordTieredRetier("shed")
+		return
+	}
+
+	etag := marker.ETag
+	go func() {
+		defer s.unregisterRetier(bucket, key)
+		defer s.releaseCacheSlot(weight)
+		defer cancel()
+
+		// Decision token BEFORE the fetch: a DELETE (or any write) racing this
+		// populate enters the store after this token and provably refuses the
+		// commit below — the token-model form of the old stamp-before-fetch.
+		_, decToken, tfound, terr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+		if terr != nil || !tfound {
+			metrics.RecordTieredRetier("changed")
+			return
+		}
+
+		resp, err := s.forwarder.DoFullObjectRequest(ctx, bucket, key, accessKey, secretKey)
+		if err != nil {
+			// A write's cancellation is normal coordination, not a failure —
+			// counting it as error would let routine PUT traffic drown the
+			// metric's signal.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				metrics.RecordTieredRetier("canceled")
+				return
+			}
+			metrics.RecordTieredRetier("error")
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Re-tier fetch failed")
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK || resp.Header.Get("ETag") != etag {
+			// Drain and COUNT: for a chunked 200 the discarded bytes are the
+			// replacement body itself — the one true length a headerless
+			// response can yield — consumed below by the converge rewrite.
+			drained, drainErr := io.Copy(io.Discard, resp.Body)
+			// Only a DEFINITIVE answer about the object counts as changed and
+			// enters the backoff: a 200 with a different ETag (replaced) or a
+			// 404 (gone). A transient status (5xx, 429, an auth blip) says
+			// nothing about the object — recording it would suppress healing
+			// for the whole cooldown and mislabel the outcome.
+			if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
+				if s.retierRecentMismatch != nil {
+					s.retierRecentMismatch.Add(bucket+"|"+key+"|"+etag, struct{}{})
+				}
+				// The marker is now PROVEN wrong, and the pre-fetch token is
+				// still in hand — converge it instead of leaving the
+				// divergence authoritative for the marker's TTL. Gone (404 —
+				// e.g. the cache bucket's own expiry collected the body):
+				// remove the marker under the token, so HEAD stops answering
+				// 200 for an object whose GET forwards to 404. Replaced (a
+				// different live ETag): rewrite the marker from the response,
+				// so HEAD advertises the object that actually serves. Either
+				// commit refuses if anything else won the key meanwhile; a
+				// refused or failed converge just leaves the backoff doing
+				// its job until the next attempt.
+				if resp.StatusCode == http.StatusNotFound {
+					if _, derr := s.cache.DeleteMetaIfVersion(ctx, bucket, key, decToken); derr != nil {
+						log.Debug().Err(derr).Str("bucket", bucket).Str("key", key).Msg("Re-tier converge: marker removal failed")
+					}
+				} else {
+					fresh := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
+					fresh.BodyUpstream = true
+					// A chunked response carries no Content-Length header
+					// (and Go's resp.ContentLength is -1 for exactly those),
+					// but the drain above read the whole replacement body —
+					// its count is the true length. A marker left
+					// unknown-length is honest but re-tier-ineligible, so
+					// use it when the drain completed cleanly.
+					if fresh.ContentLength < 0 && drainErr == nil {
+						fresh.ContentLength = drained
+					}
+					if _, perr := s.cache.PutMetaIfVersion(ctx, bucket, key, fresh, int(s.config.Cache.TTL.Seconds()), decToken); perr != nil {
+						log.Debug().Err(perr).Str("bucket", bucket).Str("key", key).Msg("Re-tier converge: marker rewrite failed")
+					}
+				}
+				metrics.RecordTieredRetier("changed")
+				return
+			}
+			metrics.RecordTieredRetier("error")
+			log.Debug().Int("status", resp.StatusCode).Str("bucket", bucket).Str("key", key).Msg("Re-tier fetch returned transient status")
+			return
+		}
+
+		// Stream the body into the cache under a fresh BodyRef, limited to
+		// CL+1 (the extra byte detects a longer-than-declared body) and
+		// counted. The upstream ETag was verified above, so unlike the
+		// engine PUT no digest needs computing — the ref exists purely so
+		// the body can stream before the commit. A body that never commits
+		// is a TTL-reclaimed orphan; definitive mismatches also delete it
+		// eagerly below.
+		ref := cache.NewBodyRef()
+		src := &captureReader{r: io.LimitReader(resp.Body, marker.ContentLength+1)}
+		putBodyErr := s.cache.PutBodyStream(ctx, bucket, key, ref, src, int64(s.config.Cache.TTL.Seconds()))
+		discardRef := func() {
+			// Detached context: the fetch ctx is CANCELED by a racing PUT —
+			// precisely the interleaving whose staged body most needs
+			// reclaiming — so the delete must not ride it.
+			dctx, dcancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer dcancel()
+			if derr := s.cache.DeleteBody(dctx, bucket, key, ref); derr != nil {
+				log.Debug().Err(derr).Str("bucket", bucket).Str("key", key).Msg("Re-tier staged body delete failed; orphan ages out by TTL")
+			}
+		}
+		if putBodyErr != nil {
+			// Transport failure mid-body or a cache write fault: transient,
+			// nothing safe to commit — and no backoff, a blip must not
+			// suppress healing.
+			discardRef()
+			metrics.RecordTieredRetier("error")
+			log.Debug().Err(putBodyErr).Int64("read", src.n).Str("bucket", bucket).Str("key", key).Msg("Re-tier body stream failed")
+			return
+		}
+		if src.n != marker.ContentLength {
+			// The body streamed COMPLETELY and its length contradicts the
+			// marker (longer: the CL+1 limit filled; shorter: clean EOF
+			// before CL). That is as definitive as a changed ETag — this
+			// marker version can never re-tier — so it enters the same
+			// backoff; without it the doomed full download repeats on every
+			// validated GET for the marker's TTL.
+			discardRef()
+			if s.retierRecentMismatch != nil {
+				s.retierRecentMismatch.Add(bucket+"|"+key+"|"+etag, struct{}{})
+			}
+			metrics.RecordTieredRetier("changed")
+			log.Debug().Int64("read", src.n).Int64("declared", marker.ContentLength).Str("bucket", bucket).Str("key", key).Msg("Re-tier body length contradicts marker")
+			return
+		}
+
+		// Identity-guarded commit: only re-write the entry if it still IS the
+		// marker this re-tier was triggered by. The commit's expectation is
+		// the PRE-FETCH decision token, so anything landing after that
+		// instant — including during the fetch — refuses the commit
+		// atomically; this re-read is purely the identity guard. The
+		// cancellation check comes after it — a racing PUT cancels before it
+		// stores, so an alive context here means no PUT has entered the store
+		// ahead of us; the token precondition then holds the line for
+		// whatever the claim window cannot see.
+		cur, _, found, gerr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+		if gerr != nil || !found || cur == nil || cur.ETag != etag || !cur.BodyUpstream {
+			discardRef()
+			metrics.RecordTieredRetier("changed")
+			return
+		}
+		if cerr := ctx.Err(); cerr != nil {
+			discardRef()
+			// Distinguish a write's cancellation (coordination) from the
+			// 60-second deadline expiring (a genuine failure).
+			if errors.Is(cerr, context.Canceled) {
+				metrics.RecordTieredRetier("canceled")
+			} else {
+				metrics.RecordTieredRetier("error")
+			}
+			return
+		}
+
+		meta := cache.MetaFromHTTPHeaders(bucket, key, http.StatusOK, resp.Header)
+		meta.BodyRef = ref
+		// The streamed byte count is authoritative for length — a chunked
+		// response carries no Content-Length header for MetaFromHTTPHeaders
+		// to copy.
+		meta.ContentLength = src.n
+		ttl := int(s.config.Cache.TTL.Seconds())
+		wrote, werr := s.cache.PutMetaIfVersion(ctx, bucket, key, meta, ttl, decToken)
+		if werr != nil {
+			// AMBIGUOUS commit (see the engine PUT's rule): the owner may
+			// have applied it, so the staged body must not be deleted —
+			// TTL reclaims a genuine orphan.
+			metrics.RecordTieredRetier("error")
+			log.Debug().Err(werr).Str("bucket", bucket).Str("key", key).Msg("Re-tier store failed")
+			return
+		}
+		if !wrote {
+			// A racer entered the store after the pre-fetch token: the object
+			// stays on its current state (marker, newer write, or deleted) —
+			// not a re-tier. Definitive refusal: reclaim the staged body.
+			discardRef()
+			metrics.RecordTieredRetier("changed")
+			return
+		}
+		metrics.RecordTieredRetier("retiered")
+	}()
+}
+
+// claimRetierWrite marks a PUT in flight for the key: it cancels any running
+// re-tier and excludes new ones from starting until the matching release.
+// PUTs write no tombstones, so this claim is what stops a re-tier from
+// committing an older version over the PUT — for a local-tier PUT, the only
+// copy. Held for the PUT's whole duration, it also covers re-tiers a GET
+// might otherwise start mid-PUT against the still-visible old marker.
+func (s *Service) claimRetierWrite(bucket, key string) {
+	k := bucket + "|" + key
+	s.retierMu.Lock()
+	s.retierClaims[k]++
+	if cancel := s.retierInflight[k]; cancel != nil {
+		cancel()
+	}
+	s.retierMu.Unlock()
+}
+
+func (s *Service) releaseRetierWrite(bucket, key string) {
+	k := bucket + "|" + key
+	s.retierMu.Lock()
+	if s.retierClaims[k]--; s.retierClaims[k] <= 0 {
+		delete(s.retierClaims, k)
+	}
+	s.retierMu.Unlock()
+}
+
+// tryRegisterRetier registers a re-tier for the key unless one is already
+// running or a write holds the claim. Registration and claim share one mutex,
+// so every interleaving either cancels the re-tier or refuses to start it.
+func (s *Service) tryRegisterRetier(bucket, key string, cancel context.CancelFunc) bool {
+	k := bucket + "|" + key
+	s.retierMu.Lock()
+	defer s.retierMu.Unlock()
+	if s.retierClaims[k] > 0 || s.retierInflight[k] != nil {
+		return false
+	}
+	s.retierInflight[k] = cancel
+	return true
+}
+
+func (s *Service) unregisterRetier(bucket, key string) {
+	s.retierMu.Lock()
+	delete(s.retierInflight, bucket+"|"+key)
+	s.retierMu.Unlock()
+}
+
+// retierRunning reports whether a re-tier is in flight for the key (tests).
+func (s *Service) retierRunning(bucket, key string) bool {
+	s.retierMu.Lock()
+	defer s.retierMu.Unlock()
+	return s.retierInflight[bucket+"|"+key] != nil
+}
+
+// handleTieredDeleteLocal answers a DELETE entirely locally when the object's
+// body is in the local tier. Returns handled=false when the caller should run
+// the ordinary forwarding DELETE instead — upstream-tier objects, objects with
+// no metadata (idempotent 204 from upstream, and it covers an expired marker's
+// orphan), and requests TAG could not validate.
+func (s *Service) handleTieredDeleteLocal(w http.ResponseWriter, r *http.Request) (handled bool, err error) {
+	start := time.Now()
+	result, _, _, authErr := s.forwarder.ValidateAndGetCredentials(r)
+	if authErr != nil {
+		metrics.RecordRequest("DeleteObject", "auth_error", metrics.SourceLocal, time.Since(start).Seconds())
+		return true, authErr
+	}
+	if result != AuthValidated || !originlessPlainObject(r) {
+		return false, nil
+	}
+
+	ctx := r.Context()
+	bucket, key := ParseBucketKey(r)
+	meta, found, cacheErr := s.cache.GetMeta(ctx, bucket, key)
+	if cacheErr != nil {
+		// Falling through would forward the DELETE, ack 204 upstream, and leave
+		// a possibly local-tier copy being served. Fail retryably instead.
+		metrics.RecordRequest("DeleteObject", "error", metrics.SourceLocal, time.Since(start).Seconds())
+		return true, cacheErr
+	}
+	if !found || meta == nil || meta.BodyUpstream {
+		return false, nil
+	}
+	return true, s.HandleOriginlessDelete(w, r)
+}
+
+// deleteUpstreamObjectAsync issues the cross-tier cleanup DELETE in the
+// background, signed with the credentials the validated request resolved —
+// which in the transparent-auth flow are TAG's OWN credentials, not the
+// client's. Tiered deployments must therefore grant TAG's credentials delete
+// permission on the upstream cache bucket (unlike proxy mode's read-only
+// guidance, which targets customer buckets); with read-only credentials every
+// cleanup is rejected 403 and orphans accumulate until bucket expiry.
+// Best-effort: a failure leaves an orphan that the cache bucket's own expiry
+// collects.
+func (s *Service) deleteUpstreamObjectAsync(bucket, key, etag, accessKey, secretKey string) {
+	if accessKey == "" || secretKey == "" {
+		return
+	}
+	if etag == "" {
+		// No ETag to bind the delete to — an unconditional delete could remove
+		// a newer object, so the orphan is left for upstream expiry instead.
+		metrics.RecordTieredCleanupSkipped("no_etag")
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), tieredCleanupTimeout)
+		defer cancel()
+		// The If-Match guard below cannot protect a LIVE upstream object that
+		// carries the SAME ETag: plain-PUT ETags are content MD5, so a
+		// delete + re-put of identical bytes recreates the object under the
+		// displaced prior's ETag, and this delayed delete would then remove
+		// the body the current marker points at. Re-check the key's current
+		// metadata first and abort when it is an upstream-tier marker for
+		// exactly this ETag — that body is authoritative again, not an
+		// orphan. (A racer between this check and the DELETE narrows to the
+		// same-ETag re-establishment landing inside one round trip; the
+		// If-Match still guards every different-ETag interleaving — Tigris
+		// enforces conditional DELETEs against the object's current version,
+		// so a different-ETag racer's body is provably left intact.)
+		if cur, found, gerr := s.cache.GetMeta(ctx, bucket, key); gerr == nil && found && cur != nil && cur.BodyUpstream && cur.ETag == etag {
+			metrics.RecordTieredCleanupSkipped("live_marker")
+			return
+		}
+		resp, err := s.forwarder.DoObjectDeleteRequest(ctx, bucket, key, etag, accessKey, secretKey)
+		if err != nil {
+			// Debug, not Info: per-request error logs flood under an upstream
+			// outage; tag_tiered_cleanup_total{outcome} is the visibility signal,
+			// with outcome classification owned by the metrics layer.
+			metrics.RecordTieredCleanup(0, err)
+			log.Debug().Err(err).Str("bucket", bucket).Str("key", key).Msg("Cross-tier cleanup delete failed")
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		// 404 (already gone) and 412 (If-Match lost to a newer version, which
+		// must be left alone) are completed outcomes, not failures.
+		if resp.StatusCode >= 300 {
+			metrics.RecordTieredCleanup(resp.StatusCode, nil)
+			if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusPreconditionFailed {
+				log.Debug().Int("status", resp.StatusCode).Str("bucket", bucket).Str("key", key).Msg("Cross-tier cleanup delete rejected")
+			}
+			return
+		}
+		// The DELETE landed. REPAIR the residual same-ETag race the pre-check
+		// cannot close: a concurrent large PUT of identical bytes can
+		// recreate the upstream object under this ETag and publish its marker
+		// between the check above and the DELETE landing, and MD5 ETags give
+		// If-Match no way to tell the versions apart. If the key's CURRENT
+		// metadata is a live marker for this ETag, the body it points at may
+		// be the one just deleted — converge on the authoritative miss
+		// instead of advertising it: the caller re-populates from its system
+		// of record, and tiered semantics make "not cached" a complete, safe
+		// answer. The removal commits under the OBSERVED VERSION, not the
+		// ETag — identical content reuses MD5 ETags, so an ETag guard could
+		// take out a same-content successor (a local-tier PUT or a re-tier
+		// commit) that landed after this read; the version guard refuses
+		// exactly those. One outcome is recorded per cleanup: deleted,
+		// marker_repaired, or repair_failed.
+		cur, curVersion, found, gerr := s.cache.GetMetaWithVersion(ctx, bucket, key)
+		if gerr != nil {
+			// The repair check could not run: a raced-in same-ETag marker may
+			// remain authoritative over the just-deleted body until TTL. Its
+			// own outcome, never folded into "deleted".
+			metrics.RecordTieredCleanupSkipped("repair_failed")
+			log.Debug().Err(gerr).Str("bucket", bucket).Str("key", key).Msg("Cleanup repair: post-delete read failed; a raced-in marker may serve until TTL")
+			return
+		}
+		if !found || cur == nil || !cur.BodyUpstream || cur.ETag != etag {
+			metrics.RecordTieredCleanup(resp.StatusCode, nil)
+			return
+		}
+		repaired, derr := s.cache.DeleteMetaIfVersion(ctx, bucket, key, curVersion)
+		switch {
+		case derr != nil:
+			metrics.RecordTieredCleanupSkipped("repair_failed")
+			log.Debug().Err(derr).Str("bucket", bucket).Str("key", key).Msg("Cleanup repair: marker removal failed; stale marker serves until TTL")
+		case repaired:
+			metrics.RecordTieredCleanupSkipped("marker_repaired")
+		default:
+			// The entry moved since the read — a newer write owns the key and
+			// keeps its metadata; the cleanup itself still completed.
+			metrics.RecordTieredCleanup(resp.StatusCode, nil)
+		}
+	}()
+}

--- a/proxy/tiered_test.go
+++ b/proxy/tiered_test.go
@@ -1,0 +1,1508 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cacheclient "github.com/tigrisdata/ocache/client"
+	"github.com/tigrisdata/tag/cache"
+	"github.com/tigrisdata/tag/config"
+)
+
+// newTieredTestService builds a Service in tiered mode with an in-memory cache
+// and the given small/large tier boundary.
+func newTieredTestService(forwarder RequestForwarder, threshold int64) (*Service, *cache.Cache) {
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = threshold
+	// Re-validate AFTER setting Mode so the mode-derived defaults apply:
+	// production tiered mode auto-selects the CAS coordinator (validateMode),
+	// and this suite must exercise the coordinator it actually runs —
+	// under legacy the cleanup repair chain (DeleteMetaIfVersion) is a stub.
+	if err := cfg.Validate(); err != nil {
+		panic(err)
+	}
+
+	memCache := cacheclient.NewMemoryCache()
+	c := cache.NewCacheWithClient(memCache, &cfg.Cache)
+	svc := NewService(forwarder, c, cfg)
+	return svc, c
+}
+
+// tieredMock wires a mockForwarder that counts upstream traffic and answers
+// like a healthy upstream: PUT → 200 + ETag, GET → 200 + body, DELETE → 204.
+func tieredMock() (*mockForwarder, *atomic.Int64, *atomic.Int64) {
+	forwards := &atomic.Int64{}
+	deletes := &atomic.Int64{}
+	m := &mockForwarder{
+		forwardFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			forwards.Add(1)
+			switch r.Method {
+			case http.MethodPut:
+				w.Header().Set("ETag", `"upstream-etag"`)
+				w.WriteHeader(http.StatusOK)
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("upstream body"))
+			}
+			return nil
+		},
+		doObjectDeleteFunc: func(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error) {
+			deletes.Add(1)
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		},
+	}
+	return m, forwards, deletes
+}
+
+func tieredDo(t *testing.T, svc *Service, method, path, body string, hdr map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body != "" || method == http.MethodPut {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	for k, v := range hdr {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+
+	var err error
+	switch method {
+	case http.MethodGet, http.MethodHead:
+		err = svc.HandleGetObject(w, req)
+		if method == http.MethodHead {
+			w = httptest.NewRecorder()
+			req = httptest.NewRequest(method, path, nil)
+			for k, v := range hdr {
+				req.Header.Set(k, v)
+			}
+			err = svc.HandleHeadObject(w, req)
+		}
+	case http.MethodPut:
+		err = svc.HandlePutObject(w, req)
+	case http.MethodDelete:
+		err = svc.HandleDeleteObject(w, req)
+	}
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	return w
+}
+
+// A small object's whole lifecycle — PUT, GET, HEAD, DELETE, GET-after-delete —
+// must complete without a single upstream request.
+func TestTieredSmallObjectLifecycleZeroUpstream(t *testing.T) {
+	mock, forwards, deletes := tieredMock()
+	svc, _ := newTieredTestService(mock, 1024)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/small", "hello tiered", nil); w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", w.Code)
+	}
+	w := tieredDo(t, svc, http.MethodGet, "/b/small", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "hello tiered" {
+		t.Fatalf("GET status = %d body %q", w.Code, w.Body.String())
+	}
+	if w := tieredDo(t, svc, http.MethodHead, "/b/small", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodDelete, "/b/small", "", nil); w.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodGet, "/b/small", "", nil); w.Code != http.StatusNotFound {
+		t.Fatalf("GET after DELETE status = %d, want 404", w.Code)
+	}
+
+	if n := forwards.Load(); n != 0 {
+		t.Fatalf("upstream forwards = %d, want 0", n)
+	}
+	if n := deletes.Load(); n != 0 {
+		t.Fatalf("upstream deletes = %d, want 0", n)
+	}
+}
+
+// A metadata miss is the authoritative answer: NoSuchKey, zero upstream.
+func TestTieredMetaMissIsLocal404(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 1024)
+
+	if w := tieredDo(t, svc, http.MethodGet, "/b/absent", "", nil); w.Code != http.StatusNotFound {
+		t.Fatalf("GET status = %d, want 404", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodHead, "/b/absent", "", nil); w.Code != http.StatusNotFound {
+		t.Fatalf("HEAD status = %d, want 404", w.Code)
+	}
+	if n := forwards.Load(); n != 0 {
+		t.Fatalf("upstream forwards = %d, want 0", n)
+	}
+}
+
+// A large PUT passes through and stamps a BodyUpstream marker; HEAD then
+// answers from the marker (no forward) while GET forwards for the body.
+func TestTieredLargePutStampsMarker(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	body := "sixteen byte body!"
+	if w := tieredDo(t, svc, http.MethodPut, "/b/large", body, nil); w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", w.Code)
+	}
+	if n := forwards.Load(); n != 1 {
+		t.Fatalf("forwards after large PUT = %d, want 1", n)
+	}
+
+	meta, found, err := c.GetMeta(context.Background(), "b", "large")
+	if err != nil || !found || meta == nil {
+		t.Fatalf("marker meta not found: found=%v err=%v", found, err)
+	}
+	if !meta.BodyUpstream {
+		t.Fatal("marker meta.BodyUpstream = false, want true")
+	}
+	if meta.ETag != `"upstream-etag"` {
+		t.Fatalf("marker ETag = %q", meta.ETag)
+	}
+	if meta.ContentLength != int64(len(body)) {
+		t.Fatalf("marker ContentLength = %d, want %d", meta.ContentLength, len(body))
+	}
+
+	if w := tieredDo(t, svc, http.MethodHead, "/b/large", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d", w.Code)
+	}
+	if n := forwards.Load(); n != 1 {
+		t.Fatalf("forwards after HEAD = %d, want 1 (HEAD must serve from marker)", n)
+	}
+
+	w := tieredDo(t, svc, http.MethodGet, "/b/large", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "upstream body" {
+		t.Fatalf("GET status = %d body %q", w.Code, w.Body.String())
+	}
+	if n := forwards.Load(); n != 2 {
+		t.Fatalf("forwards after GET = %d, want 2 (GET body forwards)", n)
+	}
+}
+
+// A small write over an upstream-tier object must delete the upstream copy.
+func TestTieredSmallOverUpstreamCleansUp(t *testing.T) {
+	mock, _, _ := tieredMock()
+	deleted := make(chan string, 1)
+	mock.doObjectDeleteFunc = func(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error) {
+		deleted <- bucket + "/" + key + " " + etag
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	}
+	svc, c := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+
+	select {
+	case got := <-deleted:
+		if got != `b/obj "upstream-etag"` {
+			t.Fatalf("cross-tier delete = %q, want key b/obj bound to the displaced ETag", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cross-tier upstream delete never issued")
+	}
+
+	meta, found, err := c.GetMeta(context.Background(), "b", "obj")
+	if err != nil || !found || meta == nil {
+		t.Fatalf("meta not found after small overwrite: found=%v err=%v", found, err)
+	}
+	if meta.BodyUpstream {
+		t.Fatal("meta still marked BodyUpstream after small overwrite")
+	}
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Body.String() != "tiny" {
+		t.Fatalf("GET body = %q, want local copy", w.Body.String())
+	}
+}
+
+// A large write over a local-tier object replaces it with an upstream marker.
+func TestTieredLargeOverLocalReplacesMeta(t *testing.T) {
+	mock, _, deletes := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+
+	meta, found, err := c.GetMeta(context.Background(), "b", "obj")
+	if err != nil || !found || meta == nil {
+		t.Fatalf("meta not found after large overwrite: found=%v err=%v", found, err)
+	}
+	if !meta.BodyUpstream {
+		t.Fatal("meta.BodyUpstream = false after large overwrite")
+	}
+	if n := deletes.Load(); n != 0 {
+		t.Fatalf("upstream deletes = %d, want 0 (local displacement is free)", n)
+	}
+}
+
+// Requests TAG cannot validate forward to upstream — the auth authority —
+// even when the object is cached locally.
+func TestTieredUnvalidatedForwards(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 1024)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "cached", nil); w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", w.Code)
+	}
+	base := forwards.Load()
+
+	mock.validateFunc = func(r *http.Request) (AuthResult, string, string, error) {
+		return AuthNotValidated, "", "", nil
+	}
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if w.Body.String() != "upstream body" {
+		t.Fatalf("GET body = %q, want the forwarded upstream response", w.Body.String())
+	}
+	if n := forwards.Load(); n != base+1 {
+		t.Fatalf("forwards = %d, want %d (unvalidated GET must forward)", n, base+1)
+	}
+}
+
+// Deleting an upstream-tier object forwards the DELETE and drops the marker.
+func TestTieredDeleteUpstreamTierForwards(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+	base := forwards.Load()
+
+	if w := tieredDo(t, svc, http.MethodDelete, "/b/obj", "", nil); w.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d", w.Code)
+	}
+	if n := forwards.Load(); n != base+1 {
+		t.Fatalf("forwards = %d, want %d (upstream-tier DELETE must forward)", n, base+1)
+	}
+	if _, found, _ := c.GetMeta(context.Background(), "b", "obj"); found {
+		t.Fatal("marker meta still present after DELETE")
+	}
+}
+
+// A conditional write against an upstream-tier prior forwards: only upstream
+// can evaluate preconditions against the version it owns.
+func TestTieredConditionalPutOverUpstreamForwards(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+	base := forwards.Load()
+
+	w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", map[string]string{"If-Match": `"upstream-etag"`})
+	if w.Code != http.StatusOK {
+		t.Fatalf("conditional PUT status = %d", w.Code)
+	}
+	if n := forwards.Load(); n != base+1 {
+		t.Fatalf("forwards = %d, want %d (conditional PUT over upstream prior must forward)", n, base+1)
+	}
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || !meta.BodyUpstream {
+		t.Fatal("expected a refreshed upstream marker after forwarded conditional PUT")
+	}
+}
+
+// A failed large overwrite must leave the prior local-tier copy intact: the
+// local tier holds the only copy, and a rejected PUT changes nothing.
+func TestTieredFailedLargeOverwriteKeepsLocalCopy(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("failed large PUT status = %d, want 503", w.Code)
+	}
+
+	mock.forwardFunc = nil
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "tiny" {
+		t.Fatalf("GET after failed overwrite = %d %q, want the intact prior copy", w.Code, w.Body.String())
+	}
+}
+
+// A DELETE whose tombstone lands while a large PUT is in flight must suppress
+// the marker: the marker is stamped with the handler's start, so the newer
+// tombstone wins and the deleted object is never resurrected as metadata.
+func TestTieredConcurrentDeleteSuppressesMarker(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		// The concurrent DELETE completes (tombstone written) while the PUT's
+		// forward is still in flight.
+		if err := c.Delete(context.Background(), "b", "obj"); err != nil {
+			t.Errorf("mid-flight delete: %v", err)
+		}
+		w.Header().Set("ETag", `"upstream-etag"`)
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+
+	if _, found, _ := c.GetMeta(context.Background(), "b", "obj"); found {
+		t.Fatal("marker written despite a newer DELETE tombstone - deleted object resurrected")
+	}
+	if w := tieredDo(t, svc, http.MethodHead, "/b/obj", "", nil); w.Code != http.StatusNotFound {
+		t.Fatalf("HEAD after suppressed marker = %d, want 404", w.Code)
+	}
+}
+
+// When the marker cannot be established, the convergence sweep must not
+// destroy a newer local write that raced the forward — it has no upstream
+// copy. Here the upstream PUT response carries no ETag (marker skipped) and a
+// small write lands mid-flight: the newer local object must keep the key.
+func TestTieredMarkerFailureSparesNewerLocalWrite(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 8)
+
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		// A newer small write completes while the large PUT's forward is in
+		// flight. The mock is restored first so the inner PUT takes the plain
+		// small-tier path.
+		inner := mock.forwardFunc
+		mock.forwardFunc = nil
+		if w2 := tieredDo(t, svc, http.MethodPut, "/b/obj", "newer", nil); w2.Code != http.StatusOK {
+			t.Errorf("mid-flight small PUT status = %d", w2.Code)
+		}
+		mock.forwardFunc = inner
+		// No ETag header: the marker cannot be established.
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "newer" {
+		t.Fatalf("GET = %d %q, want the surviving newer local write", w.Code, w.Body.String())
+	}
+}
+
+// The other edge of the identity guard: when the marker fails and the current
+// metadata still IS the displaced prior, it must be removed — the failed
+// marker must not leave the old version serving after the client's 200.
+func TestTieredMarkerFailureRemovesDisplacedPrior(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "stale", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		// 2xx with no ETag: the marker cannot be established.
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+
+	if _, found, _ := c.GetMeta(context.Background(), "b", "obj"); found {
+		t.Fatal("displaced prior metadata still present after marker failure")
+	}
+	mock.forwardFunc = nil
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Code != http.StatusNotFound {
+		t.Fatalf("GET after failed marker = %d, want authoritative 404 (never the stale prior)", w.Code)
+	}
+}
+
+// waitRetierDone polls until no re-tier is in flight for the key. The
+// LoadOrStore happens synchronously before the read returns, so absence
+// afterwards means the background attempt ran to completion.
+func waitRetierDone(t *testing.T, svc *Service, bucket, key string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if !svc.retierRunning(bucket, key) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("re-tier still in flight after 2s")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// A small object that landed upstream-tier (a cold-start PUT forwarded before
+// its key was learned) is healed by the first validated read: the body moves
+// into the local tier and subsequent reads stop forwarding.
+func TestTieredRetierOnReadHealsMisplacedObject(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 1024)
+
+	// Cold start: the key is not learned yet, so the small PUT forwards and
+	// gets an upstream-tier marker.
+	mock.validateFunc = func(r *http.Request) (AuthResult, string, string, error) {
+		return AuthNotValidated, "", "", nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("cold-start PUT status = %d", w.Code)
+	}
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || !meta.BodyUpstream {
+		t.Fatal("cold-start PUT did not stamp an upstream-tier marker")
+	}
+
+	// Keys learned: reads validate locally now.
+	mock.validateFunc = nil
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+		h := http.Header{}
+		h.Set("ETag", `"upstream-etag"`)
+		h.Set("Content-Type", "text/plain")
+		return &http.Response{StatusCode: http.StatusOK, Header: h, ContentLength: 4, Body: io.NopCloser(strings.NewReader("tiny"))}, nil
+	}
+
+	// This read still forwards (the marker is upstream-tier) and triggers the heal.
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", w.Code)
+	}
+	waitRetierDone(t, svc, "b", "obj")
+
+	meta, found, _ = c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || meta.BodyUpstream {
+		t.Fatalf("object not re-tiered: found=%v meta=%+v", found, meta)
+	}
+	base := forwards.Load()
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "tiny" {
+		t.Fatalf("GET after re-tier = %d %q, want the local body", w.Code, w.Body.String())
+	}
+	if n := forwards.Load(); n != base {
+		t.Fatalf("forwards = %d, want %d (re-tiered object must serve locally)", n, base)
+	}
+}
+
+// The re-tier must refuse to commit when the object was replaced mid-flight:
+// a fetched ETag that no longer matches the marker means a concurrent write
+// owns the key, and its state is left alone.
+func TestTieredRetierSkipsReplacedObject(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 1024)
+
+	mock.validateFunc = func(r *http.Request) (AuthResult, string, string, error) {
+		return AuthNotValidated, "", "", nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("cold-start PUT status = %d", w.Code)
+	}
+	mock.validateFunc = nil
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+		h := http.Header{}
+		h.Set("ETag", `"a-newer-version"`)
+		return &http.Response{StatusCode: http.StatusOK, Header: h, ContentLength: 5, Body: io.NopCloser(strings.NewReader("newer"))}, nil
+	}
+
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", w.Code)
+	}
+	waitRetierDone(t, svc, "b", "obj")
+
+	// The replaced object's state wins the key — and the marker CONVERGES to
+	// it: the re-tier must never commit the older body, but leaving the old
+	// marker authoritative would advertise an ETag on HEAD that no GET
+	// serves. The rewritten marker carries the live upstream identity.
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || !meta.BodyUpstream {
+		t.Fatalf("marker lost after a version-mismatched re-tier: %+v", meta)
+	}
+	if meta.ETag != `"a-newer-version"` {
+		t.Fatalf("marker ETag = %q, want convergence to the live upstream version", meta.ETag)
+	}
+}
+
+// A PUT that lands while a re-tier is in flight must win the key: the PUT
+// cancels the re-tier, and the older upstream version is never committed over
+// the newer write — which, for a local-tier PUT, is the only copy.
+func TestTieredPutCancelsInflightRetier(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 1024)
+
+	mock.validateFunc = func(r *http.Request) (AuthResult, string, string, error) {
+		return AuthNotValidated, "", "", nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "old!", nil); w.Code != http.StatusOK {
+		t.Fatalf("cold-start PUT status = %d", w.Code)
+	}
+	mock.validateFunc = nil
+
+	fetching := make(chan struct{})
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+		close(fetching)
+		// Block until the racing PUT cancels the re-tier.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", w.Code)
+	}
+	<-fetching
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "newer", nil); w.Code != http.StatusOK {
+		t.Fatalf("racing PUT status = %d", w.Code)
+	}
+	waitRetierDone(t, svc, "b", "obj")
+
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || meta.BodyUpstream || meta.ContentLength != 5 {
+		t.Fatalf("newer write lost to the re-tier: %+v", meta)
+	}
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if w.Code != http.StatusOK || w.Body.String() != "newer" {
+		t.Fatalf("GET = %d %q, want the racing PUT's body", w.Code, w.Body.String())
+	}
+}
+
+// A GET arriving while a PUT is in flight sees the old marker but must not
+// start a re-tier against it: the PUT's write claim excludes new re-tiers for
+// the key until the PUT completes.
+func TestTieredWriteClaimExcludesRetier(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, c := newTieredTestService(mock, 8)
+
+	// Cold-start marker for a small object (ContentLength 4 ≤ threshold).
+	mock.validateFunc = func(r *http.Request) (AuthResult, string, string, error) {
+		return AuthNotValidated, "", "", nil
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "old!", nil); w.Code != http.StatusOK {
+		t.Fatalf("cold-start PUT status = %d", w.Code)
+	}
+	mock.validateFunc = nil
+
+	var fetches atomic.Int64
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+		fetches.Add(1)
+		return nil, context.Canceled
+	}
+
+	// A large overwrite blocks mid-forward, holding the write claim.
+	putEntered := make(chan struct{})
+	putRelease := make(chan struct{})
+	base := mock.forwardFunc
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		if r.Method == http.MethodPut {
+			close(putEntered)
+			<-putRelease
+		}
+		return base(ctx, w, r)
+	}
+	putDone := make(chan struct{})
+	go func() {
+		defer close(putDone)
+		req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("way past threshold"))
+		if err := svc.HandlePutObject(httptest.NewRecorder(), req); err != nil {
+			t.Errorf("blocked PUT: %v", err)
+		}
+	}()
+	<-putEntered
+
+	// GET mid-PUT: forwards (old marker) but must not register a re-tier.
+	if w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", w.Code)
+	}
+	if svc.retierRunning("b", "obj") {
+		t.Fatal("re-tier registered while a write held the claim")
+	}
+
+	close(putRelease)
+	<-putDone
+	if n := fetches.Load(); n != 0 {
+		t.Fatalf("re-tier fetches = %d, want 0 (claim must exclude the heal)", n)
+	}
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || !meta.BodyUpstream || meta.ContentLength != 18 {
+		t.Fatalf("completed PUT's marker disturbed: %+v", meta)
+	}
+}
+
+// RFC 7232 §3.3: a request carrying If-None-Match is judged by it alone. A
+// non-matching If-None-Match must never fall back to an unexpired
+// If-Modified-Since — LastModified is second-granular, so that fallback would
+// 304 a client across a same-second overwrite.
+func TestTieredConditionalGetIfNoneMatchBeatsIfModifiedSince(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 1024)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "v2-body", nil); w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", w.Code)
+	}
+
+	// The client holds a STALE ETag but a fresh-enough date: the mismatching
+	// If-None-Match must win and return the full 200 body.
+	w := tieredDo(t, svc, http.MethodGet, "/b/obj", "", map[string]string{
+		"If-None-Match":     `"stale-etag"`,
+		"If-Modified-Since": time.Now().UTC().Add(time.Hour).Format(http.TimeFormat),
+	})
+	if w.Code != http.StatusOK || w.Body.String() != "v2-body" {
+		t.Fatalf("GET = %d %q, want 200 with the current body (If-Modified-Since must be ignored)", w.Code, w.Body.String())
+	}
+}
+
+// raceOnConditionalReadClient injects a replacement right after the versioned
+// read that evaluates a conditional PUT's precondition, so the store's CAS
+// must refuse the write.
+type raceOnConditionalReadClient struct {
+	cacheclient.CacheClient
+	armed   bool
+	replace func()
+}
+
+func (r *raceOnConditionalReadClient) GetWithVersion(ctx context.Context, key string) ([]byte, uint64, bool, error) {
+	data, version, found, err := r.CacheClient.GetWithVersion(ctx, key)
+	if r.armed && found && r.replace != nil {
+		r.armed = false
+		r.replace()
+	}
+	return data, version, found, err
+}
+
+// A conditional PUT whose precondition races away between evaluation and
+// store must answer 412, not 200: the version observed at the If-Match check
+// is enforced by the store's CAS.
+func TestTieredConditionalPutRacedPreconditionAnswers412(t *testing.T) {
+	mock, _, _ := tieredMock()
+	wrapper := &raceOnConditionalReadClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	// Closing the check-then-store race against a competing WRITE is
+	// CAS-coordinator strength; legacy coordination orders commits against
+	// deletes only (the pre-CAS engine's documented accepted race).
+	cfg.Cache.SetLegacyCoordination(false)
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = 1024
+	c := cache.NewCacheWithClient(wrapper, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "v1-body", nil); w.Code != http.StatusOK {
+		t.Fatalf("seed PUT status = %d", w.Code)
+	}
+	etagV1 := func() string {
+		meta, _, _ := c.GetMeta(context.Background(), "b", "obj")
+		return meta.ETag
+	}()
+
+	// Arm the race: the moment the conditional PUT's evaluation reads the
+	// versioned row, a concurrent overwrite replaces it.
+	wrapper.replace = func() {
+		req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("racer!!"))
+		if err := svc.HandlePutObject(httptest.NewRecorder(), req); err != nil {
+			t.Errorf("racing PUT: %v", err)
+		}
+	}
+	wrapper.armed = true
+
+	w := tieredDo(t, svc, http.MethodPut, "/b/obj", "cond-body", map[string]string{"If-Match": etagV1})
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("raced conditional PUT = %d, want 412", w.Code)
+	}
+	if g := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); g.Body.String() != "racer!!" {
+		t.Fatalf("GET = %q, want the racer's body to survive", g.Body.String())
+	}
+}
+
+// The same-ETag cleanup race must REPAIR: a marker with the displaced prior's
+// ETag re-established while the cross-tier DELETE is in flight (an
+// identical-content large PUT — MD5 ETags collide on identical bytes) may
+// point at the body that DELETE just removed. The repair converges the key on
+// an authoritative miss via DeleteMetaIfVersion. Fails if the suite runs the
+// legacy coordinator (whose deleteMetaIfVersion is a refusing stub) — the
+// production tiered configuration is CAS.
+func TestTieredCleanupRepairsRacedSameETagMarker(t *testing.T) {
+	mock, _, _ := tieredMock()
+	var c *cache.Cache
+	raced := make(chan struct{})
+	mock.doObjectDeleteFunc = func(ctx context.Context, bucket, key, etag, accessKey, secretKey string) (*http.Response, error) {
+		// Mid-DELETE: an identical-content large PUT re-establishes the marker
+		// under the same ETag, exactly the interleaving the pre-check missed.
+		marker := &cache.CachedObjectMeta{
+			Bucket: bucket, Key: key, ETag: etag,
+			BodyUpstream: true, StatusCode: http.StatusOK, ContentLength: 18,
+		}
+		_, tok, _, _ := c.GetMetaWithVersion(ctx, bucket, key)
+		if wrote, err := c.PutMetaIfVersion(ctx, bucket, key, marker, 60, tok); err != nil || !wrote {
+			t.Errorf("raced marker re-establishment: wrote=%v err=%v", wrote, err)
+		}
+		close(raced)
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	}
+	var svc *Service
+	svc, c = newTieredTestService(mock, 8)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "way past threshold", nil); w.Code != http.StatusOK {
+		t.Fatalf("large PUT status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+
+	select {
+	case <-raced:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup DELETE never issued")
+	}
+	// The repair runs after the DELETE returns; converge = authoritative miss.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, found, _ := c.GetMeta(context.Background(), "b", "obj")
+		if !found {
+			return // repaired: the raced-in marker is gone
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("raced-in same-ETag marker survived the cleanup repair (repair chain not exercised?)")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// bodyPutRaceClient fires race once, on the first PutStream of a body| key —
+// the window between an unconditional PUT's decision-token read and its meta
+// commit (the engine writes body first, meta second).
+type bodyPutRaceClient struct {
+	cacheclient.CacheClient
+	armed atomic.Bool
+	race  func()
+}
+
+func (b *bodyPutRaceClient) PutStream(ctx context.Context, key string, rd io.Reader, ttl int64) error {
+	err := b.CacheClient.PutStream(ctx, key, rd, ttl)
+	if err == nil && strings.HasPrefix(key, "body|") && b.armed.CompareAndSwap(true, false) && b.race != nil {
+		b.race()
+	}
+	return err
+}
+
+// An unconditional client PUT whose versioned store is refused must RETRY and
+// win, never ack 200 without storing: the racer may be TAG's own re-tier heal
+// committing the PRE-PUT version (the write claim is process-local — a
+// re-tier on another cluster node is invisible to it), and dropping the
+// client's bytes on that refusal silently reverts an acknowledged write in
+// the authoritative store. A client write is by definition the newest state.
+func TestTieredUnconditionalPutRetriesOverRacedCommit(t *testing.T) {
+	mock, _, _ := tieredMock()
+	wrapper := &bodyPutRaceClient{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = 1024
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := cache.NewCacheWithClient(wrapper, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	// Seed a local-tier prior (the version the "re-tier" will re-commit).
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "old-content", nil); w.Code != http.StatusOK {
+		t.Fatalf("seed PUT status = %d", w.Code)
+	}
+	oldMeta, _, _ := c.GetMeta(context.Background(), "b", "obj")
+
+	// The moment the client PUT's body lands (after its decision token was
+	// read, before its meta commit): a re-tier-shaped racer commits the OLD
+	// metadata under the current version, bumping it.
+	wrapper.race = func() {
+		ctx := context.Background()
+		_, tok, _, _ := c.GetMetaWithVersion(ctx, "b", "obj")
+		redo := *oldMeta
+		if wrote, err := c.PutMetaIfVersion(ctx, "b", "obj", &redo, 60, tok); err != nil || !wrote {
+			t.Errorf("racer commit: wrote=%v err=%v", wrote, err)
+		}
+	}
+	wrapper.armed.Store(true)
+
+	w := tieredDo(t, svc, http.MethodPut, "/b/obj", "client-new-bytes", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("client PUT status = %d", w.Code)
+	}
+	// The 200 must mean the CLIENT's bytes are what the key serves.
+	g := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil)
+	if g.Code != http.StatusOK || g.Body.String() != "client-new-bytes" {
+		t.Fatalf("GET after acked PUT = %d %q, want the client's bytes (acked write reverted?)", g.Code, g.Body.String())
+	}
+}
+
+// The engine validates Content-MD5 (it IS the store — no upstream will):
+// malformed = InvalidDigest, well-formed-but-wrong = BadDigest, matching
+// stores. And every error TAG originates carries an x-amz-request-id whose
+// body RequestId echoes it — clients cross-check the two.
+func TestTieredEngineContentMD5AndRequestID(t *testing.T) {
+	mock, _, _ := tieredMock()
+	svc, _ := newTieredTestService(mock, 1024)
+
+	put := func(md5hdr string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("hello"))
+		if md5hdr != "" {
+			req.Header.Set("Content-MD5", md5hdr)
+		}
+		w := httptest.NewRecorder()
+		if err := svc.HandlePutObject(w, req); err != nil {
+			t.Fatalf("PUT: %v", err)
+		}
+		return w
+	}
+
+	if w := put("not-base64!"); w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "InvalidDigest") {
+		t.Fatalf("malformed Content-MD5 = %d %q, want 400 InvalidDigest", w.Code, w.Body.String())
+	}
+	// PRESENT-but-empty is InvalidDigest on real S3; Header.Get cannot see it
+	// (returns "" for absent too), so the engine reads Values.
+	reqEmpty := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("hello"))
+	reqEmpty.Header["Content-Md5"] = []string{""}
+	wEmpty := httptest.NewRecorder()
+	if err := svc.HandlePutObject(wEmpty, reqEmpty); err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	if wEmpty.Code != http.StatusBadRequest || !strings.Contains(wEmpty.Body.String(), "InvalidDigest") {
+		t.Fatalf("empty Content-MD5 = %d %q, want 400 InvalidDigest", wEmpty.Code, wEmpty.Body.String())
+	}
+	if w := put(base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{7}, 16))); w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "BadDigest") {
+		t.Fatalf("wrong Content-MD5 = %d %q, want 400 BadDigest", w.Code, w.Body.String())
+	}
+	sum := md5.Sum([]byte("hello"))
+	if w := put(base64.StdEncoding.EncodeToString(sum[:])); w.Code != http.StatusOK {
+		t.Fatalf("matching Content-MD5 = %d, want 200", w.Code)
+	}
+
+	// Engine-originated error: header and body request ids exist and match.
+	req := httptest.NewRequest(http.MethodGet, "/b/definitely-absent", nil)
+	w := httptest.NewRecorder()
+	if err := svc.HandleGetObject(w, req); err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	rid := w.Header().Get("x-amz-request-id")
+	if w.Code != http.StatusNotFound || rid == "" {
+		t.Fatalf("engine 404 = %d request-id %q, want a minted id", w.Code, rid)
+	}
+	if !strings.Contains(w.Body.String(), "<RequestId>"+rid+"</RequestId>") {
+		t.Fatalf("body RequestId does not echo header %q: %s", rid, w.Body.String())
+	}
+}
+
+// A multipart completion in tiered mode stamps a BodyUpstream marker (the
+// assembled body lives upstream by construction), replacing the old
+// read-as-miss punt: HEAD answers from the marker with the HEAD-sourced
+// length, GET forwards for the body.
+func TestTieredMultipartCompletionStampsMarker(t *testing.T) {
+	mock, forwards, _ := tieredMock()
+	completionXML := `<CompleteMultipartUploadResult><ETag>"mp-etag-3"</ETag></CompleteMultipartUploadResult>`
+	mock.captureFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(completionXML))
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: []byte(completionXML), Complete: true, Headers: http.Header{}}, nil
+	}
+	headHdr := http.Header{}
+	headHdr.Set("ETag", `"mp-etag-3"`)
+	headHdr.Set("Content-Length", "5242880")
+	headHdr.Set("Content-Type", "application/octet-stream")
+	mock.conditionalResp = &http.Response{StatusCode: http.StatusOK, Header: headHdr, Body: http.NoBody}
+	svc, c := newTieredTestService(mock, 1024)
+
+	req := httptest.NewRequest(http.MethodPost, "/b/mp-obj?uploadId=u1", strings.NewReader("<CompleteMultipartUpload/>"))
+	w := httptest.NewRecorder()
+	if err := svc.HandleCompleteMultipartUpload(w, req); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("completion status = %d", w.Code)
+	}
+
+	// Phase 1 (immediate): the ETag-only marker exists the moment the handler
+	// returns — no read-after-write NoSuchKey window while the HEAD runs.
+	meta, found, _ := c.GetMeta(context.Background(), "b", "mp-obj")
+	if !found || meta == nil || !meta.BodyUpstream || meta.ETag != `"mp-etag-3"` {
+		t.Fatalf("no BodyUpstream marker after completion: %+v", meta)
+	}
+	// Phase 2 (background): the HEAD upgrade lands the real length.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m, f2, _ := c.GetMeta(context.Background(), "b", "mp-obj")
+		if f2 && m != nil && m.ContentLength == 5242880 {
+			meta = m
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("marker never upgraded with the HEAD-sourced length: %+v", m)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// HEAD from the marker, no forward; GET forwards for the body.
+	before := forwards.Load()
+	if hw := tieredDo(t, svc, http.MethodHead, "/b/mp-obj", "", nil); hw.Code != http.StatusOK || hw.Header().Get("Content-Length") != "5242880" {
+		t.Fatalf("HEAD = %d CL %q, want 200 with the marker's length", hw.Code, hw.Header().Get("Content-Length"))
+	}
+	if forwards.Load() != before {
+		t.Fatal("HEAD of a marker forwarded upstream")
+	}
+	gw := tieredDo(t, svc, http.MethodGet, "/b/mp-obj", "", nil)
+	if gw.Code != http.StatusOK || gw.Body.String() != "upstream body" {
+		t.Fatalf("GET = %d %q, want the forwarded body", gw.Code, gw.Body.String())
+	}
+}
+
+// A completion whose upstream HEAD is unavailable still stamps an ETag-only
+// marker (unknown length): the object must exist in the authoritative view —
+// GETs forward regardless, HEAD just omits the length.
+func TestTieredMultipartCompletionMarkerWithoutHead(t *testing.T) {
+	mock, _, _ := tieredMock()
+	completionXML := `<CompleteMultipartUploadResult><ETag>"mp-etag-9"</ETag></CompleteMultipartUploadResult>`
+	mock.captureFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*ResponseCapture, error) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(completionXML))
+		return &ResponseCapture{StatusCode: http.StatusOK, Body: []byte(completionXML), Complete: true, Headers: http.Header{}}, nil
+	}
+	mock.conditionalErr = errors.New("upstream HEAD unavailable")
+	svc, c := newTieredTestService(mock, 1024)
+
+	req := httptest.NewRequest(http.MethodPost, "/b/mp-obj?uploadId=u2", strings.NewReader("<CompleteMultipartUpload/>"))
+	if err := svc.HandleCompleteMultipartUpload(httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	meta, found, _ := c.GetMeta(context.Background(), "b", "mp-obj")
+	if !found || meta == nil || !meta.BodyUpstream || meta.ETag != `"mp-etag-9"` {
+		t.Fatalf("no fallback marker: %+v", meta)
+	}
+	if meta.ContentLength >= 0 {
+		t.Fatalf("fallback marker CL = %d, want unknown (-1)", meta.ContentLength)
+	}
+	if gw := tieredDo(t, svc, http.MethodGet, "/b/mp-obj", "", nil); gw.Code != http.StatusOK || gw.Body.String() != "upstream body" {
+		t.Fatalf("GET via fallback marker = %d %q", gw.Code, gw.Body.String())
+	}
+}
+
+// bodyKeyLedger records body-key writes and deletes so tests can assert the
+// staged-body lifecycle: exactly one stream per PUT, staged keys reclaimed on
+// abort, and meta-only retries never re-streaming.
+type bodyKeyLedger struct {
+	cacheclient.CacheClient
+	mu      sync.Mutex
+	puts    []string
+	deletes []string
+}
+
+func (b *bodyKeyLedger) PutStream(ctx context.Context, key string, r io.Reader, ttl int64) error {
+	if strings.HasPrefix(key, "body|") {
+		b.mu.Lock()
+		b.puts = append(b.puts, key)
+		b.mu.Unlock()
+	}
+	return b.CacheClient.PutStream(ctx, key, r, ttl)
+}
+
+func (b *bodyKeyLedger) Delete(ctx context.Context, key string) error {
+	if strings.HasPrefix(key, "body|") {
+		b.mu.Lock()
+		b.deletes = append(b.deletes, key)
+		b.mu.Unlock()
+	}
+	return b.CacheClient.Delete(ctx, key)
+}
+
+func newLedgerTieredService(t *testing.T, threshold int64) (*Service, *cache.Cache, *bodyKeyLedger) {
+	t.Helper()
+	mock, _, _ := tieredMock()
+	ledger := &bodyKeyLedger{CacheClient: cacheclient.NewMemoryCache()}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = threshold
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := cache.NewCacheWithClient(ledger, &cfg.Cache)
+	return NewService(mock, c, cfg), c, ledger
+}
+
+// A streamed engine PUT stores the body under its BodyRef — never under the
+// ETag — with the correct MD5 ETag, and serves back through the discriminator
+// on both the small buffered path and the large streaming path.
+func TestTieredStreamedPutBodyRefRoundTrip(t *testing.T) {
+	svc, c, ledger := newLedgerTieredService(t, 1<<20)
+
+	big := strings.Repeat("0123456789abcdef", 8192) // 128 KiB > smallObjectThreshold
+	if w := tieredDo(t, svc, http.MethodPut, "/b/big", big, nil); w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", w.Code)
+	}
+	meta, found, _ := c.GetMeta(context.Background(), "b", "big")
+	if !found || meta == nil || meta.BodyRef == "" {
+		t.Fatalf("engine entry missing BodyRef: %+v", meta)
+	}
+	sum := md5.Sum([]byte(big))
+	if meta.ETag != `"`+hex.EncodeToString(sum[:])+`"` {
+		t.Fatalf("ETag = %q, want streamed MD5", meta.ETag)
+	}
+	if len(ledger.puts) != 1 || ledger.puts[0] != cache.MakeBodyKey("b", "big", meta.BodyRef) {
+		t.Fatalf("body writes = %v, want exactly one under the BodyRef", ledger.puts)
+	}
+	if w := tieredDo(t, svc, http.MethodGet, "/b/big", "", nil); w.Code != http.StatusOK || w.Body.String() != big {
+		t.Fatalf("large GET = %d len %d, want the streamed body", w.Code, w.Body.Len())
+	}
+	if w := tieredDo(t, svc, http.MethodPut, "/b/small", "tiny", nil); w.Code != http.StatusOK {
+		t.Fatalf("small PUT status = %d", w.Code)
+	}
+	if w := tieredDo(t, svc, http.MethodGet, "/b/small", "", nil); w.Code != http.StatusOK || w.Body.String() != "tiny" {
+		t.Fatalf("small GET = %d %q", w.Code, w.Body.String())
+	}
+}
+
+// A pre-existing content-addressed entry (proxy-written shape: body keyed by
+// ETag, BodyRef null) serves through the same engine unchanged — the
+// discriminator falls back to the ETag.
+func TestTieredServesETagKeyedEntryFromPriorMode(t *testing.T) {
+	svc, c, _ := newLedgerTieredService(t, 1<<20)
+	meta := &cache.CachedObjectMeta{Bucket: "b", Key: "old", ETag: `"v1"`, ContentLength: 5, StatusCode: 200}
+	if err := c.PutWithMeta(context.Background(), "b", "old", meta, []byte("hello"), 60); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if w := tieredDo(t, svc, http.MethodGet, "/b/old", "", nil); w.Code != http.StatusOK || w.Body.String() != "hello" {
+		t.Fatalf("GET of ETag-keyed entry = %d %q", w.Code, w.Body.String())
+	}
+}
+
+// A body longer than its declared size aborts after the stream and reclaims
+// the staged body: no orphan, no meta.
+func TestTieredStreamedPutOverrunDiscardsStagedBody(t *testing.T) {
+	svc, c, ledger := newLedgerTieredService(t, 1<<20)
+	req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("0123456789"))
+	req.ContentLength = 4 // declares 4, sends 10
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, req); err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "IncompleteBody") {
+		t.Fatalf("overrun PUT = %d %q, want 400 IncompleteBody", w.Code, w.Body.String())
+	}
+	if _, found, _ := c.GetMeta(context.Background(), "b", "obj"); found {
+		t.Fatal("meta committed for an overrun body")
+	}
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	if len(ledger.puts) != 1 || len(ledger.deletes) != 1 || ledger.puts[0] != ledger.deletes[0] {
+		t.Fatalf("staged lifecycle = puts %v deletes %v, want the one staged key reclaimed", ledger.puts, ledger.deletes)
+	}
+}
+
+// A refused unconditional commit retries METADATA ONLY: one body stream
+// total, no staged-body churn, and the client's bytes win. The racer commits
+// between the handler-start token read and the meta commit (fired from the
+// conditional-read hook), so the first PutMetaIfVersion is refused.
+func TestTieredStreamedPutRetryIsMetaOnly(t *testing.T) {
+	mock, _, _ := tieredMock()
+	ledger := &bodyKeyLedger{CacheClient: cacheclient.NewMemoryCache()}
+	wrapper := &raceOnConditionalReadClient{CacheClient: ledger}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = 1024
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := cache.NewCacheWithClient(wrapper, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "old-content", nil); w.Code != http.StatusOK {
+		t.Fatalf("seed PUT status = %d", w.Code)
+	}
+	oldMeta, _, _ := c.GetMeta(context.Background(), "b", "obj")
+
+	wrapper.replace = func() {
+		ctx := context.Background()
+		_, tok, _, _ := c.GetMetaWithVersion(ctx, "b", "obj")
+		redo := *oldMeta
+		if wrote, err := c.PutMetaIfVersion(ctx, "b", "obj", &redo, 60, tok); err != nil || !wrote {
+			t.Errorf("racer commit: wrote=%v err=%v", wrote, err)
+		}
+	}
+	ledger.mu.Lock()
+	before := len(ledger.puts)
+	ledger.mu.Unlock()
+	wrapper.armed = true
+
+	if w := tieredDo(t, svc, http.MethodPut, "/b/obj", "client-new-bytes", nil); w.Code != http.StatusOK {
+		t.Fatalf("client PUT status = %d", w.Code)
+	}
+	ledger.mu.Lock()
+	streamed := len(ledger.puts) - before
+	ledger.mu.Unlock()
+	if streamed != 1 {
+		t.Fatalf("body streams during retried PUT = %d, want exactly 1 (meta-only retries)", streamed)
+	}
+	if g := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); g.Body.String() != "client-new-bytes" {
+		t.Fatalf("GET = %q, want the client's bytes", g.Body.String())
+	}
+}
+
+// truncatedReader yields some bytes then a non-sentinel EOF-family error —
+// the shape of a client disconnect mid-body.
+type truncatedReader struct {
+	data []byte
+	done bool
+}
+
+func (t *truncatedReader) Read(p []byte) (int, error) {
+	if !t.done {
+		t.done = true
+		n := copy(p, t.data)
+		return n, nil
+	}
+	return 0, io.ErrUnexpectedEOF
+}
+
+// A truncated or malformed streamed body answers 400 IncompleteBody — the
+// client misdescribed the request — never a retryable 500, and the staged
+// body is reclaimed. Covers the chunk decoder's WRAPPED EOF (which a naive
+// errors.Is(err, io.EOF) exemption would swallow into a 500) and the
+// plain-body mid-transfer disconnect.
+func TestTieredStreamedPutTruncatedBodyAnswersIncomplete(t *testing.T) {
+	svc, c, ledger := newLedgerTieredService(t, 1<<20)
+
+	// Truncated aws-chunked framing: the header declares a 5-byte chunk but
+	// the body ends mid-chunk — the decoder reports a wrapped EOF.
+	chunked := "5;chunk-signature=deadbeef\r\nhel"
+	req := httptest.NewRequest(http.MethodPut, "/b/trunc-chunked", strings.NewReader(chunked))
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+	req.Header.Set("X-Amz-Decoded-Content-Length", "5")
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, req); err != nil {
+		t.Fatalf("chunked PUT: %v", err)
+	}
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "IncompleteBody") {
+		t.Fatalf("truncated chunked PUT = %d %q, want 400 IncompleteBody", w.Code, w.Body.String())
+	}
+
+	// Plain body that dies mid-transfer with ErrUnexpectedEOF.
+	req2 := httptest.NewRequest(http.MethodPut, "/b/trunc-plain", nil)
+	req2.Body = io.NopCloser(&truncatedReader{data: []byte("hel")})
+	req2.ContentLength = 10
+	w2 := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w2, req2); err != nil {
+		t.Fatalf("plain PUT: %v", err)
+	}
+	if w2.Code != http.StatusBadRequest || !strings.Contains(w2.Body.String(), "IncompleteBody") {
+		t.Fatalf("truncated plain PUT = %d %q, want 400 IncompleteBody", w2.Code, w2.Body.String())
+	}
+
+	// Nothing committed, every staged body reclaimed.
+	for _, k := range []string{"trunc-chunked", "trunc-plain"} {
+		if _, found, _ := c.GetMeta(context.Background(), "b", k); found {
+			t.Fatalf("meta committed for truncated body %s", k)
+		}
+	}
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	if len(ledger.puts) != len(ledger.deletes) {
+		t.Fatalf("staged lifecycle = puts %v deletes %v, want every staged key reclaimed", ledger.puts, ledger.deletes)
+	}
+}
+
+// metaCommitErrClient makes the FIRST meta-key PutIfVersion return an error
+// AFTER forwarding it to the store — the ambiguous-commit shape: the write
+// may have landed, only the confirmation is lost.
+type metaCommitErrClient struct {
+	cacheclient.CacheClient
+	armed atomic.Bool
+}
+
+func (m *metaCommitErrClient) PutIfVersion(ctx context.Context, key string, value []byte, ttl int64, expected uint64) (uint64, error) {
+	v, err := m.CacheClient.PutIfVersion(ctx, key, value, ttl, expected)
+	if strings.HasPrefix(key, "meta|") && m.armed.CompareAndSwap(true, false) {
+		return v, errors.New("simulated lost confirmation")
+	}
+	return v, err
+}
+
+// An AMBIGUOUS meta-commit error must NOT delete the staged body: the write
+// may have landed (here it provably did), and deleting the body a visible
+// meta references would erase the object — a 500-answering PUT destroying
+// data. TTL reclaims genuine orphans.
+func TestTieredStreamedPutAmbiguousCommitKeepsStagedBody(t *testing.T) {
+	mock, _, _ := tieredMock()
+	inner := &bodyKeyLedger{CacheClient: cacheclient.NewMemoryCache()}
+	wrapper := &metaCommitErrClient{CacheClient: inner}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = 1024
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := cache.NewCacheWithClient(wrapper, &cfg.Cache)
+	svc := NewService(mock, c, cfg)
+
+	wrapper.armed.Store(true)
+	req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("hello"))
+	w := httptest.NewRecorder()
+	err := svc.HandlePutObject(w, req)
+	if err == nil && w.Code == http.StatusOK {
+		t.Fatal("ambiguous commit did not surface as an error")
+	}
+
+	// The commit actually landed (the wrapper forwarded before erroring):
+	// the entry must be fully servable — its staged body NOT deleted.
+	meta, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || meta == nil || meta.BodyRef == "" {
+		t.Fatalf("landed meta missing: %+v", meta)
+	}
+	inner.mu.Lock()
+	deletes := len(inner.deletes)
+	inner.mu.Unlock()
+	if deletes != 0 {
+		t.Fatalf("staged body deleted on an ambiguous commit error (deletes=%v)", inner.deletes)
+	}
+	if g := tieredDo(t, svc, http.MethodGet, "/b/obj", "", nil); g.Code != http.StatusOK || g.Body.String() != "hello" {
+		t.Fatalf("GET after ambiguous-commit PUT = %d %q, want the landed object", g.Code, g.Body.String())
+	}
+}
+
+// If-None-Match:* against a live upstream-tier MARKER is a 412: the object
+// EXISTS (its body upstream), and the local-body servability probe must not
+// read it as absent and let a create-only PUT overwrite it.
+func TestTieredConditionalPutMarkerCountsAsExisting(t *testing.T) {
+	svc, c, _ := newLedgerTieredService(t, 1024)
+	marker := &cache.CachedObjectMeta{
+		Bucket: "b", Key: "obj", ETag: `"up-1"`, BodyUpstream: true,
+		ContentLength: 5000, StatusCode: 200,
+	}
+	_, tok, _, _ := c.GetMetaWithVersion(context.Background(), "b", "obj")
+	if wrote, err := c.PutMetaIfVersion(context.Background(), "b", "obj", marker, 60, tok); err != nil || !wrote {
+		t.Fatalf("seed marker: wrote=%v err=%v", wrote, err)
+	}
+
+	// The steady-state router forwards marker-prior conditionals upstream;
+	// the ENGINE sees this shape only in the double-read race (a marker
+	// committing between the router's read and the engine's). Exercise the
+	// engine directly — the race's exact entry point.
+	req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("tiny"))
+	req.Header.Set("If-None-Match", "*")
+	w := httptest.NewRecorder()
+	if err := svc.HandleOriginlessPut(w, req); err != nil {
+		t.Fatalf("engine PUT: %v", err)
+	}
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("If-None-Match:* over a live marker = %d, want 412", w.Code)
+	}
+	cur, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || cur == nil || !cur.BodyUpstream || cur.ETag != `"up-1"` {
+		t.Fatalf("marker disturbed by refused conditional: %+v", cur)
+	}
+}
+
+// A sub-resource GET (?tagging) against a small upstream-tier marker must
+// NOT trigger a re-tier heal: the full-body download would serve nothing the
+// triggering request needs.
+func TestTieredSubresourceGetDoesNotRetier(t *testing.T) {
+	mock, _, _ := tieredMock()
+	var fullFetches atomic.Int32
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, accessKey, secretKey string) (*http.Response, error) {
+		fullFetches.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	svc, c := newTieredTestService(mock, 1024)
+	marker := &cache.CachedObjectMeta{
+		Bucket: "b", Key: "obj", ETag: `"up-1"`, BodyUpstream: true,
+		ContentLength: 100, StatusCode: 200,
+	}
+	_, tok, _, _ := c.GetMetaWithVersion(context.Background(), "b", "obj")
+	if wrote, err := c.PutMetaIfVersion(context.Background(), "b", "obj", marker, 60, tok); err != nil || !wrote {
+		t.Fatalf("seed marker: wrote=%v err=%v", wrote, err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/b/obj?tagging", nil)
+	if err := svc.HandleGetObject(httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("sub-resource GET: %v", err)
+	}
+	waitRetierDone(t, svc, "b", "obj")
+	if n := fullFetches.Load(); n != 0 {
+		t.Fatalf("sub-resource GET triggered %d re-tier fetches, want 0", n)
+	}
+}
+
+// A chunked body whose bytes match the declared length but whose framing was
+// never terminated (no data-CRLF, no terminal chunk) is TRUNCATED — the
+// decoder now surfaces every truncation shape as a wrapped error, so the
+// coincidental-length case answers IncompleteBody instead of committing 200.
+func TestTieredStreamedPutUnterminatedChunkingAnswersIncomplete(t *testing.T) {
+	svc, c, _ := newLedgerTieredService(t, 1<<20)
+	body := "5;chunk-signature=deadbeef\r\nhello" // 5 data bytes, then EOF: no CRLF, no 0-chunk
+	req := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader(body))
+	req.Header.Set("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+	req.Header.Set("X-Amz-Decoded-Content-Length", "5")
+	w := httptest.NewRecorder()
+	if err := svc.HandlePutObject(w, req); err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "IncompleteBody") {
+		t.Fatalf("unterminated chunked PUT = %d %q, want 400 IncompleteBody", w.Code, w.Body.String())
+	}
+	if _, found, _ := c.GetMeta(context.Background(), "b", "obj"); found {
+		t.Fatal("meta committed for an unterminated chunked body")
+	}
+}
+
+// A tiered DELETE forwarded (upstream-tier or unknown key) must converge the
+// cache under the PRE-FORWARD version — never the unconditional coordinator
+// delete that out-deletes racing writers. A small PUT acked DURING the
+// forward is the local tier's only copy and must survive.
+var svcForDelete *Service
+
+func TestTieredForwardedDeleteConvergeSparesRacingPut(t *testing.T) {
+	mock, _, _ := tieredMock()
+	var c *cache.Cache
+	// A large upstream-tier marker exists, so DELETE forwards (not local).
+	raced := make(chan struct{})
+	mock.doObjectDeleteFunc = func(ctx context.Context, bucket, key, etag, ak, sk string) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	}
+	mock.forwardFunc = func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		if r.Method == http.MethodDelete {
+			// Mid-forward: a small client PUT commits a new local-tier object.
+			put := httptest.NewRequest(http.MethodPut, "/b/obj", strings.NewReader("racer-wins"))
+			if err := svcForDelete.HandlePutObject(httptest.NewRecorder(), put); err != nil {
+				t.Errorf("racing PUT: %v", err)
+			}
+			close(raced)
+			w.WriteHeader(http.StatusNoContent)
+			return nil
+		}
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+	cfg := config.NewDefault()
+	cfg.Mode = config.ModeTiered
+	cfg.Cache.SetBlockCachingEnabled(false)
+	cfg.Cache.SizeThreshold = 1024
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c = cache.NewCacheWithClient(cacheclient.NewMemoryCache(), &cfg.Cache)
+	svcForDelete = NewService(mock, c, cfg)
+
+	// Seed an upstream-tier marker so the DELETE forwards.
+	marker := &cache.CachedObjectMeta{Bucket: "b", Key: "obj", ETag: `"up-1"`, BodyUpstream: true, ContentLength: 5000, StatusCode: 200}
+	_, tok, _, _ := c.GetMetaWithVersion(context.Background(), "b", "obj")
+	if wrote, err := c.PutMetaIfVersion(context.Background(), "b", "obj", marker, 60, tok); err != nil || !wrote {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/b/obj", nil)
+	if err := svcForDelete.HandleDeleteObject(httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	<-raced
+
+	// The racing PUT's object must survive the converge.
+	cur, found, _ := c.GetMeta(context.Background(), "b", "obj")
+	if !found || cur == nil || cur.BodyUpstream {
+		t.Fatalf("racing PUT's local object was out-deleted by the DELETE converge: %+v", cur)
+	}
+	g := tieredDo(t, svcForDelete, http.MethodGet, "/b/obj", "", nil)
+	if g.Code != http.StatusOK || g.Body.String() != "racer-wins" {
+		t.Fatalf("GET = %d %q, want the racing PUT's bytes", g.Code, g.Body.String())
+	}
+}
+
+// A forwarded DELETE must CANCEL an in-flight re-tier, so a heal cannot
+// commit a local-tier copy that the version-guarded converge then declines
+// to delete — resurrecting a deleted object behind a 204. The DELETE claims
+// the key (like a PUT), whose claim cancels the heal's context.
+func TestTieredForwardedDeleteCancelsInflightRetier(t *testing.T) {
+	mock, _, _ := tieredMock()
+	// The re-tier fetch blocks until we release it, giving the DELETE time to
+	// claim-and-cancel; the fetch then observes the canceled context.
+	fetchGate := make(chan struct{})
+	var fetchStarted sync.WaitGroup
+	fetchStarted.Add(1)
+	started := false
+	mock.doFullObjectFunc = func(ctx context.Context, bucket, key, ak, sk string) (*http.Response, error) {
+		if !started {
+			started = true
+			fetchStarted.Done()
+		}
+		select {
+		case <-fetchGate:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: func() http.Header { h := http.Header{}; h.Set("ETag", `"up-1"`); return h }(), Body: io.NopCloser(strings.NewReader("healed"))}, nil
+	}
+	mock.doObjectDeleteFunc = func(ctx context.Context, bucket, key, etag, ak, sk string) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	}
+	svc, c := newTieredTestService(mock, 1024)
+
+	marker := &cache.CachedObjectMeta{Bucket: "b", Key: "obj", ETag: `"up-1"`, BodyUpstream: true, ContentLength: 6, StatusCode: 200}
+	_, tok, _, _ := c.GetMetaWithVersion(context.Background(), "b", "obj")
+	if wrote, err := c.PutMetaIfVersion(context.Background(), "b", "obj", marker, 60, tok); err != nil || !wrote {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	// A validated GET triggers the re-tier (which blocks in the fetch).
+	go func() {
+		g := httptest.NewRequest(http.MethodGet, "/b/obj", nil)
+		_ = svc.HandleGetObject(httptest.NewRecorder(), g)
+	}()
+	fetchStarted.Wait()
+
+	// DELETE now: it claims the key (cancelling the re-tier's context), then
+	// forwards and converges.
+	req := httptest.NewRequest(http.MethodDelete, "/b/obj", nil)
+	if err := svc.HandleDeleteObject(httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	close(fetchGate) // let any surviving fetch proceed; its commit must fail on the canceled ctx
+
+	// The object stays deleted: no re-tier resurrection.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, found, _ := c.GetMeta(context.Background(), "b", "obj")
+		if !found {
+			return
+		}
+		m, _, _ := c.GetMeta(context.Background(), "b", "obj")
+		if m != nil && !m.BodyUpstream {
+			t.Fatal("re-tier resurrected the deleted object as a local-tier copy")
+		}
+		if time.Now().After(deadline) {
+			// Still the marker (upstream-tier) is acceptable only if the DELETE
+			// converge removed it; a surviving marker means converge missed.
+			t.Fatal("deleted object still present after DELETE + canceled re-tier")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/s3err/errors.go
+++ b/s3err/errors.go
@@ -2,8 +2,13 @@
 package s3err
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/xml"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -20,6 +25,10 @@ const (
 	ErrBucketAlreadyOwnedByYou      ErrorCode = "BucketAlreadyOwnedByYou"
 	ErrNoSuchBucket                 ErrorCode = "NoSuchBucket"
 	ErrNoSuchKey                    ErrorCode = "NoSuchKey"
+	ErrEntityTooLarge               ErrorCode = "EntityTooLarge"
+	ErrPreconditionFailed           ErrorCode = "PreconditionFailed"
+	ErrInvalidDigest                ErrorCode = "InvalidDigest"
+	ErrBadDigest                    ErrorCode = "BadDigest"
 	ErrNoSuchUpload                 ErrorCode = "NoSuchUpload"
 	ErrInvalidAccessKeyId           ErrorCode = "InvalidAccessKeyId"
 	ErrSignatureDoesNotMatch        ErrorCode = "SignatureDoesNotMatch"
@@ -68,6 +77,10 @@ var errorMap = map[ErrorCode]errorInfo{
 	ErrBucketAlreadyOwnedByYou:      {http.StatusConflict, ErrBucketAlreadyOwnedByYou, "Your previous request to create the named bucket succeeded"},
 	ErrNoSuchBucket:                 {http.StatusNotFound, ErrNoSuchBucket, "The specified bucket does not exist"},
 	ErrNoSuchKey:                    {http.StatusNotFound, ErrNoSuchKey, "The specified key does not exist"},
+	ErrEntityTooLarge:               {http.StatusBadRequest, ErrEntityTooLarge, "Your proposed upload exceeds the maximum allowed size"},
+	ErrPreconditionFailed:           {http.StatusPreconditionFailed, ErrPreconditionFailed, "At least one of the pre-conditions you specified did not hold"},
+	ErrInvalidDigest:                {http.StatusBadRequest, ErrInvalidDigest, "The Content-MD5 you specified is not valid"},
+	ErrBadDigest:                    {http.StatusBadRequest, ErrBadDigest, "The Content-MD5 you specified did not match what we received"},
 	ErrNoSuchUpload:                 {http.StatusNotFound, ErrNoSuchUpload, "The specified multipart upload does not exist"},
 	ErrInvalidAccessKeyId:           {http.StatusForbidden, ErrInvalidAccessKeyId, "The AWS access key ID you provided does not exist in our records"},
 	ErrSignatureDoesNotMatch:        {http.StatusForbidden, ErrSignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided"},
@@ -109,11 +122,22 @@ func WriteErrorWithMessage(w http.ResponseWriter, r *http.Request, code ErrorCod
 		info = errorInfo{http.StatusInternalServerError, ErrInternalError, message}
 	}
 
+	// The response's x-amz-request-id header is the request's identity, and
+	// the XML body must echo the SAME value — clients cross-check them. In
+	// proxy mode forwarded responses carry upstream's id, but errors TAG
+	// answers itself (the origin-less/tiered engine's authoritative errors
+	// above all) had neither header nor body id: mint one here and set both.
+	// Header before body: WriteHeader below commits the headers.
+	requestID := w.Header().Get("x-amz-request-id")
+	if requestID == "" {
+		requestID = newRequestID()
+		w.Header().Set("x-amz-request-id", requestID)
+	}
 	resp := ErrorResponse{
 		Code:      code,
 		Message:   message,
 		Resource:  r.URL.Path,
-		RequestID: r.Header.Get("X-Request-ID"),
+		RequestID: requestID,
 	}
 
 	log.Debug().
@@ -134,4 +158,16 @@ func WriteErrorWithMessage(w http.ResponseWriter, r *http.Request, code ErrorCod
 func WriteInternalError(w http.ResponseWriter, r *http.Request, err error) {
 	log.Error().Err(err).Str("path", r.URL.Path).Msg("Internal error")
 	WriteError(w, r, ErrInternalError)
+}
+
+// newRequestID mints an S3-shaped request id (uppercase hex, 16 bytes of
+// entropy) for responses TAG originates itself. Falls back to a timestamp
+// when the system's entropy source fails — an id must always exist, unique
+// enough for log correlation.
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return strings.ToUpper(hex.EncodeToString(b[:]))
 }

--- a/tests/s3compat/python/run-tests.sh
+++ b/tests/s3compat/python/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # S3 Compatibility Tests Runner for TAG
-# Modeled after tigris-os gateway/tests/tests.sh
+# Runs a curated selection of the ceph s3-tests suite against a local TAG.
 
 # Track test failures
 FAILED_TESTS=()
@@ -147,10 +147,24 @@ run_test() {
     fi
 }
 
-# Test arrays - curated list of tests relevant for TAG
-# Based on tigris-os gateway/tests/tests.sh
+# Test arrays — curated list of tests relevant for TAG, STRUCTURED BY
+# SEMANTIC CLASS.
+#
+# The class an operation belongs to decides whether it can pass in TIERED
+# mode (S3TEST_PROFILE=tiered), where the local metadata is authoritative and
+# small objects never exist upstream (docs/tiered-mode.md):
+#   - test_headers / test_objects / test_buckets / test_multipart run in
+#     EVERY profile — they exercise paths every mode implements.
+#   - test_listings, test_copies, and test_object_subresources are SKIPPED in
+#     the tiered profile: forwarded listings cannot see local-tier objects,
+#     server-side copies (and UploadPartCopy) cannot read a local-tier
+#     source, and object sub-resource calls (tagging, ACL) forward to an
+#     upstream that answers NoSuchKey for local-tier objects. When one of
+#     those limitations is implemented (e.g. a listings merge), move its
+#     class back into the tiered profile.
 
-# Header validation tests
+# CLASS: header validation — request-shape rejections, evaluated by whichever
+# layer owns the write (upstream in proxy modes, the engine in tiered).
 test_headers=(
     "test_object_create_bad_md5_invalid_short"
     "test_object_create_bad_md5_bad"
@@ -166,7 +180,6 @@ test_headers=(
     "test_object_create_date_and_amz_date"
     "test_object_create_amz_date_and_no_date"
     "test_bucket_create_contentlength_none"
-    "test_object_acl_create_contentlength_none"
     "test_bucket_create_bad_expect_empty"
     "test_bucket_create_bad_contentlength_negative"
     "test_bucket_create_bad_contentlength_none"
@@ -182,8 +195,11 @@ test_headers=(
     # "test_bucket_create_bad_authorization_none"
 )
 
-# Core S3 operations tests
-test_s3=(
+# CLASS: listings — every ListObjects/ListObjectsV2 shape, plus the tests that
+# VERIFY through a listing (the multi-delete pair). Skipped in tiered:
+# local-tier objects never exist upstream, so the forwarded listing is empty —
+# not merely unmerged (docs/tiered-mode.md "Not implemented").
+test_listings=(
     "test_bucket_list_empty"
     "test_bucket_list_distinct"
     "test_bucket_list_many"
@@ -239,9 +255,18 @@ test_s3=(
     "test_bucket_listv2_maxkeys_none"
     "test_bucket_list_marker_none"
     "test_bucket_list_marker_empty"
+    # Special prefix handling
+    "test_bucket_list_special_prefix"
+    # Deletes whose ASSERTION is a listing of the surviving keys.
+    "test_multi_object_delete"
+    "test_multi_objectv2_delete"
+    # "test_multi_object_delete_key_limit"  # Tigris doesn't support object versioning yet
+    # "test_multi_objectv2_delete_key_limit"  # Tigris doesn't support object versioning yet
 )
 
-# Object operations tests
+# CLASS: single-object operations — CRUD, ranges, conditionals, error shape.
+# The core of what every mode (proxy, origin-less, tiered) must answer
+# identically.
 test_objects=(
     "test_object_write_to_nonexist_bucket"
     "test_object_head_zero_bytes"
@@ -257,10 +282,6 @@ test_objects=(
     "test_object_read_not_exist"
     # "test_object_read_unreadable"
     "test_object_requestid_matches_header_on_error"
-    "test_multi_object_delete"
-    "test_multi_objectv2_delete"
-    # "test_multi_object_delete_key_limit"  # Tigris doesn't support object versioning yet
-    # "test_multi_objectv2_delete_key_limit"  # Tigris doesn't support object versioning yet
     # Range requests
     "test_ranged_request_response_code"
     "test_ranged_big_request_response_code"
@@ -279,16 +300,14 @@ test_objects=(
     "test_get_object_ifunmodifiedsince_failed"
     # Conditional PUT operations
     "test_put_object_ifmatch_failed"
-    # Large object copy
-    "test_object_copy_16m"
-    # Special prefix handling
-    "test_bucket_list_special_prefix"
     # Chunked encoding tests
     # "test_object_write_with_chunked_transfer_encoding"  # Requires HTTP Transfer-Encoding: chunked (Ceph RGW-specific, not supported by S3/Tigris)
     # "test_object_content_encoding_aws_chunked"  # Tigris stores aws-chunked in Content-Encoding as-is; stripping it in TAG breaks signatures in transparent mode
 )
 
-# Bucket operations tests
+# CLASS: bucket operations — naming, head, create/delete lifecycle. Bucket
+# calls pass through in every mode (tiered included); bucket-level tagging
+# lives here too, since no object is involved.
 test_buckets=(
     "test_bucket_create_naming_bad_starts_nonalpha"
     "test_bucket_create_naming_bad_short_one"
@@ -330,9 +349,14 @@ test_buckets=(
     # "test_bucket_list_return_data"
     "test_bucket_head"
     "test_bucket_head_notexist"
+    # Bucket-level tagging: no object involved, passes through in every mode.
+    "test_set_bucket_tagging"
 )
 
-# Multipart upload tests
+# CLASS: multipart uploads — initiate/part/complete/abort/list-parts pass
+# through in every mode; in tiered the COMPLETION stamps an upstream-tier
+# marker, so the assembled object is readable (the completed object's tagging
+# test rides here for the same reason: it exists upstream).
 test_multipart=(
     "test_multipart_upload_empty"
     "test_multipart_upload_small"
@@ -342,22 +366,19 @@ test_multipart=(
     "test_abort_multipart_upload"
     "test_abort_multipart_upload_not_found"
     "test_list_multipart_upload"
-    # Additional multipart tests
-    "test_multipart_copy_small"
-    "test_multipart_copy_invalid_range"
-    # "test_multipart_copy_improper_range"
-    "test_multipart_copy_without_range"
-    # "test_multipart_copy_special_names"
-    "test_multipart_copy_multiple_sizes"
     "test_multipart_upload_multiple_sizes"
     # "test_multipart_upload_size_too_small"
     "test_multipart_upload_missing_part"
     "test_multipart_upload_incorrect_etag"
     # "test_multipart_resend_first_finishes_last"
+    "test_set_multipart_tagging"
 )
 
-# Copy object tests
-test_copy=(
+# CLASS: server-side copies — CopyObject and UploadPartCopy. Skipped in
+# tiered: the copy SOURCE may be a local-tier object that does not exist
+# upstream, so upstream's copy answers NoSuchKey; copy destinations also get
+# no marker (docs/tiered-mode.md "Not implemented").
+test_copies=(
     "test_object_copy_zero_size"
     "test_object_copy_same_bucket"
     "test_object_copy_verify_contenttype"
@@ -367,11 +388,28 @@ test_copy=(
     "test_object_copy_canned_acl"
     "test_object_copy_retaining_metadata"
     "test_object_copy_replacing_metadata"
+    # Large object copy
+    "test_object_copy_16m"
+    # UploadPartCopy — a multipart whose parts are server-side copies.
+    "test_multipart_copy_small"
+    "test_multipart_copy_invalid_range"
+    # "test_multipart_copy_improper_range"
+    "test_multipart_copy_without_range"
+    # "test_multipart_copy_special_names"
+    "test_multipart_copy_multiple_sizes"
 )
 
-# Tagging tests
-test_tagging=(
-    "test_set_bucket_tagging"
+# CLASS: object sub-resources — tagging/ACL calls addressed to an OBJECT.
+# Skipped in tiered: they forward to upstream, which answers NoSuchKey for a
+# local-tier object (docs/tiered-mode.md "Not implemented").
+# The one header-validation-shaped member of this class lives in
+# test_headers.py, not test_s3.py — it gets its own array so each loop
+# targets the file its tests are defined in, while the tiered profile
+# empties both together.
+test_object_subresources_headers=(
+    "test_object_acl_create_contentlength_none"
+)
+test_object_subresources=(
     "test_get_obj_tagging"
     "test_get_obj_head_tagging"
     "test_put_max_tags"
@@ -382,53 +420,68 @@ test_tagging=(
     "test_put_modify_tags"
     "test_put_delete_tags"
     "test_put_obj_with_tags"
-    "test_set_multipart_tagging"
     # "test_get_tags_acl_public"
     # "test_put_tags_acl_public"
     # "test_delete_tags_obj_public"
 )
 
-# Run header validation tests
+# Profile selection. The tiered profile empties the classes whose semantics
+# tiered mode does not implement, so the job is a stable green-or-red signal
+# for the paths it DOES implement — never a triage of known failures.
+S3TEST_PROFILE="${S3TEST_PROFILE:-default}"
+if [ "$S3TEST_PROFILE" = "tiered" ]; then
+    echo "Profile 'tiered': skipping listings (${#test_listings[@]}), copies (${#test_copies[@]}), and object sub-resources (${#test_object_subresources[@]}) — by-design limitations, see docs/tiered-mode.md"
+    test_listings=()
+    test_copies=()
+    test_object_subresources=()
+    test_object_subresources_headers=()
+fi
+
+# Header-validation tests live in test_headers.py; every other class in
+# test_s3.py. (Plain loops, not a name-ref helper: macOS ships bash 3.2.)
 echo "Running header validation tests..."
 for test in "${test_headers[@]}"; do
     run_test "test_headers.py" "$test"
 done
 
-# Run core S3 operations tests
-echo "Running core S3 operations tests..."
-for test in "${test_s3[@]}"; do
-    run_test "test_s3.py" "$test"
-done
+if [ ${#test_listings[@]} -gt 0 ]; then
+    echo "Running listing tests..."
+    for test in "${test_listings[@]}"; do
+        run_test "test_s3.py" "$test"
+    done
+fi
 
-# Run object operations tests
-echo "Running object operations tests..."
+echo "Running single-object tests..."
 for test in "${test_objects[@]}"; do
     run_test "test_s3.py" "$test"
 done
 
-# Run bucket operations tests
-echo "Running bucket operations tests..."
+echo "Running bucket tests..."
 for test in "${test_buckets[@]}"; do
     run_test "test_s3.py" "$test"
 done
 
-# Run multipart upload tests
 echo "Running multipart upload tests..."
 for test in "${test_multipart[@]}"; do
     run_test "test_s3.py" "$test"
 done
 
-# Run copy object tests
-echo "Running copy object tests..."
-for test in "${test_copy[@]}"; do
-    run_test "test_s3.py" "$test"
-done
+if [ ${#test_copies[@]} -gt 0 ]; then
+    echo "Running server-side copy tests..."
+    for test in "${test_copies[@]}"; do
+        run_test "test_s3.py" "$test"
+    done
+fi
 
-# Run tagging tests
-echo "Running tagging tests..."
-for test in "${test_tagging[@]}"; do
-    run_test "test_s3.py" "$test"
-done
+if [ ${#test_object_subresources[@]} -gt 0 ]; then
+    echo "Running object sub-resource tests..."
+    for test in "${test_object_subresources_headers[@]}"; do
+        run_test "test_headers.py" "$test"
+    done
+    for test in "${test_object_subresources[@]}"; do
+        run_test "test_s3.py" "$test"
+    done
+fi
 
 # Report results
 echo ""


### PR DESCRIPTION
Cuts v1.22.0: **tiered store mode** (#203), its benchmark support (#226), and the release-review fixes (#228: tiered CopyObject converges under its pre-forward version; the tiered converge retries once). The full CAS coordination line shipped in v1.21.0 and is running in production; this release adds the mode built on it.

**Tiered store mode (`mode: tiered` / `TAG_MODE=tiered`)** — TAG as a two-tier cache in front of a cheap capacity-priced upstream bucket. Local metadata is authoritative for existence (a miss is a local NoSuchKey, the caller's cue to fall back to its system of record). Objects at or below `cache.size_threshold` are the **local tier**: PUT streams the body into the embedded cache (never buffered, fixed memory regardless of size), GET/HEAD/DELETE are served entirely locally — zero upstream traffic. Larger objects are the **upstream tier**: the PUT passes through and a metadata marker is stamped, HEAD answers from the marker, GET forwards the body. Multipart completions stamp a marker (immediately, upgraded with a background HEAD); re-tier-on-read heals mis-tiered small objects; cross-tier overwrites clean up the displaced upstream copy with a conditional DELETE.

**Startup contract**: tiered forces **CAS coordination** (auto-selected; an explicit `legacy_coordination: true` is fatal) and **whole-object caching** (`block_caching_enabled: true` is fatal). Off by default — existing deployments are unaffected; no config change needed to upgrade.

**Hardening**: four adversarial review passes plus the bot rounds closed every finding — the acked-write-loss family (all converge/sweep/cleanup paths version-guarded), the streaming PUT's abort path (panic-safe deferred reclaim, ambiguous-commit rule), RFC 7232/9110 conditional semantics (ETag lists, strong If-Match, 412s only where authoritative), Content-MD5 validation, request ids on TAG-originated errors.

**Observability**: `tag_requests_total` / `tag_request_duration_seconds` gain `mode` and `source` (`local`|`upstream`) labels; `tag_tiered_cleanup_total` / `tag_tiered_retier_total` counters. Dashboards using `sum by` are unaffected.

**Validation**: dedicated `s3-compat-tests (tiered)` CI job (79-test tiered profile, green); warp A/B at 4 MiB objects, two concurrent pairs — HEAD **~5× faster** (authoritative local metadata), PUT ~1.14× with a consistently tighter p99, GET throughput a wash with steadier latency, GET-RANGE ~0.72× (block caching's home turf, not tiered's target).

**Docs**: `docs/tiered-mode.md` (semantics, credential requirement — TAG's credentials need **delete** permission on the cache bucket — limitations: listings/copies/object sub-resources pass through and cannot see local-tier objects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DLvDTo9dhD38YQXhHpU9
